### PR TITLE
feat: passing openfga store and model id to admin service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,10 @@ npm-build:
 	$(MAKE) -C ui/ build
 .PHONY: npm-build
 
-
 dev:
-	@$(MICROK8S_REGISTRY_FLAG) $(SKAFFOLD) run --mute-logs=all --port-forward
+	@$(MICROK8S_REGISTRY_FLAG) $(SKAFFOLD) run \
+		--mute-logs=all \
+		--port-forward \
+		--no-prune=false \
+		--cache-artifacts=false
 .PHONY: dev

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,33 @@
 #!/bin/sh
 
-set -x
-# script requires the availability of rockcraft, skopeo, yq and docker in the host system
-# it also requires sudo permissions to run skopeo
+# The script requires:
+# - rockcraft
+# - skopeo with sudo privilege
+# - yq
+# - docker
 
-# export version=$(yq -r '.version' rockcraft.yaml)
+set -e
+
+rockcraft="rockcraft.yaml"
+rockcraft_backup="rockcraft_bak.yaml"
+
+restore() {
+    mv "$rockcraft_backup" "$rockcraft"
+    rm -f "$rockcraft_backup"
+}
+trap 'restore' INT TERM EXIT
+
+# The ROCK image needs certain utilities to
+# - create OpenFGA store and authorization model
+# - export OpenFGA store ID and authorization model ID to Admin UI service
+cp "$rockcraft" "$rockcraft_backup"
+yq -i \
+  '.base = "ubuntu@22.04", .parts |= ({"utils": {"plugin": "nil", "stage-packages": ["curl", "jq"]}} + .)' \
+  "$rockcraft"
 rockcraft pack -v
 
-sudo skopeo --insecure-policy copy "oci-archive:identity-platform-admin-ui_$(yq -r '.version' rockcraft.yaml)_amd64.rock" docker-daemon:$IMAGE
+sudo skopeo --insecure-policy \
+  copy "oci-archive:identity-platform-admin-ui_$(yq -r '.version' rockcraft.yaml)_amd64.rock" \
+  docker-daemon:"$IMAGE"
 
-docker push $IMAGE
+docker push "$IMAGE"

--- a/deployments/kubectl/configMap.yaml
+++ b/deployments/kubectl/configMap.yaml
@@ -112,3 +112,33 @@ data:
                 "type": "object"
             }
         }
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openfga-init
+data:
+  init.sh: |
+    #!/bin/sh
+
+    set -e
+
+    OPENFGA_URL='http://openfga.default.svc.cluster.local:8080'
+
+    until [ "$(curl -s -o /dev/null -w "%{http_code}" $OPENFGA_URL/stores)" -eq 200 ]; do
+      sleep 5
+    done
+
+    curl -sS -X POST ${OPENFGA_URL}/stores \
+      -H 'Content-Type: application/json' \
+      -d '{"name": "dev"}' | jq -r '.id' > /data/OPENFGA_STORE_ID
+
+    openfga_store_id=$(cat /data/OPENFGA_STORE_ID)
+    /usr/bin/identity-platform-admin-ui create-fga-model \
+      --fga-api-url "$OPENFGA_URL" \
+      --fga-api-token "42" \
+      --fga-store-id "$openfga_store_id"
+
+    curl -sS ${OPENFGA_URL}/stores/"$openfga_store_id"/authorization-models \
+      | jq -r '.authorization_models[0].id' > /data/OPENFGA_AUTHORIZATION_MODEL_ID

--- a/deployments/kubectl/deployment.yaml
+++ b/deployments/kubectl/deployment.yaml
@@ -19,9 +19,20 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8000"
     spec:
+      initContainers:
+        - name: init
+          image: busybox
+          command: [ "/bin/sh", "-c", "while [ ! -s /data/openfga/OPENFGA_STORE_ID ] || [ ! -s /data/openfga/OPENFGA_AUTHORIZATION_MODEL_ID ]; do sleep 5; done" ]
+          volumeMounts:
+            - mountPath: /data/openfga
+              name: openfga-pv-data
       containers:
       - image: identity-platform-admin-ui
         name: identity-platform-admin-ui
+        command: [ "/bin/sh", "-c", "export OPENFGA_STORE_ID=$(cat /data/OPENFGA_STORE_ID) OPENFGA_AUTHORIZATION_MODEL_ID=$(cat /data/OPENFGA_AUTHORIZATION_MODEL_ID); /usr/bin/identity-platform-admin-ui serve" ]
+        volumeMounts:
+          - mountPath: /data
+            name: openfga-pv-data
         envFrom:
           - configMapRef:
               name: identity-platform-admin-ui
@@ -46,3 +57,7 @@ spec:
           periodSeconds: 30
       imagePullSecrets:
       - name: regcred-github
+      volumes:
+        - name: openfga-pv-data
+          persistentVolumeClaim:
+            claimName: openfga-pv-claim

--- a/deployments/kubectl/job.yaml
+++ b/deployments/kubectl/job.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: batch/v1
+
+kind: Job
+metadata:
+  name: openfga-init
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 0
+      containers:
+        - name: job
+          image: identity-platform-admin-ui
+          command: [ "/bin/sh",  "-c", "/scripts/init.sh" ]
+          volumeMounts:
+            - mountPath: /scripts
+              name: openfga-init
+            - mountPath: /data
+              name: openfga-pv
+      restartPolicy: Never
+      volumes:
+        - name: openfga-init
+          configMap:
+            name: openfga-init
+            defaultMode: 0755
+        - name: openfga-pv
+          persistentVolumeClaim:
+            claimName: openfga-pv-claim

--- a/deployments/kubectl/storage.yaml
+++ b/deployments/kubectl/storage.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: openfga-pv-volume
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 1Mi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openfga-pv-claim
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Mi

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -28,7 +28,7 @@ manifests:
     - "deployments/kubectl/*"
 
 deploy:
-  kubectl:
+  kubectl: {}
   helm:
     releases:
       - name: postgresql


### PR DESCRIPTION
This pull request tries to solve the issue in the provisioning development setup. The admin service needs the openFGA store ID and model ID to be passed in.

The proposed setup uses a k8s job, instead of using init containers in Admin UI deployment, to create openFGA store and model and share them with the admin service by using persistent volume. This is specifically to avoid potential race conditions that could be caused by multiple Admin UI replicas.