### PR TITLE
fix: refactor error types

### DIFF
--- a/rebac-admin-backend/Makefile
+++ b/rebac-admin-backend/Makefile
@@ -13,3 +13,8 @@ help:
 pull-spec:
 	./script/generate-resources-from-spec.sh
 .PHONY: pull-spec
+
+# Generate test mocks
+mocks:
+	go generate ./...
+.PHONY: mocks

--- a/rebac-admin-backend/Makefile
+++ b/rebac-admin-backend/Makefile
@@ -18,3 +18,8 @@ pull-spec:
 mocks:
 	go generate ./...
 .PHONY: mocks
+
+# Run tests
+test: mocks
+	go test ./...
+.PHONY: test

--- a/rebac-admin-backend/v1/error.go
+++ b/rebac-admin-backend/v1/error.go
@@ -53,6 +53,8 @@ func NewValidationError(message string) error {
 
 // ErrorResponseMapper is the basic interface to allow for error -> http response mapping
 type ErrorResponseMapper interface {
+	// MapError maps an error into a Response. If the method is unable to map the
+	// error (e.g., the error is unknown), it can just return nil.
 	MapError(error) *resources.Response
 }
 

--- a/rebac-admin-backend/v1/error.go
+++ b/rebac-admin-backend/v1/error.go
@@ -90,14 +90,12 @@ func NewDelegateErrorResponseMapper(m ErrorResponseMapper) ErrorResponseMapper {
 	return &delegateErrorResponseMapper{delegate: m}
 }
 
-// mapHandlerInternalError checks if the given error is an internal
-// handler-level error (i.e., an auto-generated error type) and return the
+// mapHandlerBadRequestError checks if the given error is an "Bad Request" error
+// thrown at the handler root (i.e., an auto-generated error type) and return the
 // equivalent errorWithStatus instance. If the given error is not an internal
 // handler error, this function will return nil.
-func mapHandlerInternalError(err error) *errorWithStatus {
-	// Note that these are all auto-generated error types, that should be
-	// regarded as bad request errors.
-	if !isHandlerInternalError(err) {
+func mapHandlerBadRequestError(err error) *errorWithStatus {
+	if !isHandlerBadRequestError(err) {
 		return nil
 	}
 	return &errorWithStatus{
@@ -106,7 +104,7 @@ func mapHandlerInternalError(err error) *errorWithStatus {
 	}
 }
 
-func isHandlerInternalError(err error) bool {
+func isHandlerBadRequestError(err error) bool {
 	switch err.(type) {
 	case *resources.UnmarshalingParamError:
 		return true

--- a/rebac-admin-backend/v1/error.go
+++ b/rebac-admin-backend/v1/error.go
@@ -12,7 +12,7 @@ import (
 // errorWithStatus is an internal error representation that holds the corresponding
 // HTTP status code along with the error message.
 type errorWithStatus struct {
-	// status is the HTTP standard equivalent status status. Acceptable
+	// status is the HTTP standard equivalent status. Acceptable
 	// values are `http.Status*` constants.
 	status  int
 	message string

--- a/rebac-admin-backend/v1/error.go
+++ b/rebac-admin-backend/v1/error.go
@@ -54,7 +54,7 @@ func NewValidationError(message string) error {
 // ErrorResponseMapper is the basic interface to allow for error -> http response mapping
 type ErrorResponseMapper interface {
 	// MapError maps an error into a Response. If the method is unable to map the
-	// error (e.g., the error is unknown), it can just return nil.
+	// error (e.g., the error is unknown), it must return nil.
 	MapError(error) *resources.Response
 }
 

--- a/rebac-admin-backend/v1/identities_test.go
+++ b/rebac-admin-backend/v1/identities_test.go
@@ -495,7 +495,7 @@ func TestHandler_ValidationErrors(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			c.Assert(response.Status, qt.Equals, http.StatusBadRequest)
-			c.Assert(response.Message, qt.Equals, "Validation error: request doesn't match the expected schema")
+			c.Assert(response.Message, qt.Equals, "Bad Request: request doesn't match the expected schema")
 		})
 	}
 }

--- a/rebac-admin-backend/v1/identities_test.go
+++ b/rebac-admin-backend/v1/identities_test.go
@@ -536,7 +536,7 @@ func TestPutIdentitiesItemFailureValidation(t *testing.T) {
 	c := qt.New(t)
 
 	expectedErrorResponse := resources.Response{
-		Message: "Validation error: Identity ID from path does not match the Identity object",
+		Message: "validation error: Identity ID from path does not match the Identity object",
 		Status:  http.StatusBadRequest,
 	}
 

--- a/rebac-admin-backend/v1/response.go
+++ b/rebac-admin-backend/v1/response.go
@@ -33,7 +33,7 @@ func mapErrorResponse(err error) *resources.Response {
 		asErrorWithStatus = &errorWithStatus{status: http.StatusOK}
 	} else if e, ok := err.(*errorWithStatus); ok {
 		asErrorWithStatus = e
-	} else if e := mapHandlerInternalError(err); e != nil {
+	} else if e := mapHandlerBadRequestError(err); e != nil {
 		asErrorWithStatus = e
 	} else {
 		asErrorWithStatus = &errorWithStatus{

--- a/rebac-admin-backend/v1/response.go
+++ b/rebac-admin-backend/v1/response.go
@@ -26,6 +26,15 @@ func writeErrorResponse(w http.ResponseWriter, err error) {
 
 // mapErrorResponse returns a Response instance filled with the given error.
 func mapErrorResponse(err error) *resources.Response {
+	// Theoretically, this should never happen, but we anyway have to check for
+	// a nil argument.
+	if err == nil {
+		return &resources.Response{
+			Status:  http.StatusOK,
+			Message: "",
+		}
+	}
+
 	if isBadRequestError(err) {
 		return &resources.Response{
 			Status:  http.StatusBadRequest,

--- a/rebac-admin-backend/v1/response.go
+++ b/rebac-admin-backend/v1/response.go
@@ -33,15 +33,16 @@ func mapErrorResponse(err error) *resources.Response {
 		}
 	}
 
-	var status int
-
-	switch err.(type) {
-	case *UnauthorizedError:
-		status = http.StatusUnauthorized
-	case *NotFoundError:
-		status = http.StatusNotFound
-	default:
-		status = http.StatusInternalServerError
+	status := http.StatusInternalServerError
+	if e, ok := err.(*errorWithCode); ok {
+		switch e.code {
+		case CodeUnauthorized:
+			status = http.StatusUnauthorized
+		case CodeNotFound:
+			status = http.StatusNotFound
+		case CodeValidationError:
+			status = http.StatusBadRequest
+		}
 	}
 
 	return &resources.Response{

--- a/rebac-admin-backend/v1/response_test.go
+++ b/rebac-admin-backend/v1/response_test.go
@@ -27,7 +27,7 @@ func TestMapErrorResponse(t *testing.T) {
 		},
 		expected: &resources.Response{
 			Status:  http.StatusBadRequest,
-			Message: "Error unmarshaling parameter test-param as JSON: can't find param",
+			Message: "Bad Request: Error unmarshaling parameter test-param as JSON: can't find param",
 		},
 	}, {
 		name: "handler error: RequiredParamError",
@@ -36,7 +36,7 @@ func TestMapErrorResponse(t *testing.T) {
 		},
 		expected: &resources.Response{
 			Status:  http.StatusBadRequest,
-			Message: "Query argument foo is required, but not found",
+			Message: "Bad Request: Query argument foo is required, but not found",
 		},
 	}, {
 		name: "handler error: RequiredHeaderError",
@@ -45,7 +45,7 @@ func TestMapErrorResponse(t *testing.T) {
 		},
 		expected: &resources.Response{
 			Status:  http.StatusBadRequest,
-			Message: "Header parameter foo is required, but not found",
+			Message: "Bad Request: Header parameter foo is required, but not found",
 		},
 	}, {
 		name: "handler error: InvalidParamFormatError",
@@ -55,49 +55,49 @@ func TestMapErrorResponse(t *testing.T) {
 		},
 		expected: &resources.Response{
 			Status:  http.StatusBadRequest,
-			Message: "Invalid format for parameter test-param: invalid param",
+			Message: "Bad Request: Invalid format for parameter test-param: invalid param",
 		},
 	}, {
 		name: "handler error: TooManyValuesForParamError",
 		arg:  &resources.TooManyValuesForParamError{ParamName: "test-param"},
 		expected: &resources.Response{
 			Status:  http.StatusBadRequest,
-			Message: "Expected one value for test-param, got 0",
+			Message: "Bad Request: Expected one value for test-param, got 0",
 		},
 	}, {
 		name: "service error: UnauthorizedError",
 		arg:  NewUnauthorizedError("forbidden"),
 		expected: &resources.Response{
 			Status:  http.StatusUnauthorized,
-			Message: "unauthorized: forbidden",
+			Message: "Unauthorized: forbidden",
 		},
 	}, {
 		name: "service error: NotFoundError",
-		arg:  NewNotFoundError("test"),
+		arg:  NewNotFoundError("something not found"),
 		expected: &resources.Response{
 			Status:  http.StatusNotFound,
-			Message: "not found: test",
+			Message: "Not Found: something not found",
 		},
 	}, {
 		name: "validation error",
 		arg:  NewValidationError("request is not valid"),
 		expected: &resources.Response{
-			Message: "validation error: request is not valid",
-			Status:  400,
+			Status:  http.StatusBadRequest,
+			Message: "Bad Request: request is not valid",
 		},
 	}, {
 		name: "unknown error",
 		arg:  errors.New("unexpected error"),
 		expected: &resources.Response{
 			Status:  http.StatusInternalServerError,
-			Message: "unexpected error",
+			Message: "Internal Server Error: unexpected error",
 		},
 	}, {
 		name: "nil error",
 		arg:  nil,
 		expected: &resources.Response{
 			Status:  http.StatusOK,
-			Message: "",
+			Message: "OK",
 		},
 	},
 	}

--- a/rebac-admin-backend/v1/response_test.go
+++ b/rebac-admin-backend/v1/response_test.go
@@ -92,6 +92,13 @@ func TestMapErrorResponse(t *testing.T) {
 			Status:  http.StatusInternalServerError,
 			Message: "unexpected error",
 		},
+	}, {
+		name: "nil error",
+		arg:  nil,
+		expected: &resources.Response{
+			Status:  http.StatusOK,
+			Message: "",
+		},
 	},
 	}
 

--- a/rebac-admin-backend/v1/response_test.go
+++ b/rebac-admin-backend/v1/response_test.go
@@ -23,35 +23,39 @@ func TestMapErrorResponse(t *testing.T) {
 		name: "handler error: UnmarshalingParamError",
 		arg: &resources.UnmarshalingParamError{
 			ParamName: "test-param",
-			Err:       errors.New("Can't find param"),
+			Err:       errors.New("can't find param"),
 		},
 		expected: &resources.Response{
 			Status:  http.StatusBadRequest,
-			Message: "Error unmarshaling parameter test-param as JSON: Can't find param",
+			Message: "Error unmarshaling parameter test-param as JSON: can't find param",
 		},
 	}, {
 		name: "handler error: RequiredParamError",
-		arg:  &resources.RequiredParamError{},
+		arg: &resources.RequiredParamError{
+			ParamName: "foo",
+		},
 		expected: &resources.Response{
 			Status:  http.StatusBadRequest,
-			Message: "Query argument  is required, but not found",
+			Message: "Query argument foo is required, but not found",
 		},
 	}, {
 		name: "handler error: RequiredHeaderError",
-		arg:  &resources.RequiredHeaderError{},
+		arg: &resources.RequiredHeaderError{
+			ParamName: "foo",
+		},
 		expected: &resources.Response{
 			Status:  http.StatusBadRequest,
-			Message: "Header parameter  is required, but not found",
+			Message: "Header parameter foo is required, but not found",
 		},
 	}, {
 		name: "handler error: InvalidParamFormatError",
 		arg: &resources.InvalidParamFormatError{
 			ParamName: "test-param",
-			Err:       errors.New("Invalid param"),
+			Err:       errors.New("invalid param"),
 		},
 		expected: &resources.Response{
 			Status:  http.StatusBadRequest,
-			Message: "Invalid format for parameter test-param: Invalid param",
+			Message: "Invalid format for parameter test-param: invalid param",
 		},
 	}, {
 		name: "handler error: TooManyValuesForParamError",
@@ -62,31 +66,31 @@ func TestMapErrorResponse(t *testing.T) {
 		},
 	}, {
 		name: "service error: UnauthorizedError",
-		arg:  &UnauthorizedError{"forbidden"},
+		arg:  NewUnauthorizedError("forbidden"),
 		expected: &resources.Response{
 			Status:  http.StatusUnauthorized,
-			Message: "Unauthorized: forbidden",
+			Message: "unauthorized: forbidden",
 		},
 	}, {
 		name: "service error: NotFoundError",
-		arg:  &NotFoundError{"test"},
+		arg:  NewNotFoundError("test"),
 		expected: &resources.Response{
 			Status:  http.StatusNotFound,
-			Message: "Not found: test",
+			Message: "not found: test",
 		},
 	}, {
 		name: "validation error",
-		arg:  &ValidationError{message: "request is not valid"},
+		arg:  NewValidationError("request is not valid"),
 		expected: &resources.Response{
-			Message: "Validation error: request is not valid",
+			Message: "validation error: request is not valid",
 			Status:  400,
 		},
 	}, {
 		name: "unknown error",
-		arg:  errors.New("Unexpected error"),
+		arg:  errors.New("unexpected error"),
 		expected: &resources.Response{
 			Status:  http.StatusInternalServerError,
-			Message: "Unexpected error",
+			Message: "unexpected error",
 		},
 	},
 	}


### PR DESCRIPTION
This PR applies some refactoring on error types. A new internal type, named `errorWithCode` is introduced, with a few exported helper methods to let users create errors.

Fixes CSS-7530