### PR TITLE
IAM-337-Implement Oathkeeper integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GOFLAGS?=-ldflags=-w -ldflags=-s -a -buildvcs
 UI_FOLDER?=
 MICROK8S_REGISTRY_FLAG?=SKAFFOLD_DEFAULT_REPO=localhost:32000
 SKAFFOLD?=skaffold
+CONFIGMAP?=deployments/kubectl/configMap.yaml
 
 
 .EXPORT_ALL_VARIABLES:
@@ -50,5 +51,6 @@ npm-build:
 
 
 dev:
+	microk8s.kubectl apply -f $(CONFIGMAP)
 	@$(MICROK8S_REGISTRY_FLAG) $(SKAFFOLD) run --mute-logs=all --port-forward
 .PHONY: dev

--- a/deployments/helm/hydra/values.yaml
+++ b/deployments/helm/hydra/values.yaml
@@ -12,3 +12,5 @@ hydra:
       consent: https://my-idp/consent
   automigration:
     enabled: true
+maester:
+  enabled: false

--- a/deployments/helm/oathkeeper/values.yaml
+++ b/deployments/helm/oathkeeper/values.yaml
@@ -1,6 +1,56 @@
-demo: true
+demo: false
+maester:
+  enabled: false
 service:
   proxy:
     enabled: false
   metrics:
     enabled: false
+oathkeeper:
+  managedAccessRules: false
+  config:
+    access_rules:
+      repositories:
+        - file:///etc/rules/admin_ui_rules.json
+    authenticators:
+      anonymous:
+        enabled: true
+      jwt:
+        enabled: true
+        config:
+          jwks_urls:
+            - "https://raw.githubusercontent.com/ory/k8s/master/helm/charts/oathkeeper/demo/authenticator.jwt.jwks.json"
+      noop:
+        enabled: true
+      unauthorized:
+        enabled: true
+    authorizers:
+      allow:
+        enabled: true
+      deny:
+        enabled: true
+    mutators:
+      cookie:
+        enabled: true
+        config:
+          cookies:
+            user: "<nil>"
+      header:
+        enabled: true
+        config:
+          headers:
+            X-User: "<nil>"
+      id_token:
+        enabled: true
+        config:
+          issuer_url: http://oathkeeper/
+          jwks_url: https://raw.githubusercontent.com/ory/k8s/master/helm/charts/oathkeeper/demo/mutator.id_token.jwks.json
+      noop:
+        enabled: true
+    serve:
+      proxy:
+        cors:
+          enabled: true
+      api:
+        cors:
+          enabled: true

--- a/deployments/helm/oathkeeper/values.yaml
+++ b/deployments/helm/oathkeeper/values.yaml
@@ -1,0 +1,6 @@
+demo: true
+service:
+  proxy:
+    enabled: false
+  metrics:
+    enabled: false

--- a/deployments/kubectl/configMap.yaml
+++ b/deployments/kubectl/configMap.yaml
@@ -116,22 +116,81 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: oathkeeper-rules
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    meta.helm.sh/release-name: "oathkeeper"
+    meta.helm.sh/release-namespace: "default"
 data:
-  "ADMIN_RULE_mocked_rule1.json": |
-    {
-        "authenticators": [{"handler":"cookie_session"}],
-        "authorizer":{"handler":"allow"},
-        "id":"mocked_rule1",
-        "match":{"methods":["GET","POST"]},
-        "mutators":[{"handler":"header"}],
-        "upstream":{}
-    }
-  "ADMIN_RULE_mocked_rule2.json": |
-    {
-        "authenticators":[{"handler":"cookie_session"}],
-        "authorizer":{"handler":"deny"},
-        "id":"mocked_rule2",
-        "match":{"methods":["PUT","DELETE"]},
-        "mutators":[{"handler":"header"}],
-        "upstream":{}
-    }
+  "admin_ui_rules.json": |
+    [
+      {
+        "id": "admin-rule-1",
+        "upstream": {
+          "url": "https://httpbin.org/anything"
+        },
+        "match": {
+          "url": "http://<[^/]+>/authenticator/noop/authorizer/allow/mutator/noop",
+          "methods": ["GET", "POST", "PUT", "DELETE", "PATCH"]
+        },
+        "authenticators": [
+          {
+            "handler": "noop"
+          }
+        ],
+        "authorizer": {
+          "handler": "allow"
+        },
+        "mutators": [
+          {
+            "handler": "noop"
+          }
+        ]
+      },
+      {
+        "id": "admin-rule-2",
+        "upstream": {
+          "url": "https://httpbin.org/anything"
+        },
+        "match": {
+          "url": "http://<[^/]+>/authenticator/anonymous/authorizer/allow/mutator/header",
+          "methods": ["GET", "POST", "PUT", "DELETE", "PATCH"]
+        },
+        "authenticators": [
+          {
+            "handler": "anonymous"
+          }
+        ],
+        "authorizer": {
+          "handler": "allow"
+        },
+        "mutators": [
+          {
+            "handler": "header"
+          }
+        ]
+      },
+      {
+        "id": "admin-rule-3",
+        "upstream": {
+          "url": "https://httpbin.org/anything"
+        },
+        "match": {
+          "url": "http://<[^/]+>/authenticator/anonymous/authorizer/allow/mutator/id_token",
+          "methods": ["GET", "POST", "PUT", "DELETE", "PATCH"]
+        },
+        "authenticators": [
+          {
+            "handler": "anonymous"
+          }
+        ],
+        "authorizer": {
+          "handler": "allow"
+        },
+        "mutators": [
+          {
+            "handler": "id_token"
+          }
+        ]
+      }
+    ]

--- a/deployments/kubectl/configMap.yaml
+++ b/deployments/kubectl/configMap.yaml
@@ -10,10 +10,13 @@ data:
   KRATOS_PUBLIC_URL: http://kratos-public.default.svc.cluster.local
   KRATOS_ADMIN_URL: http://kratos-public.default.svc.cluster.local
   HYDRA_ADMIN_URL: http://hydra-admin.default.svc.cluster.local:4445
+  OATHKEEPER_PUBLIC_URL: http://oathkeeper-api.default.svc.cluster.local:4456
   IDP_CONFIGMAP_NAME: idps
   IDP_CONFIGMAP_NAMESPACE: default
   SCHEMAS_CONFIGMAP_NAME: identity-schemas
   SCHEMAS_CONFIGMAP_NAMESPACE: default
+  RULES_CONFIGMAP_NAME: oathkeeper-rules
+  RULES_CONFIGMAP_NAMESPACE: default
 
 ---
 apiVersion: v1
@@ -108,3 +111,27 @@ data:
                 "type": "object"
             }
         }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oathkeeper-rules
+data:
+  "ADMIN_RULE_mocked_rule1.json": |
+    {
+        "authenticators": [{"handler":"cookie_session"}],
+        "authorizer":{"handler":"allow"},
+        "id":"mocked_rule1",
+        "match":{"methods":["GET","POST"]},
+        "mutators":[{"handler":"header"}],
+        "upstream":{}
+    }
+  "ADMIN_RULE_mocked_rule2.json": |
+    {
+        "authenticators":[{"handler":"cookie_session"}],
+        "authorizer":{"handler":"deny"},
+        "id":"mocked_rule2",
+        "match":{"methods":["PUT","DELETE"]},
+        "mutators":[{"handler":"header"}],
+        "upstream":{}
+    }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/ory/hydra-client-go/v2 v2.1.1
 	github.com/ory/kratos-client-go v1.0.0
+	github.com/ory/oathkeeper-client-go v0.40.6
 	github.com/prometheus/client_golang v1.17.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/ory/hydra-client-go/v2 v2.1.1 h1:3JatU9uFbw5XhF3lgPCas1l1Kok2v5Mq1p26
 github.com/ory/hydra-client-go/v2 v2.1.1/go.mod h1:IiIwChp/9wRvPoyFQblqPvg78uVishCCrV9+/M7Pl34=
 github.com/ory/kratos-client-go v1.0.0 h1:mm32FMJrt4pBv2KEuhuNtiewJApc8c1Kmz0+WFHhOMA=
 github.com/ory/kratos-client-go v1.0.0/go.mod h1:a2Tl4cgQAxsjR59w3EfnH5hengabjXUHiEVDzdqiZI0=
+github.com/ory/oathkeeper-client-go v0.40.6 h1:Qm/odusPn6DTJ8mXXElNzfXYpcD5wqmb/k3dOYKUfTg=
+github.com/ory/oathkeeper-client-go v0.40.6/go.mod h1:9JUPR04XPH3e53TYbfu+KveCnTIYtlSTJiQ23rEQLJI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.17.0 h1:rl2sfwZMtSthVU752MqfjQozy7blglC+1SOtjMAMh+Q=

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -13,13 +13,17 @@ type EnvSpec struct {
 
 	Debug bool `envconfig:"debug" default:"false"`
 
-	KratosPublicURL string `envconfig:"kratos_public_url" required:"true"`
-	KratosAdminURL  string `envconfig:"kratos_admin_url" required:"true"`
-	HydraAdminURL   string `envconfig:"hydra_admin_url" required:"true"`
+	KratosPublicURL     string `envconfig:"kratos_public_url" required:"true"`
+	KratosAdminURL      string `envconfig:"kratos_admin_url" required:"true"`
+	HydraAdminURL       string `envconfig:"hydra_admin_url" required:"true"`
+	OathkeeperPublicURL string `envconfig:"oathkeeper_public_url" required:"true"`
 
 	IDPConfigMapName      string `envconfig:"idp_configmap_name" required:"true"`
 	IDPConfigMapNamespace string `envconfig:"idp_configmap_namespace" required:"true"`
 
 	SchemasConfigMapName      string `envconfig:"schemas_configmap_name" required:"true"`
 	SchemasConfigMapNamespace string `envconfig:"schemas_configmap_namespace" required:"true"`
+
+	RulesConfigMapName      string `envconfig:"rules_configmap_name" required:"true"`
+	RulesConfigMapNamespace string `envconfig:"rules_configmap_namespace" required:"true"`
 }

--- a/internal/oathkeeper/client.go
+++ b/internal/oathkeeper/client.go
@@ -1,0 +1,36 @@
+package oathkeeper
+
+import (
+	"net/http"
+
+	client "github.com/ory/oathkeeper-client-go"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+type Client struct {
+	c *client.APIClient
+}
+
+func (c *Client) ApiApi() client.ApiApi {
+	return c.c.ApiApi
+}
+
+func NewClient(url string, debug bool) *Client {
+	c := new(Client)
+
+	configuration := client.NewConfiguration()
+	configuration.Debug = debug
+	configuration.Servers = []client.ServerConfiguration{
+		{
+			URL:         url,
+			Description: "Oathkeeper endpoint",
+		},
+	}
+
+	configuration.HTTPClient = new(http.Client)
+	configuration.HTTPClient.Transport = otelhttp.NewTransport(http.DefaultTransport)
+
+	c.c = client.NewAPIClient(configuration)
+
+	return c
+}

--- a/pkg/rules/handlers.go
+++ b/pkg/rules/handlers.go
@@ -1,0 +1,241 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
+	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+
+	"github.com/go-chi/chi/v5"
+	oathkeeper "github.com/ory/oathkeeper-client-go"
+)
+
+type API struct {
+	service ServiceInterface
+
+	logger logging.LoggerInterface
+}
+
+func (a *API) RegisterEndpoints(mux *chi.Mux) {
+	mux.Get("/api/v0/rules", a.handleList)
+	mux.Get("/api/v0/rules/{id}", a.handleDetail)
+	mux.Post("/api/v0/rules", a.handleCreate)
+	mux.Put("/api/v0/rules/{id}", a.handleUpdate)
+	mux.Delete("/api/v0/rules/{id}", a.handleRemove)
+}
+
+func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	pagination := types.ParsePagination(r.URL.Query())
+
+	rules, err := a.service.ListRules(r.Context(), pagination.Page, pagination.Size)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Data:    rules,
+			Message: "List of rules",
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handleDetail(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ruleID := chi.URLParam(r, "id")
+
+	rule, err := a.service.GetRule(r.Context(), ruleID)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Data:    rule,
+			Message: "Rule detail",
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing request payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+	}
+
+	rule := new(oathkeeper.Rule)
+	if err := json.Unmarshal(body, rule); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing JSON payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+
+	}
+
+	err = a.service.CreateRule(r.Context(), *rule)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Message: fmt.Sprintf("Created rule %s", *rule.Id),
+			Status:  http.StatusCreated,
+		},
+	)
+}
+
+func (a *API) handleUpdate(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ruleID := chi.URLParam(r, "id")
+
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing request payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+	}
+
+	rule := new(oathkeeper.Rule)
+	if err := json.Unmarshal(body, rule); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing JSON payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+
+	}
+
+	err = a.service.UpdateRule(r.Context(), ruleID, *rule)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Message: fmt.Sprintf("Updated rule %s", *rule.Id),
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handleRemove(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ruleID := chi.URLParam(r, "id")
+
+	err := a.service.DeleteRule(r.Context(), ruleID)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Message: fmt.Sprintf("Deleted rule %s", ruleID),
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
+	a := new(API)
+
+	a.service = service
+
+	a.logger = logger
+
+	return a
+}

--- a/pkg/rules/handlers_test.go
+++ b/pkg/rules/handlers_test.go
@@ -1,0 +1,629 @@
+package rules
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
+	"github.com/go-chi/chi/v5"
+	"github.com/golang/mock/gomock"
+	oathkeeper "github.com/ory/oathkeeper-client-go"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package rules -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package rules -destination ./mock_interfaces.go -source=./interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package rules -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package rules -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+//go:generate mockgen -build_flags=--mod=mod -package rules -destination ./mock_corev1.go k8s.io/client-go/kubernetes/typed/core/v1 CoreV1Interface,ConfigMapInterface
+//go:generate mockgen -build_flags=--mod=mod -package rules -destination ./mock_oathkeeper.go github.com/ory/oathkeeper-client-go ApiApi
+
+func TestHandleListSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	string_athenticator_handler := "cookie_session"
+	string_mutator_handler := "header"
+	string_id1 := "mocked_rule1:allow"
+	string_id2 := "mocked_rule2:deny"
+	string_authorizer_handler_deny := "deny"
+	string_authorizer_handler_allow := "allow"
+
+	serviceOutput := []oathkeeper.Rule{
+		{
+			Id: &string_id1,
+			Authenticators: []oathkeeper.RuleHandler{
+				{
+					Handler: &string_athenticator_handler,
+				},
+			},
+			Mutators: []oathkeeper.RuleHandler{
+				{
+					Handler: &string_mutator_handler,
+				},
+			},
+			Authorizer: &oathkeeper.RuleHandler{
+				Handler: &string_authorizer_handler_allow,
+			},
+			Match: &oathkeeper.RuleMatch{
+				Methods: []string{"GET", "POST"},
+			},
+		},
+		{
+			Id: &string_id2,
+			Authenticators: []oathkeeper.RuleHandler{
+				{
+					Handler: &string_athenticator_handler,
+				},
+			},
+			Mutators: []oathkeeper.RuleHandler{
+				{
+					Handler: &string_mutator_handler,
+				},
+			},
+			Authorizer: &oathkeeper.RuleHandler{
+				Handler: &string_authorizer_handler_deny,
+			},
+			Match: &oathkeeper.RuleMatch{
+				Methods: []string{"PUT", "DELETE"},
+			},
+		},
+	}
+
+	var page int64 = 1
+	var size int64 = 100
+
+	mockService.EXPECT().ListRules(gomock.Any(), page, size).Return(serviceOutput, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/rules?page=1&size=100", nil)
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusOK, res.StatusCode)
+	}
+
+	type Response struct {
+		Data []oathkeeper.Rule `json:"data"`
+	}
+
+	rr := new(Response)
+
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	for i, r := range rr.Data {
+		if *r.Id != *serviceOutput[i].Id {
+			t.Fatalf("invalid result, expected: %v, got: %v", *serviceOutput[i].Id, *r.Id)
+		}
+	}
+}
+
+func TestHandleListFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	var page int64 = 1
+	var size int64 = 100
+
+	mockService.EXPECT().ListRules(gomock.Any(), page, size).Return(nil, fmt.Errorf("mock_error"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/rules?page=0&offset=100", nil)
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Status != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, rr.Status)
+	}
+
+	if rr.Message != "mock_error" {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, rr.Status)
+	}
+}
+
+func TestHandleDetailSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	string_athenticator_handler := "cookie_session"
+	string_mutator_handler := "header"
+	string_id1 := "mocked_rule1:allow"
+	string_authorizer_handler_allow := "allow"
+
+	serviceOutput := []oathkeeper.Rule{
+		{
+			Id: &string_id1,
+			Authenticators: []oathkeeper.RuleHandler{
+				{
+					Handler: &string_athenticator_handler,
+				},
+			},
+			Mutators: []oathkeeper.RuleHandler{
+				{
+					Handler: &string_mutator_handler,
+				},
+			},
+			Authorizer: &oathkeeper.RuleHandler{
+				Handler: &string_authorizer_handler_allow,
+			},
+			Match: &oathkeeper.RuleMatch{
+				Methods: []string{"GET", "POST"},
+			},
+		},
+	}
+
+	mockService.EXPECT().GetRule(gomock.Any(), gomock.Any()).Return(serviceOutput, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/rules/mocked_rule1:allow", nil)
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusOK, res.StatusCode)
+	}
+
+	type Response struct {
+		Data []oathkeeper.Rule `json:"data"`
+	}
+
+	rr := new(Response)
+
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	for i, r := range rr.Data {
+		if *r.Id != *serviceOutput[i].Id {
+			t.Fatalf("invalid result, expected: %v, got: %v", *serviceOutput[i].Id, *r.Id)
+		}
+	}
+}
+
+func TestHandleDetailFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	mockService.EXPECT().GetRule(gomock.Any(), "mocked_rule1:allow").Return(nil, fmt.Errorf("mock_error"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/rules/mocked_rule1:allow", nil)
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Status != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, rr.Status)
+	}
+
+	if rr.Message != "mock_error" {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, rr.Status)
+	}
+}
+
+func TestHandleUpdateSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	string_athenticator_handler := "cookie_session"
+	string_mutator_handler := "header"
+	string_id1 := "mocked_rule1:allow"
+	string_authorizer_handler_allow := "allow"
+
+	ruleUpdate := oathkeeper.Rule{
+		Id: &string_id1,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &string_athenticator_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &string_mutator_handler,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &string_authorizer_handler_allow,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+
+	payload, _ := json.Marshal(ruleUpdate)
+
+	mockService.EXPECT().UpdateRule(gomock.Any(), "mocked_rule1:allow", gomock.Any()).Return(nil)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v0/rules/mocked_rule1:allow", bytes.NewReader(payload))
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusOK, res.StatusCode)
+	}
+
+	rr := new(types.Response)
+
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Message != fmt.Sprintf("Updated rule %s", *ruleUpdate.Id) {
+		t.Fatalf("invalid result, expected: %v, got: %v", ruleUpdate.Id, rr.Message)
+	}
+}
+
+func TestHandleUpdateFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	string_athenticator_handler := "cookie_session"
+	string_mutator_handler := "header"
+	string_id1 := "mocked_rule1:allow"
+	string_authorizer_handler_allow := "allow"
+
+	ruleUpdate := oathkeeper.Rule{
+		Id: &string_id1,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &string_athenticator_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &string_mutator_handler,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &string_authorizer_handler_allow,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+
+	payload, _ := json.Marshal(ruleUpdate)
+
+	mockService.EXPECT().UpdateRule(gomock.Any(), "mocked_rule1:allow", gomock.Any()).Return(fmt.Errorf("mock_error"))
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v0/rules/mocked_rule1:allow", bytes.NewReader(payload))
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Status != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, rr.Status)
+	}
+
+	if rr.Message != "mock_error" {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, rr.Status)
+	}
+}
+
+func TestHandleCreateSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	string_athenticator_handler := "cookie_session"
+	string_mutator_handler := "header"
+	string_id1 := "mocked_rule1:allow"
+	string_authorizer_handler_allow := "allow"
+
+	ruleCreated := oathkeeper.Rule{
+		Id: &string_id1,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &string_athenticator_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &string_mutator_handler,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &string_authorizer_handler_allow,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+
+	payload, _ := json.Marshal(ruleCreated)
+
+	mockService.EXPECT().CreateRule(gomock.Any(), gomock.Any()).Return(nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v0/rules", bytes.NewReader(payload))
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusCreated {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusCreated, res.StatusCode)
+	}
+
+	rr := new(types.Response)
+
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Message != fmt.Sprintf("Created rule %s", *ruleCreated.Id) {
+		t.Fatalf("invalid result, expected: %v, got: %v", ruleCreated.Id, rr.Message)
+	}
+}
+
+func TestHandleCreateFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	string_athenticator_handler := "cookie_session"
+	string_mutator_handler := "header"
+	string_id1 := "mocked_rule1:allow"
+	string_authorizer_handler_allow := "allow"
+
+	ruleCreated := oathkeeper.Rule{
+		Id: &string_id1,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &string_athenticator_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &string_mutator_handler,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &string_authorizer_handler_allow,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+
+	payload, _ := json.Marshal(ruleCreated)
+
+	mockService.EXPECT().CreateRule(gomock.Any(), gomock.Any()).Return(fmt.Errorf("mock_error"))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v0/rules", bytes.NewReader(payload))
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Status != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, rr.Status)
+	}
+
+	if rr.Message != "mock_error" {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, rr.Status)
+	}
+}
+
+func TestHandleRemoveSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	mockService.EXPECT().DeleteRule(gomock.Any(), "mocked_rule1:allow").Return(nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v0/rules/mocked_rule1:allow", nil)
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusOK, res.StatusCode)
+	}
+
+	rr := new(types.Response)
+
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Message != fmt.Sprintf("Deleted rule mocked_rule1:allow") {
+		t.Fatalf("invalid result, expected: Deleted rule mocked_rule1:allow, got: %v", rr.Message)
+	}
+}
+
+func TestHandleRemoveFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+
+	mockService.EXPECT().DeleteRule(gomock.Any(), "mocked_rule1:allow").Return(fmt.Errorf("mock_error"))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v0/rules/mocked_rule1:allow", nil)
+	w := httptest.NewRecorder()
+	mux := chi.NewMux()
+	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+
+	mux.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, res.StatusCode)
+	}
+
+	rr := new(types.Response)
+	if err := json.Unmarshal(data, rr); err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	if rr.Status != http.StatusInternalServerError {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, rr.Status)
+	}
+
+	if rr.Message != "mock_error" {
+		t.Fatalf("expected HTTP status code %v got %v", http.StatusInternalServerError, rr.Status)
+	}
+}

--- a/pkg/rules/interfaces.go
+++ b/pkg/rules/interfaces.go
@@ -1,0 +1,15 @@
+package rules
+
+import (
+	"context"
+
+	oathkeeper "github.com/ory/oathkeeper-client-go"
+)
+
+type ServiceInterface interface {
+	ListRules(context.Context, int64, int64) ([]oathkeeper.Rule, error)
+	GetRule(context.Context, string) ([]oathkeeper.Rule, error)
+	UpdateRule(context.Context, string, oathkeeper.Rule) error
+	CreateRule(context.Context, oathkeeper.Rule) error
+	DeleteRule(context.Context, string) error
+}

--- a/pkg/rules/service.go
+++ b/pkg/rules/service.go
@@ -1,0 +1,283 @@
+package rules
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	oathkeeper "github.com/ory/oathkeeper-client-go"
+	"go.opentelemetry.io/otel/trace"
+
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreV1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const (
+	ADMIN_UI_RULE_FILE = "admin_ui_rules.json"
+)
+
+type Config struct {
+	Name      string
+	Namespace string
+	K8s       coreV1.CoreV1Interface
+	OkClient  oathkeeper.ApiApi
+}
+
+func NewConfig(cmName, cmNamespace string, k8s coreV1.CoreV1Interface, oathkeeper oathkeeper.ApiApi) *Config {
+	rulesConfig := Config{
+		K8s:       k8s,
+		Name:      cmName,
+		Namespace: cmNamespace,
+		OkClient:  oathkeeper,
+	}
+
+	return &rulesConfig
+}
+
+type Service struct {
+	oathkeeper oathkeeper.ApiApi
+
+	cmName      string
+	cmNamespace string
+
+	k8s coreV1.CoreV1Interface
+
+	tracer  trace.Tracer
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
+}
+
+func (s *Service) ListRules(ctx context.Context, page, size int64) ([]oathkeeper.Rule, error) {
+	ctx, span := s.tracer.Start(ctx, "rules.Service.ListRules")
+	defer span.End()
+
+	limit := size
+	offset := (page - 1) * size
+
+	rules, _, err := s.oathkeeper.ListRules(ctx).Limit(limit).Offset(offset).Execute()
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return nil, err
+	}
+
+	return rules, nil
+}
+
+func (s *Service) GetRule(ctx context.Context, id string) ([]oathkeeper.Rule, error) {
+	ctx, span := s.tracer.Start(ctx, "rules.Service.GetRule")
+	defer span.End()
+
+	rule, _, err := s.oathkeeper.GetRule(ctx, id).Execute()
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return nil, err
+	}
+
+	rules := make([]oathkeeper.Rule, 0)
+	rules = append(rules, *rule)
+	return rules, nil
+}
+
+func (s *Service) UpdateRule(ctx context.Context, id string, updatedRule oathkeeper.Rule) error {
+	ctx, span := s.tracer.Start(ctx, "rules.Service.UpdateRule")
+	defer span.End()
+
+	//check for inconsistency between id url parameter and the id in payload object
+	if id != *updatedRule.Id {
+		return fmt.Errorf("The URL parameter id %s is different from payload rule id %s", id, *updatedRule.Id)
+	}
+
+	cm, err := s.k8s.ConfigMaps(s.cmNamespace).Get(ctx, s.cmName, metaV1.GetOptions{})
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return err
+	}
+
+	rules, err := s.extractAdminRules(cm.Data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := rules[id]; !ok {
+		return fmt.Errorf("rule with ID %s not found", id)
+	}
+
+	rules[id] = &updatedRule
+
+	rawRuleList, err := s.marshalRuleMap(rules)
+	if err != nil {
+		return err
+	}
+
+	cm.Data[ADMIN_UI_RULE_FILE] = rawRuleList
+
+	if _, err = s.k8s.ConfigMaps(s.cmNamespace).Update(ctx, cm, metaV1.UpdateOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Service) CreateRule(ctx context.Context, newRule oathkeeper.Rule) error {
+	ctx, span := s.tracer.Start(ctx, "rules.Service.CreateRule")
+	defer span.End()
+
+	cm, err := s.k8s.ConfigMaps(s.cmNamespace).Get(ctx, s.cmName, metaV1.GetOptions{})
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return err
+	}
+
+	//Here I need to check the ID variable of all rules to make sure there's no collusion
+	rulesReadable, err := s.extractReadableRules(cm.Data)
+	if _, ok := rulesReadable[*newRule.Id]; ok {
+		return fmt.Errorf("rule with ID %s already exists", *newRule.Id)
+	}
+
+	rulesWritable, err := s.extractAdminRules(cm.Data)
+	if err != nil {
+		return err
+	}
+
+	rulesWritable[*newRule.Id] = &newRule
+
+	rawRuleList, err := s.marshalRuleMap(rulesWritable)
+	if err != nil {
+		return err
+	}
+
+	cm.Data[ADMIN_UI_RULE_FILE] = rawRuleList
+
+	if _, err = s.k8s.ConfigMaps(s.cmNamespace).Update(ctx, cm, metaV1.UpdateOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Service) DeleteRule(ctx context.Context, id string) error {
+	ctx, span := s.tracer.Start(ctx, "rules.Service.DeleteRule")
+	defer span.End()
+
+	cm, err := s.k8s.ConfigMaps(s.cmNamespace).Get(ctx, s.cmName, metaV1.GetOptions{})
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return err
+	}
+
+	rules, err := s.extractAdminRules(cm.Data)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := rules[id]; !ok {
+		return fmt.Errorf("rule with ID %s not found", id)
+	}
+
+	delete(rules, id)
+
+	rawRuleList, err := s.marshalRuleMap(rules)
+	if err != nil {
+		return err
+	}
+
+	cm.Data[ADMIN_UI_RULE_FILE] = rawRuleList
+
+	if _, err = s.k8s.ConfigMaps(s.cmNamespace).Update(ctx, cm, metaV1.UpdateOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// The input parameter is always cm.Data
+// Output map includes the rules in ADMIN_RULE_FILE, not all rules in the configmap.
+func (s *Service) extractAdminRules(data map[string]string) (map[string]*oathkeeper.Rule, error) {
+
+	ruleMap := make(map[string]*oathkeeper.Rule)
+
+	ruleList := make([]*oathkeeper.Rule, 0)
+	rawRuleList, ok := data[ADMIN_UI_RULE_FILE]
+	if !ok {
+		return ruleMap, nil
+	}
+
+	err := json.Unmarshal([]byte(rawRuleList), &ruleList)
+
+	if err != nil {
+		s.logger.Errorf("failed unmarshalling %s - %v", rawRuleList, err)
+		return nil, err
+	}
+
+	for _, v := range ruleList {
+		ruleMap[*v.Id] = v
+	}
+
+	return ruleMap, nil
+}
+
+// The input parameter is always cm.Data
+// Output map includes the all rules in the configmap, do not use the output for creating/editing/deleting rules in the configmap.
+func (s *Service) extractReadableRules(data map[string]string) (map[string]*oathkeeper.Rule, error) {
+
+	ruleMap := make(map[string]*oathkeeper.Rule)
+
+	for file, rawRuleList := range data {
+
+		ruleList := make([]*oathkeeper.Rule, 0)
+		err := json.Unmarshal([]byte(rawRuleList), &ruleList)
+
+		if err != nil {
+			s.logger.Errorf("failed unmarshalling ruleset from file %s: %s - %v", file, rawRuleList, err)
+			return nil, err
+		}
+
+		for _, v := range ruleList {
+			ruleMap[*v.Id] = v
+		}
+	}
+	return ruleMap, nil
+}
+
+// rules are stored in the configmap as a list of oathkeeper rules
+func (s *Service) marshalRuleMap(rules map[string]*oathkeeper.Rule) (string, error) {
+	ruleList := make([]*oathkeeper.Rule, 0)
+	for _, v := range rules {
+		ruleList = append(ruleList, v)
+	}
+
+	rawRuleList, err := json.Marshal(ruleList)
+
+	if err != nil {
+		s.logger.Errorf("failed marshalling %s - %v", rawRuleList, err)
+		return "", err
+	}
+
+	return string(rawRuleList), nil
+}
+
+func NewService(config *Config, tracer trace.Tracer, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *Service {
+	s := new(Service)
+
+	if config == nil {
+		panic("empty config for rules service")
+	}
+
+	s.oathkeeper = config.OkClient
+	s.k8s = config.K8s
+	s.cmName = config.Name
+	s.cmNamespace = config.Namespace
+
+	s.monitor = monitor
+	s.tracer = tracer
+	s.logger = logger
+
+	return s
+}

--- a/pkg/rules/service_test.go
+++ b/pkg/rules/service_test.go
@@ -1,0 +1,997 @@
+package rules
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	reflect "reflect"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	oathkeeper "github.com/ory/oathkeeper-client-go"
+	trace "go.opentelemetry.io/otel/trace"
+	v1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package rules -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package rules -destination ./mock_interfaces.go -source=./interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package rules -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package rules -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+//go:generate mockgen -build_flags=--mod=mod -package rules -destination ./mock_corev1.go k8s.io/client-go/kubernetes/typed/core/v1 CoreV1Interface,ConfigMapInterface
+//go:generate mockgen -build_flags=--mod=mod -package rules -destination ./mock_oathkeeper.go github.com/ory/oathkeeper-client-go ApiApi
+
+func TestListRulesSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockOathkeeperApiApi := NewMockApiApi(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+
+	ctx := context.Background()
+	config := Config{
+		Name:      "mock_config",
+		Namespace: "mock_namespace",
+		K8s:       mockCoreV1,
+		OkClient:  mockOathkeeperApiApi,
+	}
+
+	string_athenticator_handler := "cookie_session"
+	string_mutator_handler := "header"
+	string_id := "mocked_rule1:allow"
+	string_authorizer_handler := "allow"
+
+	listRulesRequest := oathkeeper.ApiApiListRulesRequest{
+		ApiService: mockOathkeeperApiApi,
+	}
+
+	mock_rules := []oathkeeper.Rule{
+		{
+			Authenticators: []oathkeeper.RuleHandler{
+				{
+					Handler: &string_athenticator_handler,
+				},
+			},
+			Mutators: []oathkeeper.RuleHandler{
+				{
+					Handler: &string_mutator_handler,
+				},
+			},
+			Id: &string_id,
+			Authorizer: &oathkeeper.RuleHandler{
+				Handler: &string_authorizer_handler,
+			},
+			Match: &oathkeeper.RuleMatch{
+				Methods: []string{
+					"GET",
+					"POST",
+				},
+			},
+		},
+	}
+
+	mockTracer.EXPECT().Start(ctx, "rules.Service.ListRules").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockOathkeeperApiApi.EXPECT().ListRules(ctx).Times(1).Return(listRulesRequest)
+	mockOathkeeperApiApi.EXPECT().ListRulesExecute(gomock.Any()).Times(1).Return(mock_rules, new(http.Response), nil)
+
+	rules, err := NewService(&config, mockTracer, mockMonitor, mockLogger).ListRules(ctx, 1, 100)
+
+	if !reflect.DeepEqual(rules, mock_rules) {
+		t.Fatalf("expected identities to be %v not  %v", mock_rules, rules)
+	}
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestListRulesFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockOathkeeperApiApi := NewMockApiApi(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+
+	ctx := context.Background()
+	config := Config{
+		Name:      "mock_config",
+		Namespace: "mock_namespace",
+		K8s:       mockCoreV1,
+		OkClient:  mockOathkeeperApiApi,
+	}
+
+	listRulesRequest := oathkeeper.ApiApiListRulesRequest{
+		ApiService: mockOathkeeperApiApi,
+	}
+
+	mock_rules := make([]oathkeeper.Rule, 0)
+
+	mockTracer.EXPECT().Start(ctx, "rules.Service.ListRules").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockOathkeeperApiApi.EXPECT().ListRules(ctx).Times(1).Return(listRulesRequest)
+	mockOathkeeperApiApi.EXPECT().ListRulesExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r oathkeeper.ApiApiListRulesRequest) ([]oathkeeper.Rule, *http.Response, error) {
+			rr := httptest.NewRecorder()
+			rr.Header().Set("Content-Type", "application/json")
+			rr.WriteHeader(http.StatusInternalServerError)
+
+			json.NewEncoder(rr).Encode(
+				map[string]interface{}{
+					"error": map[string]interface{}{
+						"code":    http.StatusInternalServerError,
+						"details": map[string]interface{}{},
+						"message": "error",
+						"reason":  "error",
+						"request": "mock_request",
+						"status":  "Not Found",
+					},
+				},
+			)
+
+			return mock_rules, rr.Result(), fmt.Errorf("error")
+		},
+	)
+	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+
+	rules, err := NewService(&config, mockTracer, mockMonitor, mockLogger).ListRules(ctx, 1, 100)
+
+	if len(rules) != 0 {
+		t.Fatalf("expected rules to be empty list")
+	}
+	if err == nil {
+		t.Fatal("expected error to be not nil")
+	}
+
+}
+
+func TestGetRuleSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockOathkeeperApiApi := NewMockApiApi(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+
+	ctx := context.Background()
+	config := Config{
+		Name:      "mock_config",
+		Namespace: "mock_namespace",
+		K8s:       mockCoreV1,
+		OkClient:  mockOathkeeperApiApi,
+	}
+
+	string_athenticator_handler := "cookie_session"
+	string_mutator_handler := "header"
+	string_id := "mocked_rule1:allow"
+	string_authorizer_handler := "allow"
+
+	getRulesRequest := oathkeeper.ApiApiGetRuleRequest{
+		ApiService: mockOathkeeperApiApi,
+	}
+
+	mock_rule := oathkeeper.Rule{
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &string_athenticator_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &string_mutator_handler,
+			},
+		},
+		Id: &string_id,
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &string_authorizer_handler,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{
+				"GET",
+				"POST",
+			},
+		},
+	}
+
+	mock_rule_list := []oathkeeper.Rule{mock_rule}
+
+	mockTracer.EXPECT().Start(ctx, "rules.Service.GetRule").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockOathkeeperApiApi.EXPECT().GetRule(ctx, string_id).Times(1).Return(getRulesRequest)
+	mockOathkeeperApiApi.EXPECT().GetRuleExecute(gomock.Any()).Times(1).Return(&mock_rule, new(http.Response), nil)
+
+	rules, err := NewService(&config, mockTracer, mockMonitor, mockLogger).GetRule(ctx, string_id)
+
+	if !reflect.DeepEqual(rules, mock_rule_list) {
+		t.Fatalf("expected identities to be %v not  %v", mock_rule_list, rules)
+	}
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestGetRuleFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockOathkeeperApiApi := NewMockApiApi(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+
+	ctx := context.Background()
+	config := Config{
+		Name:      "mock_config",
+		Namespace: "mock_namespace",
+		K8s:       mockCoreV1,
+		OkClient:  mockOathkeeperApiApi,
+	}
+
+	string_id := "mocked_rule1:allow"
+
+	getRulesRequest := oathkeeper.ApiApiGetRuleRequest{
+		ApiService: mockOathkeeperApiApi,
+	}
+
+	mock_rule := oathkeeper.Rule{}
+
+	mockTracer.EXPECT().Start(ctx, "rules.Service.GetRule").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockOathkeeperApiApi.EXPECT().GetRule(ctx, string_id).Times(1).Return(getRulesRequest)
+	mockOathkeeperApiApi.EXPECT().GetRuleExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r oathkeeper.ApiApiGetRuleRequest) (*oathkeeper.Rule, *http.Response, error) {
+			rr := httptest.NewRecorder()
+			rr.Header().Set("Content-Type", "application/json")
+			rr.WriteHeader(http.StatusInternalServerError)
+
+			json.NewEncoder(rr).Encode(
+				map[string]interface{}{
+					"error": map[string]interface{}{
+						"code":    http.StatusInternalServerError,
+						"details": map[string]interface{}{},
+						"message": "error",
+						"reason":  "error",
+						"request": "mock_request",
+						"status":  "Not Found",
+					},
+				},
+			)
+
+			return &mock_rule, rr.Result(), fmt.Errorf("error")
+		},
+	)
+	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+
+	_, err := NewService(&config, mockTracer, mockMonitor, mockLogger).GetRule(ctx, string_id)
+
+	if err == nil {
+		t.Fatal("expected error to be not nil")
+	}
+}
+
+func TestUpdateRuleSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockOathkeeperApiApi := NewMockApiApi(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+
+	ctx := context.Background()
+	config := Config{
+		Name:      "mock_config",
+		Namespace: "mock_namespace",
+		K8s:       mockCoreV1,
+		OkClient:  mockOathkeeperApiApi,
+	}
+
+	rules1_id := "mocked_rule1:allow"
+	rules2_id := "mocked_rule2:deny"
+	authen_handler := "cookie_session"
+	mutator_header := "header"
+	author_handler := "allow"
+	author_deny := "deny"
+
+	rules1 := oathkeeper.Rule{
+		Id: &rules1_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_handler,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+
+	rules2 := oathkeeper.Rule{
+		Id: &rules2_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_deny,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"PUT", "DELETE"},
+		},
+	}
+
+	ruleList := make([]oathkeeper.Rule, 0)
+	ruleList = append(ruleList, rules1, rules2)
+
+	rawRuleList, _ := json.Marshal(ruleList)
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	cm.Data[ADMIN_UI_RULE_FILE] = string(rawRuleList)
+
+	ruleUpdate := oathkeeper.Rule{
+		Id: &rules2_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_deny,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+
+	ruleUpdatedList := make([]oathkeeper.Rule, 0)
+	ruleUpdatedList = append(ruleUpdatedList, rules1, ruleUpdate)
+	ruleUpdatedRaw, _ := json.Marshal(ruleUpdatedList)
+
+	mockTracer.EXPECT().Start(ctx, "rules.Service.UpdateRule").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(config.Namespace).Times(2).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, "mock_config", gomock.Any()).Times(1).Return(cm, nil)
+	mockConfigMapV1.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context, cm *v1.ConfigMap, opts metaV1.UpdateOptions) (*v1.ConfigMap, error) {
+			rules := cm.Data[ADMIN_UI_RULE_FILE]
+
+			if ruleIncludedInMarshalledList(ruleUpdate, rules) {
+				t.Fatalf("expected result to be %v not %v", string(ruleUpdatedRaw), rules)
+			}
+
+			return cm, nil
+		},
+	)
+
+	err := NewService(&config, mockTracer, mockMonitor, mockLogger).UpdateRule(ctx, rules2_id, ruleUpdate)
+
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+
+}
+
+func TestUpdateRuleNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockOathkeeperApiApi := NewMockApiApi(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+
+	ctx := context.Background()
+	config := Config{
+		Name:      "mock_config",
+		Namespace: "mock_namespace",
+		K8s:       mockCoreV1,
+		OkClient:  mockOathkeeperApiApi,
+	}
+
+	rules1_id := "mocked_rule1:allow"
+	rules2_id := "mocked_rule2:deny"
+	rules3_id := "mocked_rule3:deny"
+	authen_handler := "cookie_session"
+	mutator_header := "header"
+	author_handler := "allow"
+	author_deny := "deny"
+
+	rules1 := oathkeeper.Rule{
+		Id: &rules1_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_handler,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+	rules2 := oathkeeper.Rule{
+		Id: &rules2_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_deny,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"PUT", "DELETE"},
+		},
+	}
+
+	ruleList := make([]oathkeeper.Rule, 0)
+	ruleList = append(ruleList, rules1, rules2)
+
+	rawRuleList, _ := json.Marshal(ruleList)
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	cm.Data[ADMIN_UI_RULE_FILE] = string(rawRuleList)
+
+	ruleUpdate := oathkeeper.Rule{
+		Id: &rules3_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_handler,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+
+	mockTracer.EXPECT().Start(ctx, "rules.Service.UpdateRule").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(config.Namespace).Times(1).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, "mock_config", gomock.Any()).Times(1).Return(cm, nil)
+
+	err := NewService(&config, mockTracer, mockMonitor, mockLogger).UpdateRule(ctx, rules3_id, ruleUpdate)
+
+	expectedError := fmt.Sprintf("rule with ID %s not found", *ruleUpdate.Id)
+	if err.Error() != expectedError {
+		t.Fatalf("expected error to be %v not  %v", expectedError, err)
+	}
+}
+
+func TestUpdateRuleIdMismatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockOathkeeperApiApi := NewMockApiApi(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+
+	ctx := context.Background()
+	config := Config{
+		Name:      "mock_config",
+		Namespace: "mock_namespace",
+		K8s:       mockCoreV1,
+		OkClient:  mockOathkeeperApiApi,
+	}
+
+	rules1_id := "mocked_rule1:allow"
+	rules2_id := "mocked_rule2:deny"
+	rules3_id := "mocked_rule3:deny"
+	authen_handler := "cookie_session"
+	mutator_header := "header"
+	author_handler := "allow"
+	author_deny := "deny"
+
+	rules1 := oathkeeper.Rule{
+		Id: &rules1_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_handler,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+	rules2 := oathkeeper.Rule{
+		Id: &rules2_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_deny,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"PUT", "DELETE"},
+		},
+	}
+
+	ruleList := make([]oathkeeper.Rule, 0)
+	ruleList = append(ruleList, rules1, rules2)
+
+	rawRuleList, _ := json.Marshal(ruleList)
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	cm.Data[ADMIN_UI_RULE_FILE] = string(rawRuleList)
+
+	rule_update := oathkeeper.Rule{
+		Id: &rules3_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_handler,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+
+	mockTracer.EXPECT().Start(ctx, "rules.Service.UpdateRule").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+
+	err := NewService(&config, mockTracer, mockMonitor, mockLogger).UpdateRule(ctx, rules1_id, rule_update)
+
+	expectedError := fmt.Sprintf("The URL parameter id %s is different from payload rule id %s", rules1_id, *rule_update.Id)
+	if err.Error() != expectedError {
+		t.Fatalf("expected error to be %v not  %v", expectedError, err)
+	}
+}
+
+func TestCreateRuleSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockOathkeeperApiApi := NewMockApiApi(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+
+	ctx := context.Background()
+	config := Config{
+		Name:      "mock_config",
+		Namespace: "mock_namespace",
+		K8s:       mockCoreV1,
+		OkClient:  mockOathkeeperApiApi,
+	}
+
+	rules1_id := "mocked_rule1:allow"
+	rules2_id := "mocked_rule2:deny"
+	rules3_id := "mocked_rule3:deny"
+	authen_handler := "cookie_session"
+	mutator_header := "header"
+	author_handler := "allow"
+	author_deny := "deny"
+
+	rules1 := oathkeeper.Rule{
+		Id: &rules1_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_handler,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+	rules2 := oathkeeper.Rule{
+		Id: &rules2_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_deny,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"PUT", "DELETE"},
+		},
+	}
+
+	ruleList := make([]oathkeeper.Rule, 0)
+	ruleList = append(ruleList, rules1, rules2)
+
+	rawRuleList, _ := json.Marshal(ruleList)
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	cm.Data[ADMIN_UI_RULE_FILE] = string(rawRuleList)
+
+	ruleCreate := oathkeeper.Rule{
+		Id: &rules3_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_handler,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+
+	ruleCreateList := make([]oathkeeper.Rule, 0)
+	ruleCreateList = append(ruleCreateList, rules1, rules2, ruleCreate)
+	ruleCreatedRaw, _ := json.Marshal(ruleCreateList)
+
+	mockTracer.EXPECT().Start(ctx, "rules.Service.CreateRule").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(config.Namespace).Times(2).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, "mock_config", gomock.Any()).Times(1).Return(cm, nil)
+	mockConfigMapV1.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context, cm *v1.ConfigMap, opts metaV1.UpdateOptions) (*v1.ConfigMap, error) {
+			rules := cm.Data[ADMIN_UI_RULE_FILE]
+			if ruleIncludedInMarshalledList(ruleCreate, rules) {
+				t.Fatalf("expected result to be %v not %v", string(ruleCreatedRaw), rules)
+			}
+
+			return cm, nil
+		},
+	)
+
+	err := NewService(&config, mockTracer, mockMonitor, mockLogger).CreateRule(ctx, ruleCreate)
+
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestCreateRuleAlreadyExists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockOathkeeperApiApi := NewMockApiApi(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+
+	ctx := context.Background()
+	config := Config{
+		Name:      "mock_config",
+		Namespace: "mock_namespace",
+		K8s:       mockCoreV1,
+		OkClient:  mockOathkeeperApiApi,
+	}
+
+	rules1_id := "mocked_rule1:allow"
+	rules2_id := "mocked_rule2:deny"
+	authen_handler := "cookie_session"
+	mutator_header := "header"
+	author_handler := "allow"
+	author_deny := "deny"
+
+	rules1 := oathkeeper.Rule{
+		Id: &rules1_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_handler,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+	rules2 := oathkeeper.Rule{
+		Id: &rules2_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_deny,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"PUT", "DELETE"},
+		},
+	}
+
+	ruleList := make([]oathkeeper.Rule, 0)
+	ruleList = append(ruleList, rules1, rules2)
+
+	rawRuleList, _ := json.Marshal(ruleList)
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	cm.Data[ADMIN_UI_RULE_FILE] = string(rawRuleList)
+
+	ruleCreate := oathkeeper.Rule{
+		Id: &rules1_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_handler,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+
+	mockTracer.EXPECT().Start(ctx, "rules.Service.CreateRule").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(config.Namespace).Times(1).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, "mock_config", gomock.Any()).Times(1).Return(cm, nil)
+
+	err := NewService(&config, mockTracer, mockMonitor, mockLogger).CreateRule(ctx, ruleCreate)
+
+	expected_error := fmt.Sprintf("rule with ID %s already exists", *ruleCreate.Id)
+	if err.Error() != expected_error {
+		t.Fatalf("expected error to be %s not  %s", expected_error, err.Error())
+	}
+}
+
+func TestDeleteRuleSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockOathkeeperApiApi := NewMockApiApi(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+
+	ctx := context.Background()
+	config := Config{
+		Name:      "mock_config",
+		Namespace: "mock_namespace",
+		K8s:       mockCoreV1,
+		OkClient:  mockOathkeeperApiApi,
+	}
+
+	rules1_id := "mocked_rule1:allow"
+	authen_handler := "cookie_session"
+	mutator_header := "header"
+	author_handler := "allow"
+
+	rules1 := oathkeeper.Rule{
+		Id: &rules1_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_handler,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+
+	ruleList := make([]oathkeeper.Rule, 0)
+	ruleList = append(ruleList, rules1)
+
+	rawRuleList, _ := json.Marshal(ruleList)
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	cm.Data[ADMIN_UI_RULE_FILE] = string(rawRuleList)
+
+	mockTracer.EXPECT().Start(ctx, "rules.Service.DeleteRule").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(config.Namespace).Times(2).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, "mock_config", gomock.Any()).Times(1).Return(cm, nil)
+	mockConfigMapV1.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+		func(ctx context.Context, cm *v1.ConfigMap, opts metaV1.UpdateOptions) (*v1.ConfigMap, error) {
+			rules := cm.Data[ADMIN_UI_RULE_FILE]
+			if !isMarshalledRuleListEmpty(rules) {
+				t.Fatalf("expected rule %s to contain empty list, not %s", ADMIN_UI_RULE_FILE, rules)
+			}
+
+			return cm, nil
+		},
+	)
+
+	err := NewService(&config, mockTracer, mockMonitor, mockLogger).DeleteRule(ctx, rules1_id)
+
+	if err != nil {
+		t.Fatalf("expected error to be nil not  %v", err)
+	}
+}
+
+func TestDeleteRuleFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockOathkeeperApiApi := NewMockApiApi(ctrl)
+	mockCoreV1 := NewMockCoreV1Interface(ctrl)
+	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
+
+	ctx := context.Background()
+	config := Config{
+		Name:      "mock_config",
+		Namespace: "mock_namespace",
+		K8s:       mockCoreV1,
+		OkClient:  mockOathkeeperApiApi,
+	}
+
+	rules1_id := "mocked_rule1:allow"
+	authen_handler := "cookie_session"
+	mutator_header := "header"
+	author_handler := "allow"
+
+	rules1 := oathkeeper.Rule{
+		Id: &rules1_id,
+		Authenticators: []oathkeeper.RuleHandler{
+			{
+				Handler: &authen_handler,
+			},
+		},
+		Mutators: []oathkeeper.RuleHandler{
+			{
+				Handler: &mutator_header,
+			},
+		},
+		Authorizer: &oathkeeper.RuleHandler{
+			Handler: &author_handler,
+		},
+		Match: &oathkeeper.RuleMatch{
+			Methods: []string{"GET", "POST"},
+		},
+	}
+
+	ruleList := make([]oathkeeper.Rule, 0)
+	ruleList = append(ruleList, rules1)
+
+	rawRuleList, _ := json.Marshal(ruleList)
+	cm := new(v1.ConfigMap)
+	cm.Data = make(map[string]string)
+	cm.Data[ADMIN_UI_RULE_FILE] = string(rawRuleList)
+
+	ruleForDeletion := "mocked_rule3:deny"
+
+	mockTracer.EXPECT().Start(ctx, "rules.Service.DeleteRule").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockCoreV1.EXPECT().ConfigMaps(config.Namespace).Times(1).Return(mockConfigMapV1)
+	mockConfigMapV1.EXPECT().Get(ctx, "mock_config", gomock.Any()).Times(1).Return(cm, nil)
+
+	err := NewService(&config, mockTracer, mockMonitor, mockLogger).DeleteRule(ctx, ruleForDeletion)
+
+	expected_error := fmt.Sprintf("rule with ID %s not found", ruleForDeletion)
+	if err.Error() != expected_error {
+		t.Fatalf("expected error to be %v not  %v", expected_error, err.Error())
+	}
+}
+
+func ruleIncludedInMarshalledList(rule oathkeeper.Rule, ruleList string) bool {
+	rules := make([]oathkeeper.Rule, 0)
+	err := json.Unmarshal([]byte(ruleList), &rules)
+
+	if err != nil {
+		return false
+	}
+
+	for _, v := range rules {
+		if v.Id == rule.Id {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isMarshalledRuleListEmpty(ruleList string) bool {
+	rules := make([]oathkeeper.Rule, 0)
+	err := json.Unmarshal([]byte(ruleList), &rules)
+
+	if err != nil {
+		return false
+	}
+
+	return len(rules) == 0
+}

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -16,11 +16,12 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/pkg/identities"
 	"github.com/canonical/identity-platform-admin-ui/pkg/idp"
 	"github.com/canonical/identity-platform-admin-ui/pkg/metrics"
+	"github.com/canonical/identity-platform-admin-ui/pkg/rules"
 	"github.com/canonical/identity-platform-admin-ui/pkg/schemas"
 	"github.com/canonical/identity-platform-admin-ui/pkg/status"
 )
 
-func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, hydraClient *ih.Client, kratos *ik.Client, tracer trace.Tracer, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) http.Handler {
+func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, rulesConfig *rules.Config, hydraClient *ih.Client, kratos *ik.Client, tracer trace.Tracer, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) http.Handler {
 	router := chi.NewMux()
 
 	middlewares := make(chi.Middlewares, 0)
@@ -57,6 +58,10 @@ func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, hydraClient
 	).RegisterEndpoints(router)
 	schemas.NewAPI(
 		schemas.NewService(schemasConfig, tracer, monitor, logger),
+		logger,
+	).RegisterEndpoints(router)
+	rules.NewAPI(
+		rules.NewService(rulesConfig, tracer, monitor, logger),
 		logger,
 	).RegisterEndpoints(router)
 	return tracing.NewMiddleware(monitor, logger).OpenTelemetry(router)

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -47,8 +47,7 @@ deploy:
       - name: oathkeeper
         remoteChart: oathkeeper
         repo: https://k8s.ory.sh/helm/charts
-        setValues:
-          demo: "true"
+        valuesFiles: ["deployments/helm/oathkeeper/values.yaml"]
         wait: false
 
 portForward:

--- a/structure-tests.yaml
+++ b/structure-tests.yaml
@@ -8,6 +8,8 @@ globalEnvVars:
     value: "https://kratos.iam.admin"
   - key: "HYDRA_ADMIN_URL"
     value: "https://hydra.iam.admin"
+  - key: "OATHKEEPER_PUBLIC_URL"
+    value: "https://oathkeeper.iam.public"
   - key: "IDP_CONFIGMAP_NAME"
     value: idps
   - key: "IDP_CONFIGMAP_NAMESPACE"
@@ -15,6 +17,10 @@ globalEnvVars:
   - key: "SCHEMAS_CONFIGMAP_NAME"
     value: identity-schemas
   - key: "SCHEMAS_CONFIGMAP_NAMESPACE"
+    value: default
+  - key: "RULES_CONFIGMAP_NAME"
+    value: oathkeeper-rules
+  - key: "RULES_CONFIGMAP_NAMESPACE"
     value: default
 
 fileExistenceTests:


### PR DESCRIPTION
This PR includes the implementation of the Admin UI Rest interface to access and manipulate Oathkeeper access rules.

Testing Guide:

The following endpoints have been implemented for Admin UI:

Get /api/v0/rules
Get /api/v0/rules/{id}
Post /api/v0/rules
Put /api/v0/rules
Delete /api/v0/rules/{id}

{id} is a URL parameter that accepts the Oathkeeper rule IDs specified in a Kubernetes configmap.

The make command make dev sets up a development environment.