### PR TITLE
(ReBAC library) Add main types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.3
 toolchain go1.21.4
 
 require (
+	github.com/frankban/quicktest v1.14.6
 	github.com/getkin/kin-openapi v0.123.0
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/go-chi/cors v1.2.1
@@ -66,6 +67,8 @@ require (
 	github.com/invopop/yaml v0.2.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -78,6 +81,7 @@ require (
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBF
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/getkin/kin-openapi v0.123.0 h1:zIik0mRwFNLyvtXK274Q6ut+dPh6nlxBp0x7mNrPhs8=
 github.com/getkin/kin-openapi v0.123.0/go.mod h1:wb1aSZA/iWmorQP9KTAS/phLj/t17B5jT7+fS8ed9NM=
 github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
@@ -55,6 +57,7 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=
 github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -126,6 +129,7 @@ github.com/ory/oathkeeper-client-go v0.40.6 h1:Qm/odusPn6DTJ8mXXElNzfXYpcD5wqmb/
 github.com/ory/oathkeeper-client-go v0.40.6/go.mod h1:9JUPR04XPH3e53TYbfu+KveCnTIYtlSTJiQ23rEQLJI=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.17.0 h1:rl2sfwZMtSthVU752MqfjQozy7blglC+1SOtjMAMh+Q=
@@ -136,6 +140,7 @@ github.com/prometheus/common v0.44.0 h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdO
 github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO7x0VV9VvuY=
 github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwaUuI=
 github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/rebac-admin-backend/v1/core.go
+++ b/rebac-admin-backend/v1/core.go
@@ -1,0 +1,43 @@
+// Copyright 2024 Canonical Ltd.
+
+// Package v1 provides HTTP handlers that implement the ReBAC Admin OpenAPI spec.
+// This package delegates authorization and data manipulation to user-defined
+// "backend"s that implement the designated abstractions.
+package v1
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
+)
+
+// ReBACAdminBackendParams contains references to user-defined implementation
+// of required abstractions, called "backend"s.
+type ReBACAdminBackendParams struct {
+	GroupsService       GroupsServiceBackend
+	GroupsAuthorization GroupsAuthorizationBackend
+}
+
+// ReBACAdminBackend represents the ReBAC admin backend as a whole package.
+type ReBACAdminBackend struct {
+	params  ReBACAdminBackendParams
+	service resources.ServerInterface
+}
+
+// NewReBACAdminBackend returns a new ReBACAdminBackend instance, configured
+// with given backends.
+func NewReBACAdminBackend(params ReBACAdminBackendParams) *ReBACAdminBackend {
+	return &ReBACAdminBackend{
+		params:  params,
+		service: service{},
+	}
+}
+
+// Handler returns HTTP handlers implementing the ReBAC Admin OpenAPI spec.
+func (b *ReBACAdminBackend) Handler(baseURL string) http.Handler {
+	baseURL, _ = strings.CutSuffix(baseURL, "/")
+	return resources.HandlerWithOptions(b.service, resources.ChiServerOptions{
+		BaseURL: baseURL + "/v1",
+	})
+}

--- a/rebac-admin-backend/v1/core_test.go
+++ b/rebac-admin-backend/v1/core_test.go
@@ -1,0 +1,66 @@
+// Copyright 2024 Canonical Ltd.
+
+package v1
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/go-chi/chi/v5"
+)
+
+// TestHandlerWorksWithStandardMux this test ensures that the returned Handler
+// can be used with the Golang standard library multiplexers, and it's not tied
+// to the underlying router library.
+func TestHandlerWorksWithStandardMux(t *testing.T) {
+	c := qt.New(t)
+
+	sut := NewReBACAdminBackend(ReBACAdminBackendParams{})
+	handler := sut.Handler("/some/base/path/")
+
+	mux := http.NewServeMux()
+	mux.Handle("/some/base/path/", handler)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	println(server.URL)
+
+	res, err := http.Get(server.URL + "/some/base/path/v1/swagger.json")
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.StatusCode, qt.Equals, http.StatusNotImplemented)
+	defer res.Body.Close()
+
+	out, err := io.ReadAll(res.Body)
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.IsNotNil)
+}
+
+// TestHandlerWorksWithChiMux this test ensures that the returned Handler
+// can be used with the Chi multiplexers.
+func TestHandlerWorksWithChiMux(t *testing.T) {
+	c := qt.New(t)
+
+	sut := NewReBACAdminBackend(ReBACAdminBackendParams{})
+	handler := sut.Handler("")
+
+	mux := chi.NewMux()
+	mux.Mount("/some/base/path", handler)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	println(server.URL)
+
+	res, err := http.Get(server.URL + "/some/base/path/v1/swagger.json")
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.StatusCode, qt.Equals, http.StatusNotImplemented)
+	defer res.Body.Close()
+
+	out, err := io.ReadAll(res.Body)
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.IsNotNil)
+}

--- a/rebac-admin-backend/v1/groups.go
+++ b/rebac-admin-backend/v1/groups.go
@@ -1,0 +1,11 @@
+// Copyright 2024 Canonical Ltd.
+
+package v1
+
+// GroupsServiceBackend defines an abstract backend to handle Groups.
+type GroupsServiceBackend interface {
+}
+
+// GroupsAuthorizationBackend defines an abstract backend to handle authorization for Groups.
+type GroupsAuthorizationBackend interface {
+}

--- a/rebac-admin-backend/v1/service.go
+++ b/rebac-admin-backend/v1/service.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+
+package v1
+
+import "github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
+
+type service struct {
+	// TODO(CSS-7311): the Unimplemented struct should be removed from here after all
+	// endpoints are implemented.
+	resources.Unimplemented
+
+	GroupsService       GroupsServiceBackend
+	GroupsAuthorization GroupsAuthorizationBackend
+}


### PR DESCRIPTION
This PR adds the main types of the library (e.g., params, constructor, some abstractions) and also creates HTTP handlers. A few tests are added to verify it works fine with both Golang standard HTTP multiplexer and Chi Mux.

This PR is based on the other branch (pushed in #194). That's why you see a lot of changes, but once the other PR lands, this one will shrink.

Fixes CSS-7249