### PR TITLE
IAM 366

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,23 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/canonical/identity-platform-admin-ui.svg)](https://pkg.go.dev/github.com/canonical/identity-platform-admin-ui)
 
 This is the Admin UI for the Canonical Identity Platform.
+
+
+
+## Environment Variables
+
+- `OTEL_GRPC_ENDPOINT`: address of the open telemetry grpc endpoint, used for tracing
+- `OTEL_HTTP_ENDPOINT`: address of the open telemetry http endpoint, used for tracing (grpc endpoint takes precedence)
+- `TRACING_ENABLED`: flag enabling tracing 
+- `LOG_LEVEL`: log level, one of `info`,`warn`,`error`,`debug`, defaults to `error`
+- `LOG_FILE`: file where to dump logs, defaults to `log.txt`
+- `PORT `: http server port, defaults to `8080`
+- `DEBUG`: debugging flag for hydra and kratos clients
+- `KRATOS_PUBLIC_URL`: Kratos public endpoints address
+- `KRATOS_ADMIN_URL`: Kratos admin endpoints address
+- `HYDRA_ADMIN_URL`: Hydra admin endpoints address
+- `IDP_CONFIGMAP_NAME`: name of the k8s config map containing Identity Providers
+- `IDP_CONFIGMAP_NAMESPACE`: namespace of the k8s config map containing Identity Providers
+- `SCHEMAS_CONFIGMAP_NAME`: name of the k8s config map containing Identity Schemas
+- `SCHEMAS_CONFIGMAP_NAMESPACE`: namespace of the k8s config map containing Identity Schemas
+

--- a/deployments/kubectl/configMap.yaml
+++ b/deployments/kubectl/configMap.yaml
@@ -7,10 +7,14 @@ data:
   PORT: "8000"
   LOG_LEVEL: DEBUG
   TRACING_ENABLED: "false" 
-  KRATOS_URL: http://kratos.svc.cluster.local:4434
-  HYDRA_ADMIN_URL: http://hydra.svc.cluster.local:4445
-  CONFIGMAP_NAME: idps
-  CONFIGMAP_NAMESPACE: default
+  KRATOS_PUBLIC_URL: http://kratos.iam.svc.cluster.local:4433
+  KRATOS_ADMIN_URL: http://kratos.iam.svc.cluster.local:4434
+  HYDRA_ADMIN_URL: http://hydra.iam.svc.cluster.local:4445
+  IDP_CONFIGMAP_NAME: idps
+  IDP_CONFIGMAP_NAMESPACE: default
+  SCHEMAS_CONFIGMAP_NAME: identity-schemas
+  SCHEMAS_CONFIGMAP_NAMESPACE: default
+
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -49,3 +53,58 @@ data:
         - email
         - address
         - phone
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-schemas
+data:
+  "default.schema": "default"
+  "admin_v0": |
+    {
+            "id": "admin_v0",
+            "schema": {
+                "$id": "https://schemas.canonical.com/presets/kratos/admin_v0.json",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "properties": {
+                    "additionalProperties": true,
+                    "traits": {
+                        "properties": {
+                            "email": {
+                                "format": "email",
+                                "minLength": 3,
+                                "ory.sh/kratos": {
+                                    "verification": {
+                                        "via": "email"
+                                    }
+                                },
+                                "title": "E-Mail",
+                                "type": "string"
+                            },
+                            "name": {
+                                "title": "Name",
+                                "type": "string"
+                            },
+                            "phone_number": {
+                                "title": "Phone Number",
+                                "type": "string"
+                            },
+                            "username": {
+                                "ory.sh/kratos": {
+                                    "credentials": {
+                                        "password": {
+                                            "identifier": true
+                                        }
+                                    }
+                                },
+                                "title": "Username",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "title": "Admin Account",
+                "type": "object"
+            }
+        }

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -13,9 +13,13 @@ type EnvSpec struct {
 
 	Debug bool `envconfig:"debug" default:"false"`
 
-	KratosURL     string `envconfig:"kratos_url" required:"true"`
-	HydraAdminURL string `envconfig:"hydra_admin_url" required:"true"`
+	KratosPublicURL string `envconfig:"kratos_public_url" required:"true"`
+	KratosAdminURL  string `envconfig:"kratos_admin_url" required:"true"`
+	HydraAdminURL   string `envconfig:"hydra_admin_url" required:"true"`
 
-	ConfigMapName      string `envconfig:"configmap_name" required:"true"`
-	ConfigMapNamespace string `envconfig:"configmap_namespace" required:"true"`
+	IDPConfigMapName      string `envconfig:"idp_configmap_name" required:"true"`
+	IDPConfigMapNamespace string `envconfig:"idp_configmap_namespace" required:"true"`
+
+	SchemasConfigMapName      string `envconfig:"schemas_configmap_name" required:"true"`
+	SchemasConfigMapNamespace string `envconfig:"schemas_configmap_namespace" required:"true"`
 }

--- a/pkg/schemas/handlers.go
+++ b/pkg/schemas/handlers.go
@@ -1,0 +1,256 @@
+package schemas
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
+	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/go-chi/chi/v5"
+	kClient "github.com/ory/kratos-client-go"
+)
+
+const okValue = "ok"
+
+type API struct {
+	service ServiceInterface
+
+	logger logging.LoggerInterface
+}
+
+func (a *API) RegisterEndpoints(mux *chi.Mux) {
+	mux.Get("/api/v0/schemas", a.handleList)
+	mux.Get("/api/v0/schemas/{id}", a.handleDetail)
+	mux.Post("/api/v0/schemas", a.handleCreate)
+	mux.Patch("/api/v0/schemas/{id}", a.handlePartialUpdate)
+	mux.Delete("/api/v0/schemas/{id}", a.handleRemove)
+}
+
+func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	pagination := types.ParsePagination(r.URL.Query())
+
+	schemas, err := a.service.ListSchemas(r.Context(), pagination.Page, pagination.Size)
+
+	if err != nil {
+		rr := a.error(schemas.Error)
+
+		w.WriteHeader(rr.Status)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Data:    schemas.IdentitySchemas,
+			Message: "List of Identity Schemas",
+			Status:  http.StatusOK,
+			Meta:    pagination,
+		},
+	)
+}
+
+func (a *API) handleDetail(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	ID := chi.URLParam(r, "id")
+
+	schemas, err := a.service.GetSchema(r.Context(), ID)
+
+	if err != nil {
+		rr := a.error(schemas.Error)
+
+		w.WriteHeader(rr.Status)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Data:    schemas.IdentitySchemas,
+			Message: "Detail of Identity Schemas",
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handlePartialUpdate(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	ID := chi.URLParam(r, "id")
+
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing request payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+	}
+
+	schema := new(kClient.IdentitySchemaContainer)
+	if err := json.Unmarshal(body, schema); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing JSON payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+
+	}
+
+	schemas, err := a.service.EditSchema(r.Context(), ID, schema)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Data:    schemas.IdentitySchemas,
+			Message: "Updated Identity Schemas",
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing request payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+	}
+
+	schema := new(kClient.IdentitySchemaContainer)
+	if err := json.Unmarshal(body, schema); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing JSON payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+
+	}
+
+	schemas, err := a.service.CreateSchema(r.Context(), schema)
+
+	if err != nil {
+		status := http.StatusInternalServerError
+
+		if schemas != nil {
+			status = http.StatusConflict
+		}
+
+		rr := types.Response{
+			Status:  status,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(status)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Data:    schemas.IdentitySchemas,
+			Message: "Created Identity Schemas",
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handleRemove(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	id := chi.URLParam(r, "id")
+
+	err := a.service.DeleteSchema(r.Context(), id)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Data:    nil,
+			Message: "Identity Schemas deleted",
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+// TODO @shipperizer encapsulate kClient.GenericError into a service error to remove library dependency
+func (a *API) error(e *kClient.GenericError) types.Response {
+	r := types.Response{
+		Status: http.StatusInternalServerError,
+	}
+
+	if e.Reason != nil {
+		r.Message = *e.Reason
+	}
+
+	if e.Code != nil {
+		r.Status = int(*e.Code)
+	}
+
+	return r
+
+}
+
+func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
+	a := new(API)
+
+	a.service = service
+
+	a.logger = logger
+
+	return a
+}

--- a/pkg/schemas/handlers_test.go
+++ b/pkg/schemas/handlers_test.go
@@ -1,0 +1,966 @@
+package schemas
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	reflect "reflect"
+	"strings"
+	"testing"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
+	"github.com/go-chi/chi/v5"
+	gomock "github.com/golang/mock/gomock"
+	kClient "github.com/ory/kratos-client-go"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_interfaces.go -source=./interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_corev1.go k8s.io/client-go/kubernetes/typed/core/v1 CoreV1Interface,ConfigMapInterface
+//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_kratos.go github.com/ory/kratos-client-go IdentityApi
+
+func TestHandleListSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+	v1Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v1.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+	v1ID := "test_v1"
+
+	schemas := IdentitySchemaData{
+		IdentitySchemas: []kClient.IdentitySchemaContainer{
+			{
+				Id:     &v0ID,
+				Schema: v0Schema,
+			},
+			{
+				Id:     &v1ID,
+				Schema: v1Schema,
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/schemas", nil)
+
+	mockService.EXPECT().ListSchemas(gomock.Any(), int64(1), int64(100)).Return(&schemas, nil)
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code 200 got %v", res.StatusCode)
+	}
+
+	// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+	type Response struct {
+		Data []kClient.IdentitySchemaContainer `json:"data"`
+	}
+
+	rr := new(Response)
+
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	// cannot use reflect.DeepEqual on the result because Configuration container a json.RawMessage that doesn't play well with it
+	if len(schemas.IdentitySchemas) != len(rr.Data) {
+		t.Fatalf("invalid result, expected %v schemas, got: %v", len(schemas.IdentitySchemas), len(rr.Data))
+	}
+
+	if !reflect.DeepEqual([]string{*schemas.IdentitySchemas[0].Id, *schemas.IdentitySchemas[1].Id}, []string{*rr.Data[0].Id, *rr.Data[1].Id}) {
+		t.Fatalf("invalid result, expected: %v, got: %v", schemas.IdentitySchemas, rr.Data)
+	}
+}
+
+func TestHandleListFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/schemas", nil)
+
+	gerr := new(kClient.GenericError)
+	gerr.SetCode(http.StatusInternalServerError)
+	gerr.SetMessage("teapot error")
+	gerr.SetReason("teapot is broken")
+
+	mockService.EXPECT().ListSchemas(gomock.Any(), int64(1), int64(100)).Return(&IdentitySchemaData{IdentitySchemas: make([]kClient.IdentitySchemaContainer, 0), Error: gerr}, fmt.Errorf("error"))
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code 500 got %v", res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+}
+
+func TestHandleDetailSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/schemas/%s", v0ID), nil)
+
+	mockService.EXPECT().GetSchema(gomock.Any(), v0ID).Return(
+		&IdentitySchemaData{
+			IdentitySchemas: []kClient.IdentitySchemaContainer{
+				{
+					Id:     &v0ID,
+					Schema: v0Schema,
+				},
+			},
+		},
+		nil,
+	)
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code 200 got %v", res.StatusCode)
+	}
+
+	// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+	type Response struct {
+		Data []kClient.IdentitySchemaContainer `json:"data"`
+	}
+
+	rr := new(Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if len(rr.Data) != 1 {
+		t.Fatalf("invalid result, expected only 1 schema, got %v", rr.Data)
+	}
+
+	if *rr.Data[0].Id != v0ID {
+		t.Fatalf("invalid result, expected: %v, got: %v", v0ID, rr.Data[0])
+	}
+}
+
+func TestHandleDetailEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/schemas/%s", "random"), nil)
+
+	mockService.EXPECT().GetSchema(gomock.Any(), "random").Return(
+		&IdentitySchemaData{
+			IdentitySchemas: []kClient.IdentitySchemaContainer{},
+		},
+		nil,
+	)
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code 200 got %v", res.StatusCode)
+	}
+
+	// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+	type Response struct {
+		Data []kClient.IdentitySchemaContainer `json:"data"`
+	}
+
+	rr := new(Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if len(rr.Data) != 0 {
+		t.Fatalf("invalid result, expected no schemas, got %v", rr.Data)
+	}
+}
+
+func TestHandleDetailFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	ID := "test-1"
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/schemas/%s", ID), nil)
+
+	gerr := new(kClient.GenericError)
+	gerr.SetCode(http.StatusInternalServerError)
+	gerr.SetMessage("teapot error")
+	gerr.SetReason("teapot is broken")
+
+	mockService.EXPECT().GetSchema(gomock.Any(), ID).Return(&IdentitySchemaData{IdentitySchemas: make([]kClient.IdentitySchemaContainer, 0), Error: gerr}, fmt.Errorf("error"))
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code 418 got %v", res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+}
+
+func TestHandleCreateSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+
+	c := new(kClient.IdentitySchemaContainer)
+	c.Id = &v0ID
+	c.Schema = v0Schema
+
+	payload, _ := json.Marshal(c)
+	req := httptest.NewRequest(http.MethodPost, "/api/v0/schemas", bytes.NewReader(payload))
+
+	mockService.EXPECT().CreateSchema(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, schema *kClient.IdentitySchemaContainer) (*IdentitySchemaData, error) {
+
+			if *schema.Id != *c.Id {
+				t.Fatalf("invalid ID, expected %s got %s", *c.Id, *schema.Id)
+			}
+
+			if !reflect.DeepEqual(schema.Schema, c.Schema) {
+				t.Fatalf("invalid schema, expected %s got %s", c.Schema, schema.Schema)
+			}
+
+			return &IdentitySchemaData{IdentitySchemas: []kClient.IdentitySchemaContainer{*c}}, nil
+		},
+	)
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code 200 got %v", res.StatusCode)
+	}
+
+	// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+	type Response struct {
+		Data []kClient.IdentitySchemaContainer `json:"data"`
+	}
+
+	rr := new(Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if len(rr.Data) != 1 {
+		t.Fatalf("invalid result, expected only 1 schema, got %v", rr.Data)
+	}
+
+	if *rr.Data[0].Id != *c.Id {
+		t.Fatalf("invalid result, expected: %v, got: %v", c, rr.Data[0])
+	}
+}
+
+func TestHandleCreateFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+
+	c := new(kClient.IdentitySchemaContainer)
+	c.Id = &v0ID
+	c.Schema = v0Schema
+
+	payload, _ := json.Marshal(c)
+	req := httptest.NewRequest(http.MethodPost, "/api/v0/schemas", bytes.NewReader(payload))
+
+	mockService.EXPECT().CreateSchema(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, schema *kClient.IdentitySchemaContainer) (*IdentitySchemaData, error) {
+
+			if *schema.Id != *c.Id {
+				t.Fatalf("invalid ID, expected %s got %s", *c.Id, *schema.Id)
+			}
+
+			if !reflect.DeepEqual(schema.Schema, c.Schema) {
+				t.Fatalf("invalid schema, expected %s got %s", c.Schema, schema.Schema)
+			}
+
+			return nil, fmt.Errorf("error")
+		},
+	)
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code 500 got %v", res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Status != http.StatusInternalServerError {
+		t.Errorf("expected code to be %v got %v", http.StatusInternalServerError, rr.Status)
+	}
+}
+
+func TestHandleCreateFailsConflict(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+
+	c := new(kClient.IdentitySchemaContainer)
+	c.Id = &v0ID
+	c.Schema = v0Schema
+
+	payload, _ := json.Marshal(c)
+	req := httptest.NewRequest(http.MethodPost, "/api/v0/schemas", bytes.NewReader(payload))
+
+	mockService.EXPECT().CreateSchema(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, schema *kClient.IdentitySchemaContainer) (*IdentitySchemaData, error) {
+
+			if *schema.Id != *c.Id {
+				t.Fatalf("invalid ID, expected %s got %s", *c.Id, *schema.Id)
+			}
+
+			if !reflect.DeepEqual(schema.Schema, c.Schema) {
+				t.Fatalf("invalid schema, expected %s got %s", c.Schema, schema.Schema)
+			}
+
+			return &IdentitySchemaData{}, fmt.Errorf("error")
+		},
+	)
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusConflict {
+		t.Fatalf("expected HTTP status code 409 got %v", res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Status != http.StatusConflict {
+		t.Errorf("expected code to be %v got %v", http.StatusConflict, rr.Status)
+	}
+}
+
+func TestHandleCreateFailBadRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v0/schemas", strings.NewReader("test"))
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected HTTP status code 400 got %v", res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Status != http.StatusBadRequest {
+		t.Errorf("expected code to be %v got %v", http.StatusBadRequest, rr.Status)
+	}
+}
+
+func TestHandlePartialUpdateSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+
+	c := new(kClient.IdentitySchemaContainer)
+	c.Id = &v0ID
+	c.Schema = v0Schema
+
+	payload, _ := json.Marshal(c)
+	req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v0/schemas/%s", *c.Id), bytes.NewReader(payload))
+
+	mockService.EXPECT().EditSchema(gomock.Any(), *c.Id, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, ID string, schema *kClient.IdentitySchemaContainer) (*IdentitySchemaData, error) {
+			if ID != *c.Id {
+				t.Fatalf("invalid ID, expected %s got %s", *c.Id, ID)
+			}
+
+			if *schema.Id != *c.Id {
+				t.Fatalf("invalid ID, expected %s got %s", *c.Id, *schema.Id)
+			}
+
+			if !reflect.DeepEqual(schema.Schema, c.Schema) {
+				t.Fatalf("invalid schema, expected %s got %s", c.Schema, schema.Schema)
+			}
+
+			return &IdentitySchemaData{IdentitySchemas: []kClient.IdentitySchemaContainer{*c}}, nil
+		},
+	)
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code 200 got %v", res.StatusCode)
+	}
+
+	// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+	type Response struct {
+		Data []kClient.IdentitySchemaContainer `json:"data"`
+	}
+
+	rr := new(Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if len(rr.Data) != 1 {
+		t.Fatalf("invalid result, expected only 1 schema, got %v", rr.Data)
+	}
+
+	if *rr.Data[0].Id != *c.Id {
+		t.Fatalf("invalid result, expected: %v, got: %v", c, rr.Data[0])
+	}
+}
+
+func TestHandlePartialUpdateFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+
+	c := new(kClient.IdentitySchemaContainer)
+	c.Id = &v0ID
+	c.Schema = v0Schema
+
+	payload, _ := json.Marshal(c)
+	req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v0/schemas/%s", *c.Id), bytes.NewReader(payload))
+
+	mockService.EXPECT().EditSchema(gomock.Any(), *c.Id, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, ID string, schema *kClient.IdentitySchemaContainer) (*IdentitySchemaData, error) {
+			if ID != *c.Id {
+				t.Fatalf("invalid ID, expected %s got %s", *c.Id, ID)
+			}
+
+			if *schema.Id != *c.Id {
+				t.Fatalf("invalid ID, expected %s got %s", *c.Id, *schema.Id)
+			}
+
+			if !reflect.DeepEqual(schema.Schema, c.Schema) {
+				t.Fatalf("invalid schema, expected %s got %s", c.Schema, schema.Schema)
+			}
+
+			return nil, fmt.Errorf("error")
+		},
+	)
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code 500 got %v", res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Status != http.StatusInternalServerError {
+		t.Errorf("expected code to be %v got %v", http.StatusInternalServerError, rr.Status)
+	}
+}
+
+func TestHandlePartialUpdateFailBadRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v0/schemas/fake", strings.NewReader("test"))
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected HTTP status code 400 got %v", res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Status != http.StatusBadRequest {
+		t.Errorf("expected code to be %v got %v", http.StatusBadRequest, rr.Status)
+	}
+}
+
+func TestHandleRemoveSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	credID := "test-1"
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v0/schemas/%s", credID), nil)
+
+	mockService.EXPECT().DeleteSchema(gomock.Any(), credID).Return(nil)
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code 200 got %v", res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Data != nil {
+		t.Fatalf("invalid result, expected no schemas, got %v", rr.Data)
+	}
+	if rr.Status != http.StatusOK {
+		t.Errorf("expected code to be %v got %v", http.StatusOK, rr.Status)
+	}
+}
+
+func TestHandleRemoveFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	credID := "test-1"
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v0/schemas/%s", credID), nil)
+
+	mockService.EXPECT().DeleteSchema(gomock.Any(), credID).Return(fmt.Errorf("error"))
+
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code 500 got %v", res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Status != http.StatusInternalServerError {
+		t.Errorf("expected code to be %v got %v", http.StatusInternalServerError, rr.Status)
+	}
+}

--- a/pkg/schemas/interfaces.go
+++ b/pkg/schemas/interfaces.go
@@ -1,0 +1,15 @@
+package schemas
+
+import (
+	"context"
+
+	kClient "github.com/ory/kratos-client-go"
+)
+
+type ServiceInterface interface {
+	ListSchemas(context.Context, int64, int64) (*IdentitySchemaData, error)
+	GetSchema(context.Context, string) (*IdentitySchemaData, error)
+	EditSchema(context.Context, string, *kClient.IdentitySchemaContainer) (*IdentitySchemaData, error)
+	CreateSchema(context.Context, *kClient.IdentitySchemaContainer) (*IdentitySchemaData, error)
+	DeleteSchema(context.Context, string) error
+}

--- a/pkg/schemas/service.go
+++ b/pkg/schemas/service.go
@@ -1,0 +1,269 @@
+package schemas
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	kClient "github.com/ory/kratos-client-go"
+	"go.opentelemetry.io/otel/trace"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreV1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const DEFAULT_SCHEMA = "default.schema"
+
+type Config struct {
+	Name      string
+	Namespace string
+	K8s       coreV1.CoreV1Interface
+	Kratos    kClient.IdentityApi
+}
+
+type IdentitySchemaData struct {
+	IdentitySchemas []kClient.IdentitySchemaContainer
+	Error           *kClient.GenericError
+}
+
+// TODO @shipperizer verify during integration test if this is actually the format
+type KratosError struct {
+	Error *kClient.GenericError `json:"error,omitempty"`
+}
+
+type Service struct {
+	cmName      string
+	cmNamespace string
+
+	k8s    coreV1.CoreV1Interface
+	kratos kClient.IdentityApi
+
+	tracer  trace.Tracer
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
+}
+
+func (s *Service) parseError(ctx context.Context, r *http.Response) *kClient.GenericError {
+	ctx, span := s.tracer.Start(ctx, "schemas.Service.parseError")
+	defer span.End()
+
+	gerr := KratosError{Error: kClient.NewGenericErrorWithDefaults()}
+
+	defer r.Body.Close()
+	body, _ := io.ReadAll(r.Body)
+
+	if err := json.Unmarshal(body, &gerr); err != nil {
+		gerr.Error.SetMessage("unable to parse kratos error response")
+		gerr.Error.SetCode(http.StatusInternalServerError)
+	}
+
+	return gerr.Error
+}
+
+func (s *Service) ListSchemas(ctx context.Context, page, size int64) (*IdentitySchemaData, error) {
+	ctx, span := s.tracer.Start(ctx, "schemas.Service.ListSchemas")
+	defer span.End()
+
+	schemas, rr, err := s.kratos.ListIdentitySchemasExecute(
+		s.kratos.ListIdentitySchemas(ctx).Page(page).PerPage(size),
+	)
+
+	data := new(IdentitySchemaData)
+
+	if err != nil {
+		s.logger.Error(err)
+		data.Error = s.parseError(ctx, rr)
+	}
+
+	data.IdentitySchemas = schemas
+
+	// TODO @shipperizer check if schemas is defaulting to empty slice inside kratos-client
+	if data.IdentitySchemas == nil {
+		data.IdentitySchemas = make([]kClient.IdentitySchemaContainer, 0)
+	}
+
+	return data, err
+}
+
+func (s *Service) GetSchema(ctx context.Context, ID string) (*IdentitySchemaData, error) {
+	ctx, span := s.tracer.Start(ctx, "schemas.Service.GetSchema")
+	defer span.End()
+
+	schema, rr, err := s.kratos.GetIdentitySchemaExecute(
+		s.kratos.GetIdentitySchema(ctx, ID),
+	)
+
+	data := new(IdentitySchemaData)
+
+	if err != nil {
+		s.logger.Error(err)
+		data.Error = s.parseError(ctx, rr)
+	}
+
+	if schema != nil {
+		data.IdentitySchemas = []kClient.IdentitySchemaContainer{
+			{Schema: schema, Id: &ID},
+		}
+	} else {
+		data.IdentitySchemas = []kClient.IdentitySchemaContainer{}
+	}
+
+	return data, err
+}
+
+func (s *Service) EditSchema(ctx context.Context, ID string, data *kClient.IdentitySchemaContainer) (*IdentitySchemaData, error) {
+	ctx, span := s.tracer.Start(ctx, "schemas.Service.EditSchema")
+	defer span.End()
+
+	cm, err := s.k8s.ConfigMaps(s.cmNamespace).Get(ctx, s.cmName, metaV1.GetOptions{})
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return nil, err
+	}
+
+	i := new(IdentitySchemaData)
+
+	// TODO @shipperizer DEFAULT_SCHEMA doesn't return here, but might be worth making it more explicit
+	schemas := s.schemas(cm.Data)
+
+	if _, ok := schemas[ID]; !ok {
+		i.IdentitySchemas = []kClient.IdentitySchemaContainer{}
+
+		return i, fmt.Errorf("schema with ID %s not found", ID)
+	}
+
+	rawSchema, err := json.Marshal(data.Schema)
+
+	if err != nil {
+		return nil, err
+	}
+
+	cm.Data[ID] = string(rawSchema)
+
+	if _, err = s.k8s.ConfigMaps(s.cmNamespace).Update(ctx, cm, metaV1.UpdateOptions{}); err != nil {
+
+		return nil, err
+	}
+
+	i.IdentitySchemas = []kClient.IdentitySchemaContainer{*data}
+
+	return i, nil
+
+}
+
+func (s *Service) CreateSchema(ctx context.Context, data *kClient.IdentitySchemaContainer) (*IdentitySchemaData, error) {
+	ctx, span := s.tracer.Start(ctx, "schemas.Service.CreateSchema")
+	defer span.End()
+
+	cm, err := s.k8s.ConfigMaps(s.cmNamespace).Get(ctx, s.cmName, metaV1.GetOptions{})
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return nil, err
+	}
+	i := new(IdentitySchemaData)
+
+	schemas := s.schemas(cm.Data)
+
+	if _, ok := schemas[*data.Id]; ok {
+		i.IdentitySchemas = []kClient.IdentitySchemaContainer{}
+
+		return i, fmt.Errorf("schema with same ID already exists")
+	}
+
+	rawSchema, err := json.Marshal(data.Schema)
+
+	if err != nil {
+		return nil, err
+	}
+
+	cm.Data[*data.Id] = string(rawSchema)
+
+	if _, err = s.k8s.ConfigMaps(s.cmNamespace).Update(ctx, cm, metaV1.UpdateOptions{}); err != nil {
+
+		return nil, err
+	}
+
+	i.IdentitySchemas = []kClient.IdentitySchemaContainer{*data}
+
+	return i, nil
+}
+
+func (s *Service) DeleteSchema(ctx context.Context, ID string) error {
+	ctx, span := s.tracer.Start(ctx, "schemas.Service.DeleteSchema")
+	defer span.End()
+
+	cm, err := s.k8s.ConfigMaps(s.cmNamespace).Get(ctx, s.cmName, metaV1.GetOptions{})
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return err
+	}
+
+	if ID == DEFAULT_SCHEMA {
+		return fmt.Errorf("default schema %s cannot be deleted as ", ID)
+	}
+
+	if _, ok := cm.Data[ID]; !ok {
+		return fmt.Errorf("schema with ID %s not found", ID)
+	}
+
+	delete(cm.Data, ID)
+
+	if _, err = s.k8s.ConfigMaps(s.cmNamespace).Update(ctx, cm, metaV1.UpdateOptions{}); err != nil {
+
+		return err
+	}
+
+	return nil
+
+}
+
+func (s *Service) schemas(schemas map[string]string) map[string]*kClient.IdentitySchemaContainer {
+
+	schemaConfig := make(map[string]*kClient.IdentitySchemaContainer)
+
+	for key, rawSchema := range schemas {
+		// skip if special key
+		if key == DEFAULT_SCHEMA {
+			continue
+		}
+
+		schema := make(map[string]interface{})
+
+		err := json.Unmarshal([]byte(rawSchema), &schema)
+
+		if err != nil {
+			s.logger.Errorf("failed unmarshalling %s - %v", rawSchema, err)
+			return nil
+		}
+
+		schemaConfig[key] = &kClient.IdentitySchemaContainer{Id: &key, Schema: schema}
+	}
+
+	return schemaConfig
+}
+
+// TODO @shipperizer analyze if providers IDs need to be what we use for path or if filename is the right one
+func NewService(config *Config, tracer trace.Tracer, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *Service {
+	s := new(Service)
+
+	if config == nil {
+		panic("empty config for schemas service")
+	}
+
+	s.kratos = config.Kratos
+	s.k8s = config.K8s
+	s.cmName = config.Name
+	s.cmNamespace = config.Namespace
+
+	s.monitor = monitor
+	s.tracer = tracer
+	s.logger = logger
+
+	return s
+}

--- a/pkg/schemas/service_test.go
+++ b/pkg/schemas/service_test.go
@@ -1,0 +1,1410 @@
+package schemas
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	reflect "reflect"
+	"testing"
+
+	gomock "github.com/golang/mock/gomock"
+	kClient "github.com/ory/kratos-client-go"
+	"go.opentelemetry.io/otel/trace"
+	v1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_interfaces.go -source=./interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_corev1.go k8s.io/client-go/kubernetes/typed/core/v1 CoreV1Interface,ConfigMapInterface
+//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_kratos.go github.com/ory/kratos-client-go IdentityApi
+
+func TestListSchemasSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+	v1Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v1.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+	v1ID := "test_v1"
+
+	schemas := []kClient.IdentitySchemaContainer{
+		{
+			Id:     &v0ID,
+			Schema: v0Schema,
+		},
+		{
+			Id:     &v1ID,
+			Schema: v1Schema,
+		},
+	}
+
+	identitySchemaRequest := kClient.IdentityApiListIdentitySchemasRequest{
+		ApiService: mockKratosIdentityApi,
+	}
+
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.ListSchemas").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityApi.EXPECT().ListIdentitySchemas(ctx).Times(1).Return(identitySchemaRequest)
+	mockKratosIdentityApi.EXPECT().ListIdentitySchemasExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.IdentityApiListIdentitySchemasRequest) ([]kClient.IdentitySchemaContainer, *http.Response, error) {
+
+			// use reflect as attributes are private, also are pointers so need to cast it multiple times
+			if page := (*int64)(reflect.ValueOf(r).FieldByName("page").UnsafePointer()); *page != 1 {
+				t.Fatalf("expected page as 1, got %v", *page)
+			}
+
+			if pageSize := (*int64)(reflect.ValueOf(r).FieldByName("perPage").UnsafePointer()); *pageSize != 10 {
+				t.Fatalf("expected page size as 10, got %v", *pageSize)
+			}
+
+			return schemas, new(http.Response), nil
+		},
+	)
+	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).ListSchemas(ctx, 1, 10)
+
+	if !reflect.DeepEqual(is.IdentitySchemas, schemas) {
+		t.Fatalf("expected schemas to be %v not  %v", schemas, is.IdentitySchemas)
+
+	}
+
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestListSchemasFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	identitySchemaRequest := kClient.IdentityApiListIdentitySchemasRequest{
+		ApiService: mockKratosIdentityApi,
+	}
+
+	schemas := make([]kClient.IdentitySchemaContainer, 0)
+
+	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.ListSchemas").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.parseError").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityApi.EXPECT().ListIdentitySchemas(ctx).Times(1).Return(identitySchemaRequest)
+	mockKratosIdentityApi.EXPECT().ListIdentitySchemasExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.IdentityApiListIdentitySchemasRequest) ([]kClient.IdentitySchemaContainer, *http.Response, error) {
+
+			// use reflect as attributes are private, also are pointers so need to cast it multiple times
+			if page := (*int64)(reflect.ValueOf(r).FieldByName("page").UnsafePointer()); *page != 1 {
+				t.Fatalf("expected page as 1, got %v", *page)
+			}
+
+			if pageSize := (*int64)(reflect.ValueOf(r).FieldByName("perPage").UnsafePointer()); *pageSize != 10 {
+				t.Fatalf("expected page size as 10, got %v", *pageSize)
+			}
+
+			rr := httptest.NewRecorder()
+			rr.Header().Set("Content-Type", "application/json")
+			rr.WriteHeader(http.StatusInternalServerError)
+
+			json.NewEncoder(rr).Encode(
+				map[string]interface{}{
+					"error": map[string]interface{}{
+						"code":    http.StatusInternalServerError,
+						"debug":   "--------",
+						"details": map[string]interface{}{},
+						"id":      "string",
+						"message": "error",
+						"reason":  "error",
+						"request": "d7ef54b1-ec15-46e6-bccb-524b82c035e6",
+						"status":  "Not Found",
+					},
+				},
+			)
+
+			return schemas, rr.Result(), fmt.Errorf("error")
+		},
+	)
+	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).ListSchemas(ctx, 1, 10)
+
+	if is.Error == nil {
+		t.Fatal("expected ids.Error to be not nil")
+	}
+
+	if *is.Error.Code != http.StatusInternalServerError {
+		t.Fatalf("expected code to be %v not  %v", http.StatusInternalServerError, *is.Error.Code)
+	}
+
+	if err == nil {
+		t.Fatal("expected error to be not nil")
+	}
+}
+
+func TestListSchemasSuccessButEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	schemas := []kClient.IdentitySchemaContainer{}
+
+	identitySchemaRequest := kClient.IdentityApiListIdentitySchemasRequest{
+		ApiService: mockKratosIdentityApi,
+	}
+
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.ListSchemas").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityApi.EXPECT().ListIdentitySchemas(ctx).Times(1).Return(identitySchemaRequest)
+	mockKratosIdentityApi.EXPECT().ListIdentitySchemasExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.IdentityApiListIdentitySchemasRequest) ([]kClient.IdentitySchemaContainer, *http.Response, error) {
+
+			// use reflect as attributes are private, also are pointers so need to cast it multiple times
+			if page := (*int64)(reflect.ValueOf(r).FieldByName("page").UnsafePointer()); *page != 1 {
+				t.Fatalf("expected page as 1, got %v", *page)
+			}
+
+			if pageSize := (*int64)(reflect.ValueOf(r).FieldByName("perPage").UnsafePointer()); *pageSize != 10 {
+				t.Fatalf("expected page size as 10, got %v", *pageSize)
+			}
+
+			return schemas, new(http.Response), nil
+		},
+	)
+	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).ListSchemas(ctx, 1, 10)
+
+	if !reflect.DeepEqual(is.IdentitySchemas, schemas) {
+		t.Fatalf("expected schemas to be %v not  %v", schemas, is.IdentitySchemas)
+
+	}
+
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestGetSchemaSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	identitySchemaRequest := kClient.IdentityApiGetIdentitySchemaRequest{
+		ApiService: mockKratosIdentityApi,
+	}
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+
+	schema := kClient.IdentitySchemaContainer{
+		Id:     &v0ID,
+		Schema: v0Schema,
+	}
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.GetSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityApi.EXPECT().GetIdentitySchema(ctx, v0ID).Times(1).Return(identitySchemaRequest)
+	mockKratosIdentityApi.EXPECT().GetIdentitySchemaExecute(gomock.Any()).Times(1).Return(schema.Schema, new(http.Response), nil)
+
+	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).GetSchema(ctx, v0ID)
+
+	if !reflect.DeepEqual(is.IdentitySchemas, []kClient.IdentitySchemaContainer{schema}) {
+		t.Fatalf("expected schemas to be %v not  %v", schema, is.IdentitySchemas)
+	}
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestGetSchemaSuccessButEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	identitySchemaRequest := kClient.IdentityApiGetIdentitySchemaRequest{
+		ApiService: mockKratosIdentityApi,
+	}
+
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.GetSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityApi.EXPECT().GetIdentitySchema(ctx, "test").Times(1).Return(identitySchemaRequest)
+	mockKratosIdentityApi.EXPECT().GetIdentitySchemaExecute(gomock.Any()).Times(1).Return(nil, new(http.Response), nil)
+
+	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).GetSchema(ctx, "test")
+
+	if !reflect.DeepEqual(is.IdentitySchemas, []kClient.IdentitySchemaContainer{}) {
+		t.Fatalf("expected schemas to be empty not  %v", is.IdentitySchemas)
+	}
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestGetSchemaFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	identitySchemaRequest := kClient.IdentityApiGetIdentitySchemaRequest{
+		ApiService: mockKratosIdentityApi,
+	}
+
+	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.GetSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.parseError").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityApi.EXPECT().GetIdentitySchema(ctx, "fake").Times(1).Return(identitySchemaRequest)
+	mockKratosIdentityApi.EXPECT().GetIdentitySchemaExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.IdentityApiGetIdentitySchemaRequest) (map[string]interface{}, *http.Response, error) {
+			rr := httptest.NewRecorder()
+			rr.Header().Set("Content-Type", "application/json")
+			rr.WriteHeader(http.StatusNotFound)
+
+			json.NewEncoder(rr).Encode(
+				map[string]interface{}{
+					"error": map[string]interface{}{
+						"code":    http.StatusNotFound,
+						"debug":   "--------",
+						"details": map[string]interface{}{},
+						"id":      "string",
+						"message": "error",
+						"reason":  "error",
+						"request": "d7ef54b1-ec15-46e6-bccb-524b82c035e6",
+						"status":  "Not Found",
+					},
+				},
+			)
+
+			return nil, rr.Result(), fmt.Errorf("error")
+		},
+	)
+
+	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).GetSchema(ctx, "fake")
+
+	if !reflect.DeepEqual(is.IdentitySchemas, make([]kClient.IdentitySchemaContainer, 0)) {
+		t.Fatalf("expected schemas to be empty not  %v", is.IdentitySchemas)
+	}
+
+	if is.Error == nil {
+		t.Fatal("expected is.Error to be not nil")
+	}
+
+	if *is.Error.Code != int64(http.StatusNotFound) {
+		t.Fatalf("expected code to be %v not  %v", http.StatusNotFound, *is.Error.Code)
+	}
+
+	if err == nil {
+		t.Fatal("expected error to be not nil")
+	}
+}
+
+func TestEdiSchemaSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+	v1Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v1.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+	v1ID := "test_v1"
+
+	schemas := []kClient.IdentitySchemaContainer{
+		{
+			Id:     &v0ID,
+			Schema: v0Schema,
+		},
+		{
+			Id:     &v1ID,
+			Schema: v1Schema,
+		},
+	}
+
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	for _, sc := range schemas {
+		rawSchema, _ := json.Marshal(sc.Schema)
+
+		cm.Data[*sc.Id] = string(rawSchema)
+	}
+
+	c := new(kClient.IdentitySchemaContainer)
+	c.Id = &v0ID
+	c.Schema = map[string]interface{}{
+		"test": "test",
+	}
+
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.EditSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(2).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
+	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).Return(cm, nil)
+
+	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).EditSchema(ctx, v0ID, c)
+
+	if !reflect.DeepEqual(is.IdentitySchemas[0].Schema, c.Schema) {
+		t.Fatalf("expected schema secret to be %v not  %v", c.Schema, is.IdentitySchemas[0].Schema)
+
+	}
+
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestEditSchemaNotfound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+	v1Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v1.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+	v1ID := "test_v1"
+
+	schemas := []kClient.IdentitySchemaContainer{
+		{
+			Id:     &v0ID,
+			Schema: v0Schema,
+		},
+		{
+			Id:     &v1ID,
+			Schema: v1Schema,
+		},
+	}
+
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	for _, sc := range schemas {
+		rawSchema, _ := json.Marshal(sc.Schema)
+
+		cm.Data[*sc.Id] = string(rawSchema)
+	}
+
+	ID := "fake"
+
+	c := new(kClient.IdentitySchemaContainer)
+	c.Id = &ID
+	c.Schema = map[string]interface{}{
+		"test": "test",
+	}
+
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.EditSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
+
+	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).EditSchema(ctx, "fake", c)
+
+	if len(is.IdentitySchemas) != 0 {
+		t.Fatalf("expected schemas to be empty not  %v", is.IdentitySchemas)
+	}
+
+	if err == nil {
+		t.Fatalf("expected error not to be nil")
+	}
+}
+
+func TestEditSchemaFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	rawSchema, _ := json.Marshal(v0Schema)
+	cm.Data[v0ID] = string(rawSchema)
+
+	c := new(kClient.IdentitySchemaContainer)
+	c.Id = &v0ID
+	c.Schema = map[string]interface{}{
+		"test": "test",
+	}
+
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.EditSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(2).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
+	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).Return(cm, fmt.Errorf("error"))
+
+	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).EditSchema(ctx, v0ID, c)
+
+	if is != nil {
+		t.Fatalf("expected schemas to be nil, not %v", is)
+	}
+
+	if err == nil {
+		t.Fatalf("expected error not to be nil")
+	}
+}
+
+func TestCreateSchemaSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+
+	c := new(kClient.IdentitySchemaContainer)
+	c.Id = &v0ID
+	c.Schema = v0Schema
+
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.CreateSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(2).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
+	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context, configMap *v1.ConfigMap, opts metaV1.UpdateOptions) (*v1.ConfigMap, error) {
+			i := new(kClient.IdentitySchemaContainer)
+
+			rawSchema, _ := configMap.Data[*c.Id]
+
+			_ = json.Unmarshal([]byte(rawSchema), &i.Schema)
+
+			if !reflect.DeepEqual(i.Schema, v0Schema) {
+				t.Fatalf("expected schema to be %v not %v", v0Schema, i.Schema)
+			}
+
+			if *c.Id != v0ID {
+				t.Fatalf("expected schema ID to be %v not %v", v0ID, i.Id)
+			}
+
+			return cm, nil
+		},
+	)
+
+	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).CreateSchema(ctx, c)
+
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+
+	if !reflect.DeepEqual(is.IdentitySchemas[0].Schema, v0Schema) {
+		t.Fatalf("expected schema to be %v not %v", v0Schema, is.IdentitySchemas[0].Schema)
+	}
+
+	if *is.IdentitySchemas[0].Id != v0ID {
+		t.Fatalf("expected schema ID to be %v not %v", v0ID, is.IdentitySchemas[0].Id)
+	}
+
+}
+
+func TestCreateSchemaFailsConflict(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	rawSchema, _ := json.Marshal(v0Schema)
+	cm.Data[v0ID] = string(rawSchema)
+
+	c := new(kClient.IdentitySchemaContainer)
+	c.Id = &v0ID
+	c.Schema = v0Schema
+
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.CreateSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
+
+	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).CreateSchema(ctx, c)
+
+	if err == nil {
+		t.Fatalf("expected error not to be nil")
+	}
+
+	if len(is.IdentitySchemas) != 0 {
+		t.Fatalf("expected schemas to be empty not %v", is.IdentitySchemas[0].Schema)
+	}
+
+}
+
+func TestCreateSchemaFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+
+	c := new(kClient.IdentitySchemaContainer)
+	c.Id = &v0ID
+	c.Schema = v0Schema
+
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.CreateSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(2).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
+	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context, configMap *v1.ConfigMap, opts metaV1.UpdateOptions) (*v1.ConfigMap, error) {
+			i := new(kClient.IdentitySchemaContainer)
+
+			rawSchema, _ := configMap.Data[*c.Id]
+
+			_ = json.Unmarshal([]byte(rawSchema), &i.Schema)
+
+			if !reflect.DeepEqual(i.Schema, v0Schema) {
+				t.Fatalf("expected schema to be %v not %v", v0Schema, i.Schema)
+			}
+
+			if *c.Id != v0ID {
+				t.Fatalf("expected schema ID to be %v not %v", v0ID, i.Id)
+			}
+
+			return nil, fmt.Errorf("error")
+		},
+	)
+
+	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).CreateSchema(ctx, c)
+
+	if is != nil {
+		t.Fatalf("expected schema to be empty not %v", is.IdentitySchemas)
+	}
+
+	if err == nil {
+		t.Fatalf("expected error not to be nil")
+	}
+}
+
+func TestDeleteSchemaSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+	v1Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v1.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+	v1ID := "test_v1"
+
+	schemas := []kClient.IdentitySchemaContainer{
+		{
+			Id:     &v0ID,
+			Schema: v0Schema,
+		},
+		{
+			Id:     &v1ID,
+			Schema: v1Schema,
+		},
+	}
+
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	for _, sc := range schemas {
+		rawSchema, _ := json.Marshal(sc.Schema)
+
+		cm.Data[*sc.Id] = string(rawSchema)
+	}
+
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.DeleteSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(2).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
+	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context, configMap *v1.ConfigMap, opts metaV1.UpdateOptions) (*v1.ConfigMap, error) {
+			if _, ok := cm.Data[v0ID]; ok {
+				t.Fatalf("expected key %s to be deleted", v0ID)
+			}
+
+			return cm, nil
+		},
+	)
+
+	err := NewService(cfg, mockTracer, mockMonitor, mockLogger).DeleteSchema(ctx, v0ID)
+
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestDeleteSchemaNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+	v1Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v1.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+	v1ID := "test_v1"
+
+	schemas := []kClient.IdentitySchemaContainer{
+		{
+			Id:     &v0ID,
+			Schema: v0Schema,
+		},
+		{
+			Id:     &v1ID,
+			Schema: v1Schema,
+		},
+	}
+
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	for _, sc := range schemas {
+		rawSchema, _ := json.Marshal(sc.Schema)
+
+		cm.Data[*sc.Id] = string(rawSchema)
+	}
+
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.DeleteSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
+	err := NewService(cfg, mockTracer, mockMonitor, mockLogger).DeleteSchema(ctx, "fake")
+
+	if err == nil {
+		t.Fatalf("expected error not to be nil")
+	}
+}
+
+func TestDeleteSchemaFailsIfDefault(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+	v1Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v1.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+	v1ID := "test_v1"
+
+	schemas := []kClient.IdentitySchemaContainer{
+		{
+			Id:     &v0ID,
+			Schema: v0Schema,
+		},
+		{
+			Id:     &v1ID,
+			Schema: v1Schema,
+		},
+	}
+
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	for _, sc := range schemas {
+		rawSchema, _ := json.Marshal(sc.Schema)
+
+		cm.Data[*sc.Id] = string(rawSchema)
+	}
+	cm.Data[DEFAULT_SCHEMA] = v0ID
+
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.DeleteSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
+
+	err := NewService(cfg, mockTracer, mockMonitor, mockLogger).DeleteSchema(ctx, DEFAULT_SCHEMA)
+
+	if err == nil {
+		t.Fatalf("expected error not to be nil")
+	}
+}
+
+func TestDeleteSchemaFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	ctx := context.Background()
+
+	cfg := new(Config)
+	cfg.K8s = mockCoreV1
+	cfg.Kratos = mockKratosIdentityApi
+	cfg.Name = "schemas"
+	cfg.Namespace = "default"
+
+	v0Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v0.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+	v1Schema := map[string]interface{}{
+		"$id":     "https://schemas.canonical.com/presets/kratos/test_v1.json",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title":   "Admin Account",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"traits": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":  "string",
+						"title": "Username",
+						"ory.sh/kratos": map[string]interface{}{
+							"credentials": map[string]interface{}{
+								"password": map[string]interface{}{
+									"identifier": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"additionalProperties": true,
+	}
+
+	v0ID := "test_v0"
+	v1ID := "test_v1"
+
+	schemas := []kClient.IdentitySchemaContainer{
+		{
+			Id:     &v0ID,
+			Schema: v0Schema,
+		},
+		{
+			Id:     &v1ID,
+			Schema: v1Schema,
+		},
+	}
+
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	for _, sc := range schemas {
+		rawSchema, _ := json.Marshal(sc.Schema)
+
+		cm.Data[*sc.Id] = string(rawSchema)
+	}
+
+	mockTracer.EXPECT().Start(ctx, "schemas.Service.DeleteSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(2).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
+	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context, configMap *v1.ConfigMap, opts metaV1.UpdateOptions) (*v1.ConfigMap, error) {
+			return nil, fmt.Errorf("error")
+		},
+	)
+	err := NewService(cfg, mockTracer, mockMonitor, mockLogger).DeleteSchema(ctx, v0ID)
+
+	if err == nil {
+		t.Fatalf("expected error not to be nil")
+	}
+}

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -16,10 +16,11 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/pkg/identities"
 	"github.com/canonical/identity-platform-admin-ui/pkg/idp"
 	"github.com/canonical/identity-platform-admin-ui/pkg/metrics"
+	"github.com/canonical/identity-platform-admin-ui/pkg/schemas"
 	"github.com/canonical/identity-platform-admin-ui/pkg/status"
 )
 
-func NewRouter(idpConfig *idp.Config, hydraClient *ih.Client, kratos *ik.Client, tracer trace.Tracer, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) http.Handler {
+func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, hydraClient *ih.Client, kratos *ik.Client, tracer trace.Tracer, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) http.Handler {
 	router := chi.NewMux()
 
 	middlewares := make(chi.Middlewares, 0)
@@ -54,6 +55,9 @@ func NewRouter(idpConfig *idp.Config, hydraClient *ih.Client, kratos *ik.Client,
 		idp.NewService(idpConfig, tracer, monitor, logger),
 		logger,
 	).RegisterEndpoints(router)
-
+	schemas.NewAPI(
+		schemas.NewService(schemasConfig, tracer, monitor, logger),
+		logger,
+	).RegisterEndpoints(router)
 	return tracing.NewMiddleware(monitor, logger).OpenTelemetry(router)
 }


### PR DESCRIPTION
IAM-366: identity schemas endpoints

- feat: add schemas service layer and interfaces
- feat: add schemas endpoints
- ci: add schemas cm for local testing
- feat: wire up schemas pkg
- docs: update env vars on README

-----

pagination on the `schemas` endpoint doesn't behave like the `identities`
as docs says in this case the page doesn't work as somebody would expect in any other application



---

```
shipperizer in ~/shipperizer/kratos-operator on IAM-362-add-configmap λ http :8000/api/v0/schemas/admin_v0 
HTTP/1.1 200 OK
Content-Length: 681
Content-Type: application/json
Date: Thu, 24 Aug 2023 13:26:36 GMT
Vary: Origin

{
    "_meta": null,
    "data": [
        {
            "id": "admin_v0",
            "schema": {
                "$id": "https://schemas.canonical.com/presets/kratos/admin_v0.json",
                "$schema": "http://json-schema.org/draft-07/schema#",
                "properties": {
                    "additionalProperties": true,
                    "traits": {
                        "properties": {
                            "email": {
                                "format": "email",
                                "minLength": 3,
                                "ory.sh/kratos": {
                                    "verification": {
                                        "via": "email"
                                    }
                                },
                                "title": "E-Mail",
                                "type": "string"
                            },
                            "name": {
                                "title": "Name",
                                "type": "string"
                            },
                            "phone_number": {
                                "title": "Phone Number",
                                "type": "string"
                            },
                            "username": {
                                "ory.sh/kratos": {
                                    "credentials": {
                                        "password": {
                                            "identifier": true
                                        }
                                    }
                                },
                                "title": "Username",
                                "type": "string"
                            }
                        },
                        "type": "object"
                    }
                },
                "title": "Admin Account",
                "type": "object"
            }
        }
    ],
    "message": "Detail of Identity Schemas",
    "status": 200
}


shipperizer in ~/shipperizer/kratos-operator on IAM-362-add-configmap λ http :8000/api/v0/schemas/admin_v0 size==1
HTTP/1.1 200 OK
Content-Length: 681
Content-Type: application/json
Date: Thu, 24 Aug 2023 13:26:50 GMT
Vary: Origin

{
    "_meta": null,
    "data": [
        {
            "id": "admin_v0",
            "schema": {
                "$id": "https://schemas.canonical.com/presets/kratos/admin_v0.json",
                "$schema": "http://json-schema.org/draft-07/schema#",
                "properties": {
                    "additionalProperties": true,
                    "traits": {
                        "properties": {
                            "email": {
                                "format": "email",
                                "minLength": 3,
                                "ory.sh/kratos": {
                                    "verification": {
                                        "via": "email"
                                    }
                                },
                                "title": "E-Mail",
                                "type": "string"
                            },
                            "name": {
                                "title": "Name",
                                "type": "string"
                            },
                            "phone_number": {
                                "title": "Phone Number",
                                "type": "string"
                            },
                            "username": {
                                "ory.sh/kratos": {
                                    "credentials": {
                                        "password": {
                                            "identifier": true
                                        }
                                    }
                                },
                                "title": "Username",
                                "type": "string"
                            }
                        },
                        "type": "object"
                    }
                },
                "title": "Admin Account",
                "type": "object"
            }
        }
    ],
    "message": "Detail of Identity Schemas",
    "status": 200
}


shipperizer in ~/shipperizer/kratos-operator on IAM-362-add-configmap λ k get cm identity-schemas -o yaml | yq .data
{
  "default.schema": "default"
}
shipperizer in ~/shipperizer/kratos-operator on IAM-362-add-configmap λ http POST :8000/api/v0/schemas id=admin_v1 schema:='{"$id":"https://canonical.com/schemas/admin_v1.json","props":{"1":"test"}}'
HTTP/1.1 200 OK
Content-Length: 176
Content-Type: application/json
Date: Thu, 24 Aug 2023 13:24:12 GMT
Vary: Origin

{
    "_meta": null,
    "data": [
        {
            "id": "admin_v1",
            "schema": {
                "$id": "https://canonical.com/schemas/admin_v1.json",
                "props": {
                    "1": "test"
                }
            }
        }
    ],
    "message": "Created Identity Schemas",
    "status": 200
}


shipperizer in ~/shipperizer/kratos-operator on IAM-362-add-configmap λ k get cm identity-schemas -o yaml | yq .data                                                                                   
{
  "admin_v1": "{\"$id\":\"https://canonical.com/schemas/admin_v1.json\",\"props\":{\"1\":\"test\"}}",
  "default.schema": "default"
}
shipperizer in ~/shipperizer/kratos-operator on IAM-362-add-configmap λ http PATCH :8000/api/v0/schemas/admin_v1 id=admin_v1 schema:='{"$id":"https://canonical.com/schemas/admin_v1.json","props":{"2":"test","3":true}}'
HTTP/1.1 200 OK
Content-Length: 185
Content-Type: application/json
Date: Thu, 24 Aug 2023 13:24:57 GMT
Vary: Origin

{
    "_meta": null,
    "data": [
        {
            "id": "admin_v1",
            "schema": {
                "$id": "https://canonical.com/schemas/admin_v1.json",
                "props": {
                    "2": "test",
                    "3": true
                }
            }
        }
    ],
    "message": "Updated Identity Schemas",
    "status": 200
}


shipperizer in ~/shipperizer/kratos-operator on IAM-362-add-configmap λ k get cm identity-schemas -o yaml | yq .data                                                                                                      
{
  "admin_v1": "{\"$id\":\"https://canonical.com/schemas/admin_v1.json\",\"props\":{\"2\":\"test\",\"3\":true}}",
  "default.schema": "default"
}
shipperizer in ~/shipperizer/kratos-operator on IAM-362-add-configmap λ http DELETE :8000/api/v0/schemas/admin_v1                                                                                                          
HTTP/1.1 200 OK
Content-Length: 77
Content-Type: application/json
Date: Thu, 24 Aug 2023 13:25:14 GMT
Vary: Origin

{
    "_meta": null,
    "data": null,
    "message": "Identity Schemas deleted",
    "status": 200
}


shipperizer in ~/shipperizer/kratos-operator on IAM-362-add-configmap λ k get cm identity-schemas -o yaml | yq .data
{
  "default.schema": "default"
}

```