### PR TITLE
(ReBAC library) Implement proper error formatting

### DIFF
--- a/rebac-admin-backend/v1/core.go
+++ b/rebac-admin-backend/v1/core.go
@@ -28,9 +28,17 @@ type ReBACAdminBackend struct {
 // NewReBACAdminBackend returns a new ReBACAdminBackend instance, configured
 // with given backends.
 func NewReBACAdminBackend(params ReBACAdminBackendParams) *ReBACAdminBackend {
+	return newReBACAdminBackendWithService(params, &service{})
+}
+
+// newReBACAdminBackendWithService returns a new ReBACAdminBackend instance, configured
+// with given backends and service implementation.
+//
+// This is intended for internal/test use cases.
+func newReBACAdminBackendWithService(params ReBACAdminBackendParams, service resources.ServerInterface) *ReBACAdminBackend {
 	return &ReBACAdminBackend{
 		params:  params,
-		service: service{},
+		service: service,
 	}
 }
 
@@ -38,6 +46,7 @@ func NewReBACAdminBackend(params ReBACAdminBackendParams) *ReBACAdminBackend {
 func (b *ReBACAdminBackend) Handler(baseURL string) http.Handler {
 	baseURL, _ = strings.CutSuffix(baseURL, "/")
 	return resources.HandlerWithOptions(b.service, resources.ChiServerOptions{
-		BaseURL: baseURL + "/v1",
+		BaseURL:          baseURL + "/v1",
+		ErrorHandlerFunc: writeErrorResponse,
 	})
 }

--- a/rebac-admin-backend/v1/error.go
+++ b/rebac-admin-backend/v1/error.go
@@ -1,0 +1,17 @@
+// Copyright 2024 Canonical Ltd.
+
+package v1
+
+// UnauthorizedError represents unauthorized access error.
+type UnauthorizedError struct{}
+
+func (e *UnauthorizedError) Error() string {
+	return "unauthorized"
+}
+
+// NotFoundError represents missing entity error.
+type NotFoundError struct{}
+
+func (e *NotFoundError) Error() string {
+	return "not found"
+}

--- a/rebac-admin-backend/v1/response.go
+++ b/rebac-admin-backend/v1/response.go
@@ -1,0 +1,71 @@
+// Copyright 2024 Canonical Ltd.
+
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
+)
+
+// writeErrorResponse writes the given err in the response with format defined
+// by the OpenAPI spec.
+func writeErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
+	resp := getErrorResponse(err)
+
+	body, err := json.Marshal(resp)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("unexpected marshalling error"))
+	}
+
+	w.WriteHeader(int(resp.Status))
+	w.Write(body)
+}
+
+// getErrorResponse returns a Response instance filled with the given error.
+func getErrorResponse(err error) resources.Response {
+	if isBadRequestError(err) {
+		return resources.Response{
+			Status:  http.StatusBadRequest,
+			Message: "Bad request",
+		}
+	}
+
+	switch err.(type) {
+	case *UnauthorizedError:
+		return resources.Response{
+			Status:  http.StatusUnauthorized,
+			Message: "Unauthorized",
+		}
+	case *NotFoundError:
+		return resources.Response{
+			Status:  http.StatusNotFound,
+			Message: "Not found",
+		}
+	default:
+		return resources.Response{
+			Status:  http.StatusInternalServerError,
+			Message: "Unexpected error",
+		}
+	}
+}
+
+// isBadRequestError determines whether the given error should be teated as a
+// "Bad Request" (400) error.
+func isBadRequestError(err error) bool {
+	switch err.(type) {
+	case *resources.UnmarshalingParamError:
+		return true
+	case *resources.RequiredParamError:
+		return true
+	case *resources.RequiredHeaderError:
+		return true
+	case *resources.InvalidParamFormatError:
+		return true
+	case *resources.TooManyValuesForParamError:
+		return true
+	}
+	return false
+}

--- a/rebac-admin-backend/v1/response.go
+++ b/rebac-admin-backend/v1/response.go
@@ -12,7 +12,7 @@ import (
 // writeErrorResponse writes the given err in the response with format defined
 // by the OpenAPI spec.
 func writeErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
-	resp := getErrorResponse(err)
+	resp := mapErrorResponse(err)
 
 	body, err := json.Marshal(resp)
 	if err != nil {
@@ -24,8 +24,8 @@ func writeErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
 	w.Write(body)
 }
 
-// getErrorResponse returns a Response instance filled with the given error.
-func getErrorResponse(err error) resources.Response {
+// mapErrorResponse returns a Response instance filled with the given error.
+func mapErrorResponse(err error) resources.Response {
 	if isBadRequestError(err) {
 		return resources.Response{
 			Status:  http.StatusBadRequest,

--- a/rebac-admin-backend/v1/response_test.go
+++ b/rebac-admin-backend/v1/response_test.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
 	qt "github.com/frankban/quicktest"
+
+	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
 )
 
 func TestGetErrorResponse(t *testing.T) {

--- a/rebac-admin-backend/v1/response_test.go
+++ b/rebac-admin-backend/v1/response_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
 )
 
-func TestGetErrorResponse(t *testing.T) {
+func TestMapErrorResponse(t *testing.T) {
 	c := qt.New(t)
 
 	tests := []struct {
@@ -81,7 +81,7 @@ func TestGetErrorResponse(t *testing.T) {
 	for _, t := range tests {
 		tt := t
 		c.Run(tt.name, func(c *qt.C) {
-			value := getErrorResponse(tt.arg)
+			value := mapErrorResponse(tt.arg)
 			c.Assert(value, qt.DeepEquals, tt.expected)
 		})
 	}

--- a/rebac-admin-backend/v1/response_test.go
+++ b/rebac-admin-backend/v1/response_test.go
@@ -1,0 +1,87 @@
+// Copyright 2024 Canonical Ltd.
+
+package v1
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
+	qt "github.com/frankban/quicktest"
+)
+
+func TestGetErrorResponse(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		arg      error
+		expected resources.Response
+	}{{
+		name: "handler error: UnmarshalingParamError",
+		arg:  &resources.UnmarshalingParamError{},
+		expected: resources.Response{
+			Status:  http.StatusBadRequest,
+			Message: "Bad request",
+		},
+	}, {
+		name: "handler error: RequiredParamError",
+		arg:  &resources.RequiredParamError{},
+		expected: resources.Response{
+			Status:  http.StatusBadRequest,
+			Message: "Bad request",
+		},
+	}, {
+		name: "handler error: RequiredHeaderError",
+		arg:  &resources.RequiredHeaderError{},
+		expected: resources.Response{
+			Status:  http.StatusBadRequest,
+			Message: "Bad request",
+		},
+	}, {
+		name: "handler error: InvalidParamFormatError",
+		arg:  &resources.InvalidParamFormatError{},
+		expected: resources.Response{
+			Status:  http.StatusBadRequest,
+			Message: "Bad request",
+		},
+	}, {
+		name: "handler error: TooManyValuesForParamError",
+		arg:  &resources.TooManyValuesForParamError{},
+		expected: resources.Response{
+			Status:  http.StatusBadRequest,
+			Message: "Bad request",
+		},
+	}, {
+		name: "service error: UnauthorizedError",
+		arg:  &UnauthorizedError{},
+		expected: resources.Response{
+			Status:  http.StatusUnauthorized,
+			Message: "Unauthorized",
+		},
+	}, {
+		name: "service error: NotFoundError",
+		arg:  &NotFoundError{},
+		expected: resources.Response{
+			Status:  http.StatusNotFound,
+			Message: "Not found",
+		},
+	}, {
+		name: "unknown error",
+		arg:  errors.New("something went wrong"),
+		expected: resources.Response{
+			Status:  http.StatusInternalServerError,
+			Message: "Unexpected error",
+		},
+	},
+	}
+
+	for _, t := range tests {
+		tt := t
+		c.Run(tt.name, func(c *qt.C) {
+			value := getErrorResponse(tt.arg)
+			c.Assert(value, qt.DeepEquals, tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
This PR applies proper error formatting to match the OpenAPI spec, by implementing a custom `ErrorHandlerFunc` function. This also introduces some generic error types (e.g., `UnauthorizedError` or `NotFoundError`) which should be used by custom backends).

Some test cases are added to verify errors added are correctly formatted to a `Response` type.

Fixes CSS-7327