### PR TITLE
IAM-655 - authz/middleware

### DIFF
--- a/internal/authorization/converters.go
+++ b/internal/authorization/converters.go
@@ -1,0 +1,206 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL
+
+package authorization
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// these constants relate directly to the authorization model types
+const (
+	IDENTITY_TYPE = "identity"
+	CLIENT_TYPE   = "client"
+	PROVIDER_TYPE = "provider"
+	RULE_TYPE     = "rule"
+	SCHEME_TYPE   = "scheme"
+	ROLE_TYPE     = "role"
+	GROUP_TYPE    = "group"
+
+	CAN_VIEW   = "can_view"
+	CAN_EDIT   = "can_edit"
+	CAN_CREATE = "can_create"
+	CAN_DELETE = "can_delete"
+)
+
+type Permission struct {
+	Relation   string
+	ResourceID string
+}
+
+func relation(r *http.Request) string {
+	switch r.Method {
+	case http.MethodGet:
+		return CAN_VIEW
+	case http.MethodPost:
+		return CAN_CREATE
+	case http.MethodPut, http.MethodPatch:
+		return CAN_EDIT
+	case http.MethodDelete:
+		return CAN_DELETE
+	default:
+		return CAN_VIEW
+	}
+}
+
+type IdentityConverter struct{}
+
+func (c IdentityConverter) TypeName() string {
+	return IDENTITY_TYPE
+}
+
+func (c IdentityConverter) Map(r *http.Request) []Permission {
+	id := chi.URLParam(r, "id")
+
+	if id == "" {
+		// global is used in place of `*`, reason is OpenFGA has a special meaning for `*`
+		// see [public access](https://openfga.dev/docs/modeling/public-access)
+		id = "global"
+	}
+
+	return []Permission{
+		{Relation: relation(r), ResourceID: fmt.Sprintf("%s:%s", c.TypeName(), id)},
+	}
+}
+
+type ClientConverter struct{}
+
+func (c ClientConverter) TypeName() string {
+	return CLIENT_TYPE
+}
+
+func (c ClientConverter) Map(r *http.Request) []Permission {
+	id := chi.URLParam(r, "id")
+
+	if id == "" {
+		id = "global"
+	}
+	return []Permission{
+		{Relation: relation(r), ResourceID: fmt.Sprintf("%s:%s", c.TypeName(), id)},
+	}
+}
+
+type ProviderConverter struct{}
+
+func (c ProviderConverter) TypeName() string {
+	return PROVIDER_TYPE
+}
+
+func (c ProviderConverter) Map(r *http.Request) []Permission {
+	id := chi.URLParam(r, "id")
+
+	if id == "" {
+		id = "global"
+	}
+	return []Permission{
+		{Relation: relation(r), ResourceID: fmt.Sprintf("%s:%s", c.TypeName(), id)},
+	}
+}
+
+type RuleConverter struct{}
+
+func (c RuleConverter) TypeName() string {
+	return RULE_TYPE
+}
+
+func (c RuleConverter) Map(r *http.Request) []Permission {
+	id := chi.URLParam(r, "id")
+
+	if id == "" {
+		id = "global"
+	}
+	return []Permission{
+		{Relation: relation(r), ResourceID: fmt.Sprintf("%s:%s", c.TypeName(), id)},
+	}
+}
+
+type SchemeConverter struct{}
+
+func (c SchemeConverter) TypeName() string {
+	return SCHEME_TYPE
+}
+
+func (c SchemeConverter) Map(r *http.Request) []Permission {
+	// TODO @shipperizer let's make sure this is a good way to codify the
+	// default schema API
+	if r.URL.Path == "/api/v0/schemas/default" {
+		return []Permission{
+			{
+				Relation:   relation(r),
+				ResourceID: fmt.Sprintf("%s:**DEFAULT**", c.TypeName()),
+			},
+		}
+	}
+
+	id := chi.URLParam(r, "id")
+
+	if id == "" {
+		id = "global"
+	}
+
+	return []Permission{
+		{Relation: relation(r), ResourceID: fmt.Sprintf("%s:%s", c.TypeName(), id)},
+	}
+}
+
+// TODO @shipperizer RoleConverter implementation follows provisional roles API
+// GET /roles
+// POST /roles
+// GET /roles/{id}
+// PATCH /roles/{id}
+// DELETE /roles/{id}
+// GET /roles/{id}/entitlements
+// POST /roles/{id}/entitlements
+// GET /roles/{id}/entitlements/{e_id} --- not sure we need this?we need to know the type
+// DELETE /roles/{id}/entitlements/{e_id}
+// POST /roles/{id}/identities/{i_id} --- evaluate if needed, assigning identity to a role
+type RoleConverter struct{}
+
+func (c RoleConverter) TypeName() string {
+	return ROLE_TYPE
+}
+
+func (c RoleConverter) Map(r *http.Request) []Permission {
+	role_id := chi.URLParam(r, "id")
+	entitlement_id := chi.URLParam(r, "e_id")
+	identity_id := chi.URLParam(r, "i_id")
+
+	if entitlement_id != "" && r.Method == http.MethodDelete {
+		// DELETE /roles/{id}/entitlements/{e_id} will check for an
+		// edit permission on role {id}
+		return []Permission{
+			{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", c.TypeName(), role_id)},
+		}
+	}
+
+	// POST /roles/{id}/entitlements
+	if strings.HasSuffix(r.URL.Path, "entitlements") && r.Method == http.MethodPost {
+		return []Permission{
+			{
+				Relation:   CAN_EDIT,
+				ResourceID: fmt.Sprintf("%s:%s", c.TypeName(), role_id),
+			},
+		}
+	}
+
+	// TODO @shipperizer this might be canned if we want to stick with PATCH /roles/{id} for user assignment
+	if identity_id != "" && r.Method == http.MethodPost {
+		// POST /roles/{id}/identities/{i_id} will check for an edit on role {id} and view on {i_id}
+		return []Permission{
+			{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", c.TypeName(), role_id)},
+			{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, identity_id)},
+		}
+	}
+
+	if role_id == "" {
+		role_id = "global"
+	}
+
+	return []Permission{
+		{Relation: relation(r), ResourceID: fmt.Sprintf("%s:%s", c.TypeName(), role_id)},
+	}
+}

--- a/internal/authorization/converters_test.go
+++ b/internal/authorization/converters_test.go
@@ -1,0 +1,464 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL
+
+package authorization
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestIdentityConverterMapReturnsPermissions(t *testing.T) {
+	type input struct {
+		method   string
+		endpoint string
+		ID       string
+	}
+
+	tests := []struct {
+		name   string
+		input  input
+		output []Permission
+	}{
+		{
+			name:  "GET /api/v0/identities",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/identities"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "global")},
+			},
+		},
+		{
+			name:  "POST /api/v0/identities",
+			input: input{method: http.MethodPost, endpoint: "/api/v0/identities"},
+			output: []Permission{
+				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "global")},
+			},
+		},
+		{
+			name:  "GET /api/v0/identities/id-1234",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/identities/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "PUT /api/v0/identities/id-1234",
+			input: input{method: http.MethodPut, endpoint: "/api/v0/identities/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "DELETE /api/v0/identities/id-1234",
+			input: input{method: http.MethodDelete, endpoint: "/api/v0/identities/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_DELETE, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "id-1234")},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := httptest.NewRequest(test.input.method, test.input.endpoint, nil)
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", test.input.ID)
+
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			result := new(IdentityConverter).Map(r)
+
+			if !reflect.DeepEqual(result, test.output) {
+				t.Errorf("Map returned %v", result)
+			}
+		})
+	}
+}
+
+func TestClientConverterMapReturnsPermissions(t *testing.T) {
+	type input struct {
+		method   string
+		endpoint string
+		ID       string
+	}
+
+	tests := []struct {
+		name   string
+		input  input
+		output []Permission
+	}{
+		{
+			name:  "GET /api/v0/clients",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/clients"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", CLIENT_TYPE, "global")},
+			},
+		},
+		{
+			name:  "POST /api/v0/clients",
+			input: input{method: http.MethodPost, endpoint: "/api/v0/clients"},
+			output: []Permission{
+				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", CLIENT_TYPE, "global")},
+			},
+		},
+		{
+			name:  "GET /api/v0/clients/id-1234",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/clients/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", CLIENT_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "PUT /api/v0/clients/id-1234",
+			input: input{method: http.MethodPut, endpoint: "/api/v0/clients/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", CLIENT_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "DELETE /api/v0/clients/id-1234",
+			input: input{method: http.MethodDelete, endpoint: "/api/v0/clients/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_DELETE, ResourceID: fmt.Sprintf("%s:%s", CLIENT_TYPE, "id-1234")},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := httptest.NewRequest(test.input.method, test.input.endpoint, nil)
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", test.input.ID)
+
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			result := new(ClientConverter).Map(r)
+
+			if !reflect.DeepEqual(result, test.output) {
+				t.Errorf("Map returned %v", result)
+			}
+		})
+	}
+}
+
+func TestProviderConverterMapReturnsPermissions(t *testing.T) {
+	type input struct {
+		method   string
+		endpoint string
+		ID       string
+	}
+
+	tests := []struct {
+		name   string
+		input  input
+		output []Permission
+	}{
+		{
+			name:  "GET /api/v0/idps",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/idps"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", PROVIDER_TYPE, "global")},
+			},
+		},
+		{
+			name:  "POST /api/v0/idps",
+			input: input{method: http.MethodPost, endpoint: "/api/v0/idps"},
+			output: []Permission{
+				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", PROVIDER_TYPE, "global")},
+			},
+		},
+		{
+			name:  "GET /api/v0/idps/id-1234",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/idps/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", PROVIDER_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "PATCH /api/v0/idps/id-1234",
+			input: input{method: http.MethodPatch, endpoint: "/api/v0/idps/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", PROVIDER_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "DELETE /api/v0/idps/id-1234",
+			input: input{method: http.MethodDelete, endpoint: "/api/v0/idps/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_DELETE, ResourceID: fmt.Sprintf("%s:%s", PROVIDER_TYPE, "id-1234")},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := httptest.NewRequest(test.input.method, test.input.endpoint, nil)
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", test.input.ID)
+
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			result := new(ProviderConverter).Map(r)
+
+			if !reflect.DeepEqual(result, test.output) {
+				t.Errorf("Map returned %v", result)
+			}
+		})
+	}
+}
+
+func TestRuleConverterMapReturnsPermissions(t *testing.T) {
+	type input struct {
+		method   string
+		endpoint string
+		ID       string
+	}
+
+	tests := []struct {
+		name   string
+		input  input
+		output []Permission
+	}{
+		{
+			name:  "GET /api/v0/rules",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/rules"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", RULE_TYPE, "global")},
+			},
+		},
+		{
+			name:  "POST /api/v0/rules",
+			input: input{method: http.MethodPost, endpoint: "/api/v0/rules"},
+			output: []Permission{
+				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", RULE_TYPE, "global")},
+			},
+		},
+		{
+			name:  "GET /api/v0/rules/id-1234",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/rules/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", RULE_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "PUT /api/v0/rules/id-1234",
+			input: input{method: http.MethodPut, endpoint: "/api/v0/rules/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", RULE_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "DELETE /api/v0/rules/id-1234",
+			input: input{method: http.MethodDelete, endpoint: "/api/v0/rules/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_DELETE, ResourceID: fmt.Sprintf("%s:%s", RULE_TYPE, "id-1234")},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := httptest.NewRequest(test.input.method, test.input.endpoint, nil)
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", test.input.ID)
+
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			result := new(RuleConverter).Map(r)
+
+			if !reflect.DeepEqual(result, test.output) {
+				t.Errorf("Map returned %v", result)
+			}
+		})
+	}
+}
+
+func TestSchemeConverterMapReturnsPermissions(t *testing.T) {
+	type input struct {
+		method   string
+		endpoint string
+		ID       string
+	}
+
+	tests := []struct {
+		name   string
+		input  input
+		output []Permission
+	}{
+		{
+			name:  "GET /api/v0/schemas",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/schemas"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", SCHEME_TYPE, "global")},
+			},
+		},
+		{
+			name:  "POST /api/v0/schemas",
+			input: input{method: http.MethodPost, endpoint: "/api/v0/schemas"},
+			output: []Permission{
+				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", SCHEME_TYPE, "global")},
+			},
+		},
+		{
+			name:  "GET /api/v0/schemas/id-1234",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/schemas/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", SCHEME_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "PATCH /api/v0/schemas/id-1234",
+			input: input{method: http.MethodPatch, endpoint: "/api/v0/schemas/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", SCHEME_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "DELETE /api/v0/schemas/id-1234",
+			input: input{method: http.MethodDelete, endpoint: "/api/v0/schemas/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_DELETE, ResourceID: fmt.Sprintf("%s:%s", SCHEME_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "GET /api/v0/schemas/default",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/schemas/default"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", SCHEME_TYPE, "**DEFAULT**")},
+			},
+		},
+		{
+			name:  "PUT /api/v0/schemas/default",
+			input: input{method: http.MethodPut, endpoint: "/api/v0/schemas/default"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", SCHEME_TYPE, "**DEFAULT**")},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := httptest.NewRequest(test.input.method, test.input.endpoint, nil)
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", test.input.ID)
+
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			result := new(SchemeConverter).Map(r)
+
+			if !reflect.DeepEqual(result, test.output) {
+				t.Errorf("Map returned %v", result)
+			}
+		})
+	}
+}
+
+func TestRoleConverterMapReturnsPermissions(t *testing.T) {
+	type input struct {
+		method        string
+		endpoint      string
+		ID            string
+		EntitlementID string
+		IdentityID    string
+	}
+
+	tests := []struct {
+		name   string
+		input  input
+		output []Permission
+	}{
+		{
+			name:  "GET /api/v0/roles",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/roles"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "global")},
+			},
+		},
+		{
+			name:  "POST /api/v0/roles",
+			input: input{method: http.MethodPost, endpoint: "/api/v0/roles"},
+			output: []Permission{
+				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "global")},
+			},
+		},
+		{
+			name:  "GET /api/v0/roles/id-1234",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/roles/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "PATCH /api/v0/roles/id-1234",
+			input: input{method: http.MethodPatch, endpoint: "/api/v0/roles/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "DELETE /api/v0/roles/id-1234",
+			input: input{method: http.MethodDelete, endpoint: "/api/v0/roles/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_DELETE, ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "GET /api/v0/roles/id-1234/entitlements",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/roles/id-1234/entitlements", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "DELETE /api/v0/roles/id-1234/entitlements/can_view::role:1",
+			input: input{method: http.MethodDelete, endpoint: "/api/v0/roles/id-1234/entitlements", ID: "id-1234", EntitlementID: "can_view::role:1"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "POST /api/v0/roles/id-1234/entitlements",
+			input: input{method: http.MethodPost, endpoint: "/api/v0/roles/id-1234/entitlements", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "POST /api/v0/roles/id-1234/identities/user-1",
+			input: input{method: http.MethodPost, endpoint: "/api/v0/roles/id-1234/identities/user-1", ID: "id-1234", IdentityID: "user-1"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "id-1234")},
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "user-1")},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := httptest.NewRequest(test.input.method, test.input.endpoint, nil)
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", test.input.ID)
+			rctx.URLParams.Add("e_id", test.input.EntitlementID)
+			rctx.URLParams.Add("i_id", test.input.IdentityID)
+
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			result := new(RoleConverter).Map(r)
+
+			if !reflect.DeepEqual(result, test.output) {
+				t.Errorf("Map returned %v", result)
+			}
+		})
+	}
+}

--- a/internal/authorization/middlewares.go
+++ b/internal/authorization/middlewares.go
@@ -1,0 +1,205 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL
+
+package authorization
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
+	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+)
+
+const (
+	// custom header for the time being
+	TOKEN_HEADER                 = "X-Authorization"
+	ADMIN_PRIVILEGE              = "privileged:superuser"
+	ADMIN_CTX       AdminContext = "adminCtx"
+	USER_CTX        UserContext  = "userCtx"
+)
+
+type UserContext string
+type AdminContext string
+
+type User struct {
+	ID string
+}
+
+// Middleware is the monitoring middleware object implementing Prometheus monitoring
+type Middleware struct {
+	auth AuthorizerInterface
+
+	// converters
+	IdentityConverter
+	ClientConverter
+	ProviderConverter
+	RuleConverter
+	SchemeConverter
+	RoleConverter
+
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
+}
+
+func (mdw *Middleware) transformToken(token string) *User {
+	user := new(User)
+	user.ID = "admin"
+
+	// TODO @shipperizer rudimentary base64 username
+	if token != "" {
+		ID, _ := base64.StdEncoding.DecodeString(token)
+		user.ID = string(ID)
+	}
+
+	return user
+
+}
+
+// TODO @shipperizer move this to a separate middleware once implementation of authorization is starting
+func (mdw *Middleware) admin(r *http.Request) bool {
+	// TODO @shipperizer implement how to fetch user from cookie or header
+	user := mdw.transformToken(r.Header.Get(TOKEN_HEADER))
+
+	isAdmin, err := mdw.auth.Check(context.Background(), fmt.Sprintf("user:%s", user.ID), "admin", ADMIN_PRIVILEGE)
+
+	return isAdmin && err == nil
+}
+
+// TODO @shipperizer move this to a separate middleware once implementation of authorization is starting
+func (mdw *Middleware) user(r *http.Request) *User {
+	// TODO @shipperizer implement how to fetch user from cookie or header
+	user := mdw.transformToken(r.Header.Get(TOKEN_HEADER))
+
+	return user
+}
+
+func (mdw *Middleware) mapper(r *http.Request) []Permission {
+	// TODO @shipperizer exploit https://pkg.go.dev/github.com/go-chi/chi/v5#URLParam to fetch
+	// resource ids like {id}, {<x>_id}, also parse the path to understand type to check against
+
+	if strings.HasPrefix(r.URL.Path, "/api/v0/identities") {
+		return mdw.IdentityConverter.Map(r)
+	}
+	if strings.HasPrefix(r.URL.Path, "/api/v0/clients") {
+		return mdw.ClientConverter.Map(r)
+	}
+	if strings.HasPrefix(r.URL.Path, "/api/v0/idps") {
+		return mdw.ProviderConverter.Map(r)
+	}
+	if strings.HasPrefix(r.URL.Path, "/api/v0/rules") {
+		return mdw.RuleConverter.Map(r)
+	}
+	if strings.HasPrefix(r.URL.Path, "/api/v0/schemas") {
+		return mdw.SchemeConverter.Map(r)
+	}
+	if strings.HasPrefix(r.URL.Path, "/api/v0/roles") {
+		return mdw.RoleConverter.Map(r)
+	}
+
+	return []Permission{}
+}
+
+func (mdw *Middleware) check(ctx context.Context, userID string, r *http.Request) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+
+	// TODO @shipperizer implement BatchCheck
+	for _, permission := range mdw.mapper(r) {
+		authorized, err := mdw.auth.Check(ctx, userID, permission.Relation, permission.ResourceID)
+
+		select {
+		case <-ctx.Done():
+			return false, fmt.Errorf("issues connecting to OpenFGA server")
+		default:
+			// stop at the first failed check
+			if !authorized || err != nil {
+				return false, err
+			}
+		}
+	}
+
+	return true, nil
+}
+
+func (mdw *Middleware) skipRoute(r *http.Request) bool {
+	switch r.URL.Path {
+	case "/api/v0/status", "/api/v0/version":
+		return true
+	case "/api/v0/metrics":
+		return true
+	default:
+		return false
+	}
+}
+
+func (mwd *Middleware) error(message string, status int, w http.ResponseWriter) {
+	r := types.Response{
+		Status:  status,
+		Message: message,
+	}
+
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(r)
+}
+
+func (mdw *Middleware) Authorize() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+
+				// not all endpoints need to validate authorization
+				if mdw.skipRoute(r) {
+					next.ServeHTTP(w, r)
+				}
+
+				user := mdw.user(r)
+				isAdmin := mdw.admin(r)
+
+				ID := fmt.Sprintf("user:%s", user.ID)
+				// TODO @shipperizer add context timeout
+				authorized, err := mdw.check(r.Context(), ID, r)
+
+				if err != nil {
+					mdw.logger.Errorf("failed %s", err)
+					mdw.error("failed connecting with OpenFGA", http.StatusInternalServerError, w)
+
+					return
+				}
+
+				if !authorized {
+					mdw.logger.Debugf("%s not authorized to perform operation", ID)
+					mdw.error("insufficient permissions to execute operation", http.StatusForbidden, w)
+
+					return
+				}
+
+				// pass on context with user object
+				ctx := context.WithValue(r.Context(), USER_CTX, user)
+				// TOOD @shipperizer evenutally we will want to add the contextual tuple in the context
+				// so it can be used in subsequent calls
+				ctx = context.WithValue(ctx, ADMIN_CTX, isAdmin)
+
+				next.ServeHTTP(w, r.WithContext(ctx))
+			},
+		)
+	}
+}
+
+// NewMiddleware returns a Middleware based on the type of monitor
+func NewMiddleware(auth AuthorizerInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *Middleware {
+	mdw := new(Middleware)
+
+	mdw.auth = auth
+
+	mdw.monitor = monitor
+	mdw.logger = logger
+
+	return mdw
+}

--- a/internal/authorization/middlewares_test.go
+++ b/internal/authorization/middlewares_test.go
@@ -1,0 +1,211 @@
+// Copyright 2024 Canonical Ltd
+// SPDX-License-Identifier: AGPL
+
+package authorization
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/mock/gomock"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package authorization -destination ./mock_monitor.go -source=../monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package authorization -destination ./mock_logger.go -source=../logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package authorization -destination ./mock_interfaces.go -source=./interfaces.go
+
+type API struct{}
+
+func (a *API) RegisterEndpoints(router *chi.Mux) {
+	router.Get("/api/v0/identities", a.handleAll)
+	router.Get("/api/v0/identities/1", a.handleAll)
+	router.Post("/api/v0/clients", a.handleAll)
+	router.Get("/api/v0/idps/github", a.handleAll)
+	router.Delete("/api/v0/rules/1", a.handleAll)
+	router.Patch("/api/v0/schemas/x", a.handleAll)
+	router.Post("/api/v0/roles/viewer/identities/1", a.handleAll)
+	router.Get("/api/v0/allow", a.handleAll)
+	router.Get("/api/v0/forbidden", a.handleAll)
+}
+
+func (a *API) handleAll(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+}
+
+func TestMiddlewareAuthorize(t *testing.T) {
+	type input struct {
+		method     string
+		endpoint   string
+		ID         string
+		IdentityID string
+	}
+
+	tests := []struct {
+		name   string
+		input  input
+		expect []Permission
+		output bool
+	}{
+		{
+			name:   "GET /api/v0/allow",
+			input:  input{method: http.MethodGet, endpoint: "/api/v0/allow"},
+			expect: []Permission{},
+			output: true,
+		},
+		{
+			name:  "GET /api/v0/identities/1",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/identities/1", ID: "1"},
+			expect: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "1")},
+			},
+			output: false,
+		},
+		{
+			name:  "GET /api/v0/identities",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/identities"},
+			expect: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "global")},
+			},
+			output: true,
+		},
+		{
+			name:  "GET /api/v0/idps/github",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/idps/github", ID: "github"},
+			expect: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", PROVIDER_TYPE, "github")},
+			},
+			output: true,
+		},
+		{
+			name:  "PATCH /api/v0/schemas/x",
+			input: input{method: http.MethodPatch, endpoint: "/api/v0/schemas/x", ID: "x"},
+			expect: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", SCHEME_TYPE, "x")},
+			},
+			output: true,
+		},
+		{
+			name:  "DELETE /api/v0/rules/1",
+			input: input{method: http.MethodDelete, endpoint: "/api/v0/rules/1", ID: "1"},
+			expect: []Permission{
+				{Relation: CAN_DELETE, ResourceID: fmt.Sprintf("%s:%s", RULE_TYPE, "1")},
+			},
+			output: true,
+		},
+		{
+			name:  "POST /api/v0/roles/viewer/identities/1",
+			input: input{method: http.MethodPost, endpoint: "/api/v0/roles/viewer/identities/1", ID: "viewer", IdentityID: "1"},
+			expect: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "viewer")},
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "1")},
+			},
+			output: true,
+		},
+		{
+			name:  "POST /api/v0/clients",
+			input: input{method: http.MethodPost, endpoint: "/api/v0/clients"},
+			expect: []Permission{
+				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", CLIENT_TYPE, "global")},
+			},
+			output: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockAuthorizer := NewMockAuthorizerInterface(ctrl)
+
+			router := chi.NewMux().With(
+				NewMiddleware(mockAuthorizer, mockMonitor, mockLogger).Authorize(),
+			).(*chi.Mux)
+
+			new(API).RegisterEndpoints(router)
+
+			calls := []*gomock.Call{}
+
+			mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+
+			calls = append(calls, mockAuthorizer.EXPECT().Check(gomock.Any(), "user:admin", "admin", ADMIN_PRIVILEGE).Times(1).Return(false, nil))
+			for _, check := range test.expect {
+				calls = append(
+					calls,
+					mockAuthorizer.EXPECT().Check(gomock.Any(), gomock.Any(), check.Relation, check.ResourceID).Times(1).Return(test.output, nil),
+				)
+			}
+
+			gomock.InAnyOrder(calls)
+
+			r := httptest.NewRequest(test.input.method, test.input.endpoint, nil)
+			r.Header.Set("Content-Type", "application/json")
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", test.input.ID)
+			rctx.URLParams.Add("i_id", test.input.IdentityID)
+
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, r)
+
+			if !test.output && w.Result().StatusCode != http.StatusForbidden {
+				t.Fatalf("expected HTTP status code 403 got %v", w.Result().StatusCode)
+			}
+
+			if test.output && w.Result().StatusCode != http.StatusOK {
+				t.Fatalf("expected HTTP status code 200 got %v", w.Result().StatusCode)
+			}
+
+		})
+	}
+}
+
+func TestMiddlewareAuthorizeUseTokenHeader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockAuthorizer := NewMockAuthorizerInterface(ctrl)
+
+	router := chi.NewMux().With(
+		NewMiddleware(mockAuthorizer, mockMonitor, mockLogger).Authorize(),
+	).(*chi.Mux)
+
+	new(API).RegisterEndpoints(router)
+
+	testUser := "test-user"
+
+	calls := []*gomock.Call{}
+
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	calls = append(
+		calls,
+		mockAuthorizer.EXPECT().Check(gomock.Any(), fmt.Sprintf("user:%s", testUser), "admin", ADMIN_PRIVILEGE).Times(1).Return(false, nil),
+		mockAuthorizer.EXPECT().Check(gomock.Any(), gomock.Any(), CAN_VIEW, fmt.Sprintf("%s:%s", IDENTITY_TYPE, "global")).Times(1).Return(true, nil),
+	)
+
+	gomock.InAnyOrder(calls)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v0/identities", nil)
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set(TOKEN_HEADER, base64.RawStdEncoding.EncodeToString([]byte(testUser)))
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected HTTP status code 200 got %v", w.Result().StatusCode)
+	}
+}


### PR DESCRIPTION
IAM-655: first iteration on the authorization middleware

code relies on the model defined in the spec [ID-034](https://docs.google.com/document/d/1GMoTB6MtfUtfv_gUTjrWZWqv2dH7jVhJQCS4gLKoD7o/edit?usp=sharing)

to be plugged as middleware, please use the `With` directive, not `Use` due to how the[ `URLParam` function operates](https://stackoverflow.com/a/70516491)


```
	middlewares := make(chi.Middlewares, 0)
	middlewares = append(
		middlewares,
		middleware.RequestID,
		middleware.RequestLogger(logging.NewLogFormatter(logger)), // LogFormatter will only work if logger is set to DEBUG level,

	)

	router.Use(middlewares...)
	
        chiMux := router.With(authMdw).(*chi.Mux)
	roles.NewAPI(roles.NewService(ofga, tracer, monitor, logger), tracer, monitor, logger).RegisterEndpoints(chiMux)
``` 


## Changes 

- feat: authorization middleware based on openFGA
- feat: implement converters for each type of API


