### PR TITLE
feat: add `/groups` endpoints

### DIFF
--- a/rebac-admin-backend/Makefile
+++ b/rebac-admin-backend/Makefile
@@ -16,6 +16,7 @@ pull-spec:
 
 # Generate test mocks
 mocks:
+	go install go.uber.org/mock/mockgen@v0.3.0
 	go generate ./...
 .PHONY: mocks
 

--- a/rebac-admin-backend/v1/core.go
+++ b/rebac-admin-backend/v1/core.go
@@ -9,14 +9,24 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/interfaces"
 	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
 )
 
 // ReBACAdminBackendParams contains references to user-defined implementation
 // of required abstractions, called "backend"s.
 type ReBACAdminBackendParams struct {
-	GroupsService       GroupsServiceBackend
-	GroupsAuthorization GroupsAuthorizationBackend
+	IdentitiesService       interfaces.IdentitiesService
+	IdentitiesAuthorization interfaces.IdentitiesAuthorization
+	IdentitiesErrorMapper   ErrorResponseMapper
+
+	RolesService       interfaces.RolesService
+	RolesAuthorization interfaces.RolesAuthorization
+	RolesErrorMapper   ErrorResponseMapper
+
+	GroupsService       interfaces.GroupsService
+	GroupsAuthorization interfaces.GroupsAuthorization
+	GroupsErrorMapper   ErrorResponseMapper
 }
 
 // ReBACAdminBackend represents the ReBAC admin backend as a whole package.

--- a/rebac-admin-backend/v1/groups.go
+++ b/rebac-admin-backend/v1/groups.go
@@ -1,11 +1,241 @@
 // Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
 package v1
 
-// GroupsServiceBackend defines an abstract backend to handle Groups.
-type GroupsServiceBackend interface {
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
+)
+
+// GetGroups returns the list of known groups.
+// (GET /groups)
+func (h handler) GetGroups(w http.ResponseWriter, req *http.Request, params resources.GetGroupsParams) {
+	ctx := req.Context()
+
+	groups, err := h.Groups.ListGroups(ctx, &params)
+	if err != nil {
+		response := h.GroupsErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	response := resources.GetGroupsResponse{
+		Data:   groups.Data,
+		Status: http.StatusOK,
+	}
+
+	writeResponse(w, http.StatusOK, response)
 }
 
-// GroupsAuthorizationBackend defines an abstract backend to handle authorization for Groups.
-type GroupsAuthorizationBackend interface {
+// PostGroups adds a new group.
+// (POST /groups)
+func (h handler) PostGroups(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
+	group := new(resources.Group)
+	defer req.Body.Close()
+
+	if err := json.NewDecoder(req.Body).Decode(group); err != nil {
+		writeErrorResponse(w, NewValidationError("request doesn't match the expected schema"))
+		return
+	}
+
+	group, err := h.Groups.CreateGroup(ctx, group)
+	if err != nil {
+		response := h.GroupsErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	writeResponse(w, http.StatusCreated, group)
+}
+
+// DeleteGroupsItem deletes the specified group.
+// (DELETE /groups/{id})
+func (h handler) DeleteGroupsItem(w http.ResponseWriter, req *http.Request, id string) {
+	ctx := req.Context()
+
+	_, err := h.Groups.DeleteGroup(ctx, id)
+	if err != nil {
+		response := h.GroupsErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetGroupsItem returns the group identified by the provided ID.
+// (GET /groups/{id})
+func (h handler) GetGroupsItem(w http.ResponseWriter, req *http.Request, id string) {
+	ctx := req.Context()
+
+	identity, err := h.Groups.GetGroup(ctx, id)
+	if err != nil {
+		response := h.GroupsErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	writeResponse(w, http.StatusOK, identity)
+}
+
+// PutGroupsItem updates the group identified by the provided ID.
+// (PUT /groups/{id})
+func (h handler) PutGroupsItem(w http.ResponseWriter, req *http.Request, id string) {
+	ctx := req.Context()
+
+	group := new(resources.Group)
+	defer req.Body.Close()
+
+	if err := json.NewDecoder(req.Body).Decode(group); err != nil {
+		writeErrorResponse(w, NewValidationError("request doesn't match the expected schema"))
+		return
+	}
+
+	if id != *group.Id {
+		writeErrorResponse(w, NewValidationError("group ID from path does not match the Group object"))
+		return
+	}
+
+	group, err := h.Groups.UpdateGroup(ctx, group)
+	if err != nil {
+		response := h.GroupsErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	writeResponse(w, http.StatusOK, group)
+}
+
+// GetGroupsItemEntitlements returns the list of entitlements for a group identified by the provided ID.
+// (GET /groups/{id}/entitlements)
+func (h handler) GetGroupsItemEntitlements(w http.ResponseWriter, req *http.Request, id string, params resources.GetGroupsItemEntitlementsParams) {
+	ctx := req.Context()
+
+	entitlements, err := h.Groups.GetGroupEntitlements(ctx, id, &params)
+	if err != nil {
+		response := h.GroupsErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	response := resources.GetGroupEntitlementsResponse{
+		Data:   entitlements,
+		Status: http.StatusOK,
+	}
+
+	writeResponse(w, http.StatusOK, response)
+}
+
+// PatchGroupsItemEntitlements Adds or removes entitlements to/from a group.
+// (PATCH /groups/{id}/entitlements)
+func (h handler) PatchGroupsItemEntitlements(w http.ResponseWriter, req *http.Request, id string) {
+	ctx := req.Context()
+
+	patchesRequest := new(resources.GroupEntitlementsPatchRequestBody)
+	defer req.Body.Close()
+
+	if err := json.NewDecoder(req.Body).Decode(patchesRequest); err != nil {
+		writeErrorResponse(w, NewValidationError("request doesn't match the expected schema"))
+		return
+	}
+
+	_, err := h.Groups.PatchGroupEntitlements(ctx, id, patchesRequest.Patches)
+	if err != nil {
+		response := h.GroupsErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetGroupsItemIdentities returns the list of identities within a group identified by given id.
+// (GET /groups/{id}/identities)
+func (h handler) GetGroupsItemIdentities(w http.ResponseWriter, req *http.Request, id string, params resources.GetGroupsItemIdentitiesParams) {
+	ctx := req.Context()
+
+	groups, err := h.Groups.GetGroupIdentities(ctx, id, &params)
+	if err != nil {
+		response := h.GroupsErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	response := resources.GetGroupIdentitiesResponse{
+		Data:   groups.Data,
+		Status: http.StatusOK,
+	}
+
+	writeResponse(w, http.StatusOK, response)
+}
+
+// PatchGroupsItemIdentities adds or removes identities to/from the group identified by given ID.
+// (PATCH /groups/{id}/identities)
+func (h handler) PatchGroupsItemIdentities(w http.ResponseWriter, req *http.Request, id string) {
+	ctx := req.Context()
+
+	patchesRequest := new(resources.GroupIdentitiesPatchRequestBody)
+	defer req.Body.Close()
+
+	if err := json.NewDecoder(req.Body).Decode(patchesRequest); err != nil {
+		writeErrorResponse(w, NewValidationError("request doesn't match the expected schema"))
+		return
+	}
+
+	_, err := h.Groups.PatchGroupIdentities(ctx, id, patchesRequest.Patches)
+	if err != nil {
+		response := h.GroupsErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetGroupsItemRoles returns the list of roles assigned to a group identified by given ID.
+// (GET /groups/{id}/roles)
+func (h handler) GetGroupsItemRoles(w http.ResponseWriter, req *http.Request, id string, params resources.GetGroupsItemRolesParams) {
+	ctx := req.Context()
+
+	roles, err := h.Groups.GetGroupRoles(ctx, id, &params)
+	if err != nil {
+		response := h.GroupsErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	response := resources.GetIdentityRolesResponse{
+		Data:   roles.Data,
+		Status: http.StatusOK,
+	}
+
+	writeResponse(w, http.StatusOK, response)
+}
+
+// PatchGroupsItemRoles Add or remove roles assigned to/from a group identified by given ID.
+// (PATCH /groups/{id}/roles)
+func (h handler) PatchGroupsItemRoles(w http.ResponseWriter, req *http.Request, id string) {
+	ctx := req.Context()
+
+	patchesRequest := new(resources.GroupRolesPatchRequestBody)
+	defer req.Body.Close()
+
+	if err := json.NewDecoder(req.Body).Decode(patchesRequest); err != nil {
+		writeErrorResponse(w, NewValidationError("request doesn't match the expected schema"))
+		return
+	}
+
+	_, err := h.Groups.PatchGroupRoles(ctx, id, patchesRequest.Patches)
+	if err != nil {
+		response := h.GroupsErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }

--- a/rebac-admin-backend/v1/groups.go
+++ b/rebac-admin-backend/v1/groups.go
@@ -53,7 +53,7 @@ func (h handler) PostGroups(w http.ResponseWriter, req *http.Request) {
 	writeResponse(w, http.StatusCreated, group)
 }
 
-// DeleteGroupsItem deletes the specified group.
+// DeleteGroupsItem deletes the specified group identified by the provided ID.
 // (DELETE /groups/{id})
 func (h handler) DeleteGroupsItem(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
@@ -131,7 +131,7 @@ func (h handler) GetGroupsItemEntitlements(w http.ResponseWriter, req *http.Requ
 	writeResponse(w, http.StatusOK, response)
 }
 
-// PatchGroupsItemEntitlements Adds or removes entitlements to/from a group.
+// PatchGroupsItemEntitlements Adds or removes entitlements to/from a group identified by the provided ID.
 // (PATCH /groups/{id}/entitlements)
 func (h handler) PatchGroupsItemEntitlements(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()

--- a/rebac-admin-backend/v1/groups.go
+++ b/rebac-admin-backend/v1/groups.go
@@ -73,14 +73,14 @@ func (h handler) DeleteGroupsItem(w http.ResponseWriter, req *http.Request, id s
 func (h handler) GetGroupsItem(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
 
-	identity, err := h.Groups.GetGroup(ctx, id)
+	group, err := h.Groups.GetGroup(ctx, id)
 	if err != nil {
 		response := h.GroupsErrorMapper.MapError(err)
 		writeResponse(w, response.Status, response)
 		return
 	}
 
-	writeResponse(w, http.StatusOK, identity)
+	writeResponse(w, http.StatusOK, group)
 }
 
 // PutGroupsItem updates the group identified by the provided ID.

--- a/rebac-admin-backend/v1/groups_test.go
+++ b/rebac-admin-backend/v1/groups_test.go
@@ -1,0 +1,548 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"go.uber.org/mock/gomock"
+
+	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/interfaces"
+	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
+)
+
+var (
+	mockGroupName              = "MockGroupName"
+	mockGroupIdentityFirstName = "MockGroupIdentityFirstName"
+	mockGroupIdentityId        = "MockGroupIdentityId"
+	mockGroupRoleId            = "MockRoleId"
+	mockGroupRoleName          = "MockRoleName"
+	mockGroupId                = "test-id"
+)
+
+//go:generate mockgen -package interfaces -destination ./interfaces/mock_groups.go -source=./interfaces/groups.go
+//go:generate mockgen -package v1 -destination ./mock_error_response.go -source=./error.go
+
+func TestHandler_Groups_Success(t *testing.T) {
+	c := qt.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockGroupObject := resources.Group{
+		Id:   &mockGroupId,
+		Name: mockGroupName,
+	}
+
+	mockEntitlements := []resources.EntityEntitlement{{
+		EntitlementType: "mock-entl-type",
+		EntityName:      "mock-entity-name",
+		EntityType:      "mock-entity-type",
+	}}
+
+	mockIdentities := resources.Identities{
+		Data: []resources.Identity{{
+			Id:        &mockGroupIdentityId,
+			FirstName: &mockGroupIdentityFirstName,
+		}},
+	}
+
+	mockRoles := resources.Roles{
+		Data: []resources.Role{{
+			Id:   &mockGroupRoleId,
+			Name: mockGroupRoleName,
+		}},
+	}
+
+	type EndpointTest struct {
+		name             string
+		setupServiceMock func(mockService *interfaces.MockGroupsService)
+		triggerFunc      func(h handler, w *httptest.ResponseRecorder)
+		expectedStatus   int
+		expectedBody     any
+	}
+
+	tests := []EndpointTest{
+		{
+			name: "TestHandler_Groups_ListGroupsSuccess",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().
+					ListGroups(gomock.Any(), gomock.Eq(&resources.GetGroupsParams{})).
+					Return(&resources.Groups{
+						Data: []resources.Group{mockGroupObject},
+					}, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockRequest := httptest.NewRequest(http.MethodGet, "/groups", nil)
+				h.GetGroups(w, mockRequest, resources.GetGroupsParams{})
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody: resources.GetGroupsResponse{
+				Data:   []resources.Group{mockGroupObject},
+				Status: http.StatusOK,
+			},
+		},
+		{
+			name: "TestHandler_Groups_CreateGroupSuccess",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().
+					CreateGroup(gomock.Any(), gomock.Eq(&mockGroupObject)).
+					Return(&mockGroupObject, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				groupBody, _ := json.Marshal(mockGroupObject)
+				mockRequest := httptest.NewRequest(http.MethodPost, "/groups", bytes.NewReader(groupBody))
+				h.PostGroups(w, mockRequest)
+			},
+			expectedStatus: http.StatusCreated,
+			expectedBody:   mockGroupObject,
+		},
+		{
+			name: "TestHandler_Groups_GetGroupSuccess",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().
+					GetGroup(gomock.Any(), gomock.Eq(mockGroupId)).
+					Return(&mockGroupObject, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%s", mockGroupId), nil)
+				h.GetGroupsItem(w, mockRequest, mockGroupId)
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   mockGroupObject,
+		},
+		{
+			name: "TestHandler_Groups_UpdateGroupSuccess",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().
+					UpdateGroup(gomock.Any(), gomock.Eq(&mockGroupObject)).
+					Return(&mockGroupObject, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				groupBody, _ := json.Marshal(mockGroupObject)
+				mockRequest := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/groups/%s", mockGroupId), bytes.NewReader(groupBody))
+				h.PutGroupsItem(w, mockRequest, mockGroupId)
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   mockGroupObject,
+		},
+		{
+			name: "TestHandler_Groups_DeleteGroupSuccess",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().
+					DeleteGroup(gomock.Any(), gomock.Eq(mockGroupId)).
+					Return(true, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockRequest := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/groups/%s", mockGroupId), nil)
+				h.DeleteGroupsItem(w, mockRequest, mockGroupId)
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "TestHandler_Groups_GetGroupIdentitiesSuccess",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().
+					GetGroupIdentities(gomock.Any(), gomock.Eq(mockGroupId), gomock.Eq(&resources.GetGroupsItemIdentitiesParams{})).
+					Return(&mockIdentities, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%s/identities", mockGroupId), nil)
+				h.GetGroupsItemIdentities(w, mockRequest, mockGroupId, resources.GetGroupsItemIdentitiesParams{})
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody: resources.GetGroupIdentitiesResponse{
+				Data:   mockIdentities.Data,
+				Status: http.StatusOK,
+			},
+		},
+		{
+			name: "TestHandler_Groups_PatchGroupIdentitiesSuccess",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().
+					PatchGroupIdentities(gomock.Any(), gomock.Eq(mockGroupId), gomock.Any()).
+					Return(true, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				patchesBody, _ := json.Marshal(resources.GroupIdentitiesPatchRequestBody{
+					Patches: []resources.GroupIdentitiesPatchItem{
+						{
+							Identity: *mockIdentities.Data[0].Id,
+							Op:       "add",
+						},
+					},
+				})
+				mockRequest := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/groups/%s/identities", mockGroupId), bytes.NewReader(patchesBody))
+				h.PatchGroupsItemIdentities(w, mockRequest, mockGroupId)
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "TestHandler_Groups_GetGroupRolesSuccess",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().
+					GetGroupRoles(gomock.Any(), gomock.Eq(mockGroupId), gomock.Eq(&resources.GetGroupsItemRolesParams{})).
+					Return(&mockRoles, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%s/roles", mockGroupId), nil)
+				h.GetGroupsItemRoles(w, mockRequest, mockGroupId, resources.GetGroupsItemRolesParams{})
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody: resources.GetGroupRolesResponse{
+				Data:   mockRoles.Data,
+				Status: http.StatusOK,
+			},
+		},
+		{
+			name: "TestHandler_Groups_PatchGroupRolesSuccess",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().
+					PatchGroupRoles(gomock.Any(), gomock.Eq(mockGroupId), gomock.Any()).
+					Return(true, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				patchesBody, _ := json.Marshal(resources.GroupRolesPatchRequestBody{
+					Patches: []resources.GroupRolesPatchItem{
+						{
+							Role: *mockRoles.Data[0].Id,
+							Op:   "add",
+						},
+					},
+				})
+				mockRequest := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/groups/%s/roles", mockGroupId), bytes.NewReader(patchesBody))
+				h.PatchGroupsItemRoles(w, mockRequest, mockGroupId)
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "TestHandler_Groups_GetGroupEntitlementsSuccess",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().
+					GetGroupEntitlements(gomock.Any(), gomock.Eq(mockGroupId), gomock.Eq(&resources.GetGroupsItemEntitlementsParams{})).
+					Return(mockEntitlements, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%s/entitlements", mockGroupId), nil)
+				h.GetGroupsItemEntitlements(w, mockRequest, mockGroupId, resources.GetGroupsItemEntitlementsParams{})
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody: resources.GetGroupEntitlementsResponse{
+				Data:   mockEntitlements,
+				Status: http.StatusOK,
+			},
+		},
+		{
+			name: "TestHandler_Groups_PatchGroupEntitlementsSuccess",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().
+					PatchGroupEntitlements(gomock.Any(), gomock.Eq(mockGroupId), gomock.Any()).
+					Return(true, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				patchesBody, _ := json.Marshal(resources.GroupEntitlementsPatchRequestBody{
+					Patches: []resources.GroupEntitlementsPatchItem{
+						{
+							Entitlement: mockEntitlements[0],
+							Op:          "add",
+						},
+					},
+				})
+				mockRequest := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/groups/%s/entitlements", mockGroupId), bytes.NewReader(patchesBody))
+				h.PatchGroupsItemEntitlements(w, mockRequest, mockGroupId)
+			},
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		tt := test
+		c.Run(tt.name, func(c *qt.C) {
+			mockGroupsService := interfaces.NewMockGroupsService(ctrl)
+			tt.setupServiceMock(mockGroupsService)
+
+			sut := handler{Groups: mockGroupsService}
+
+			mockWriter := httptest.NewRecorder()
+			tt.triggerFunc(sut, mockWriter)
+
+			result := mockWriter.Result()
+			defer result.Body.Close()
+
+			c.Assert(result.StatusCode, qt.Equals, tt.expectedStatus)
+
+			body, err := io.ReadAll(result.Body)
+			c.Assert(err, qt.IsNil)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling response, got: %v", err))
+
+			if tt.expectedBody != nil {
+				c.Assert(string(body), qt.JSONEquals, tt.expectedBody)
+			} else {
+				c.Assert(len(body), qt.Equals, 0)
+			}
+		})
+	}
+
+}
+
+func TestHandler_Groups_ValidationErrors(t *testing.T) {
+	c := qt.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// need a value that is not a struct to trigger Decode error
+	mockInvalidRequestBody := true
+
+	invalidRequestBody, _ := json.Marshal(mockInvalidRequestBody)
+
+	type EndpointTest struct {
+		name        string
+		triggerFunc func(h handler, w *httptest.ResponseRecorder)
+	}
+
+	tests := []EndpointTest{
+		{
+			name: "TestPostGroupsFailureInvalidRequest",
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				req := httptest.NewRequest(http.MethodPost, "/groups", bytes.NewReader(invalidRequestBody))
+				h.PostGroups(w, req)
+			},
+		},
+		{
+			name: "TestPutGroupsFailureInvalidRequest",
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/groups/%s", mockGroupId), bytes.NewReader(invalidRequestBody))
+				h.PutGroupsItem(w, req, mockGroupId)
+			},
+		},
+		{
+			name: "TestPatchGroupsIdentitiesFailureInvalidRequest",
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/groups/%s/identities", mockGroupId), bytes.NewReader(invalidRequestBody))
+				h.PatchGroupsItemIdentities(w, req, mockGroupId)
+			},
+		},
+		{
+			name: "TestPatchGroupsRolesFailureInvalidRequest",
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/groups/%s/roles", mockGroupId), bytes.NewReader(invalidRequestBody))
+				h.PatchGroupsItemRoles(w, req, mockGroupId)
+			},
+		},
+		{
+			name: "TestPatchGroupsEntitlementsFailureInvalidRequest",
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/groups/%s/entitlements", mockGroupId), bytes.NewReader(invalidRequestBody))
+				h.PatchGroupsItemEntitlements(w, req, mockGroupId)
+			},
+		},
+	}
+	for _, test := range tests {
+		tt := test
+		c.Run(tt.name, func(c *qt.C) {
+			mockWriter := httptest.NewRecorder()
+			sut := handler{}
+
+			tt.triggerFunc(sut, mockWriter)
+
+			result := mockWriter.Result()
+			defer result.Body.Close()
+
+			c.Assert(result.StatusCode, qt.Equals, http.StatusBadRequest)
+
+			data, err := io.ReadAll(result.Body)
+			c.Assert(err, qt.IsNil)
+
+			response := new(resources.Response)
+
+			err = json.Unmarshal(data, response)
+			c.Assert(err, qt.IsNil)
+
+			c.Assert(response.Status, qt.Equals, http.StatusBadRequest)
+			c.Assert(response.Message, qt.Equals, "Bad Request: request doesn't match the expected schema")
+		})
+	}
+}
+
+func TestHandler_Groups_ServiceBackendFailures(t *testing.T) {
+	c := qt.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockErrorResponse := resources.Response{
+		Message: "mock-error",
+		Status:  http.StatusInternalServerError,
+	}
+
+	mockError := errors.New("test-error")
+
+	type EndpointTest struct {
+		name             string
+		setupServiceMock func(mockService *interfaces.MockGroupsService)
+		triggerFunc      func(h handler, w *httptest.ResponseRecorder)
+	}
+
+	tests := []EndpointTest{
+		{
+			name: "TestGetGroupsFailure",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().ListGroups(gomock.Any(), gomock.Any()).Return(nil, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockParams := resources.GetGroupsParams{}
+				mockRequest := httptest.NewRequest(http.MethodGet, "/groups", nil)
+				h.GetGroups(w, mockRequest, mockParams)
+			},
+		},
+		{
+			name: "TestPostGroupsFailure",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().CreateGroup(gomock.Any(), gomock.Any()).Return(nil, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				group, _ := json.Marshal(&resources.Group{})
+				request := httptest.NewRequest(http.MethodPost, "/groups", bytes.NewReader(group))
+				h.PostGroups(w, request)
+			},
+		},
+		{
+			name: "TestDeleteGroupsItemFailure",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().DeleteGroup(gomock.Any(), gomock.Any()).Return(false, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockRequest := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/groups/%s", mockGroupId), nil)
+				h.DeleteGroupsItem(w, mockRequest, mockGroupId)
+			},
+		},
+		{
+			name: "TestGetRolesItemFailure",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().GetGroup(gomock.Any(), gomock.Any()).Return(nil, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%s", mockGroupId), nil)
+				h.GetGroupsItem(w, mockRequest, mockGroupId)
+			},
+		},
+		{
+			name: "TestPutGroupsItemFailure",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().UpdateGroup(gomock.Any(), gomock.Any()).Return(nil, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				group, _ := json.Marshal(&resources.Group{Id: &mockGroupId})
+				request := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/groups/%s", mockGroupId), bytes.NewReader(group))
+				h.PutGroupsItem(w, request, mockGroupId)
+			},
+		},
+		{
+			name: "TestGetGroupsItemIdentitiesFailure",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().GetGroupIdentities(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				params := resources.GetGroupsItemIdentitiesParams{}
+				mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%s/identities", mockGroupId), nil)
+				h.GetGroupsItemIdentities(w, mockRequest, mockGroupId, params)
+			},
+		},
+		{
+			name: "TestPatchGroupsItemIdentitiesFailure",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().PatchGroupIdentities(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				patches, _ := json.Marshal(&resources.GroupIdentitiesPatchRequestBody{})
+				request := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/groups/%s/identities", mockGroupId), bytes.NewReader(patches))
+				h.PatchGroupsItemIdentities(w, request, mockGroupId)
+			},
+		},
+		{
+			name: "TestGetGroupsItemRolesFailure",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().GetGroupRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				params := resources.GetGroupsItemRolesParams{}
+				mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%s/roles", mockGroupId), nil)
+				h.GetGroupsItemRoles(w, mockRequest, mockGroupId, params)
+			},
+		},
+		{
+			name: "TestPatchGroupsItemRolesFailure",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().PatchGroupRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				patches, _ := json.Marshal(&resources.GroupRolesPatchRequestBody{})
+				request := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/groups/%s/roles", mockGroupId), bytes.NewReader(patches))
+				h.PatchGroupsItemRoles(w, request, mockGroupId)
+			},
+		},
+		{
+			name: "TestGetGroupsItemEntitlementsFailure",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().GetGroupEntitlements(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				params := resources.GetGroupsItemEntitlementsParams{}
+				mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%s/entitlements", mockGroupId), nil)
+				h.GetGroupsItemEntitlements(w, mockRequest, mockGroupId, params)
+			},
+		},
+		{
+			name: "TestPatchGroupsItemEntitlementsFailure",
+			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
+				mockService.EXPECT().PatchGroupEntitlements(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				patches, _ := json.Marshal(&resources.GroupEntitlementsPatchRequestBody{})
+				request := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/groups/%s/entitlements", mockGroupId), bytes.NewReader(patches))
+				h.PatchGroupsItemEntitlements(w, request, mockGroupId)
+			},
+		},
+	}
+	for _, test := range tests {
+		tt := test
+		c.Run(tt.name, func(c *qt.C) {
+			mockErrorResponseMapper := NewMockErrorResponseMapper(ctrl)
+			mockErrorResponseMapper.EXPECT().MapError(gomock.Any()).Return(&mockErrorResponse)
+
+			mockGroupsService := interfaces.NewMockGroupsService(ctrl)
+			tt.setupServiceMock(mockGroupsService)
+
+			mockWriter := httptest.NewRecorder()
+			sut := handler{
+				Groups:            mockGroupsService,
+				GroupsErrorMapper: mockErrorResponseMapper,
+			}
+
+			tt.triggerFunc(sut, mockWriter)
+
+			result := mockWriter.Result()
+			defer result.Body.Close()
+
+			c.Assert(result.StatusCode, qt.Equals, http.StatusInternalServerError)
+
+			data, err := io.ReadAll(result.Body)
+			c.Assert(err, qt.IsNil)
+
+			response := new(resources.Response)
+			err = json.Unmarshal(data, response)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling response, got: %v", err))
+			c.Assert(response.Status, qt.Equals, http.StatusInternalServerError)
+			c.Assert(response.Message, qt.Equals, "mock-error")
+		})
+	}
+}

--- a/rebac-admin-backend/v1/handler.go
+++ b/rebac-admin-backend/v1/handler.go
@@ -12,9 +12,6 @@ type handler struct {
 	// endpoints are implemented.
 	resources.Unimplemented
 
-	Groups              GroupsServiceBackend
-	GroupsAuthorization GroupsAuthorizationBackend
-
 	Identities              interfaces.IdentitiesService
 	IdentitiesAuthorization interfaces.IdentitiesAuthorization
 	IdentitiesErrorMapper   ErrorResponseMapper
@@ -23,10 +20,6 @@ type handler struct {
 	RolesAuthorization interfaces.RolesAuthorization
 	RolesErrorMapper   ErrorResponseMapper
 
-	IdentityProviders              interfaces.IdentityProvidersService
-	IdentityProvidersAuthorization interfaces.IdentityProvidersAuthorization
-	IdentityProvidersErrorMapper   ErrorResponseMapper
-
 	Capabilities              interfaces.CapabilitiesService
 	CapabilitiesAuthorization interfaces.CapabilitiesAuthorization
 	CapabilitiesErrorMapper   ErrorResponseMapper
@@ -34,4 +27,8 @@ type handler struct {
 	Entitlements              interfaces.EntitlementsService
 	EntitlementsAuthorization interfaces.EntitlementsAuthorization
 	EntitlementsErrorMapper   ErrorResponseMapper
+
+	Groups              interfaces.GroupsService
+	GroupsAuthorization interfaces.GroupsAuthorization
+	GroupsErrorMapper   ErrorResponseMapper
 }

--- a/rebac-admin-backend/v1/handler.go
+++ b/rebac-admin-backend/v1/handler.go
@@ -20,6 +20,10 @@ type handler struct {
 	RolesAuthorization interfaces.RolesAuthorization
 	RolesErrorMapper   ErrorResponseMapper
 
+	IdentityProviders              interfaces.IdentityProvidersService
+	IdentityProvidersAuthorization interfaces.IdentityProvidersAuthorization
+	IdentityProvidersErrorMapper   ErrorResponseMapper
+
 	Capabilities              interfaces.CapabilitiesService
 	CapabilitiesAuthorization interfaces.CapabilitiesAuthorization
 	CapabilitiesErrorMapper   ErrorResponseMapper

--- a/rebac-admin-backend/v1/identities.go
+++ b/rebac-admin-backend/v1/identities.go
@@ -174,7 +174,7 @@ func (h handler) GetIdentitiesItemGroups(w http.ResponseWriter, req *http.Reques
 	writeResponse(w, http.StatusOK, response)
 }
 
-// PatchIdentitiesItemGroups adds or removes the identity to/from a group.
+// PatchIdentitiesItemGroups adds or removes the identity to/from groups.
 // (PATCH /identities/{id}/groups)
 func (h handler) PatchIdentitiesItemGroups(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
@@ -217,7 +217,7 @@ func (h handler) GetIdentitiesItemRoles(w http.ResponseWriter, req *http.Request
 	writeResponse(w, http.StatusOK, response)
 }
 
-// PatchIdentitiesItemRoles Add or remove the identity to/from a role.
+// PatchIdentitiesItemRoles Add or remove the identity to/from roles.
 // (PATCH /identities/{id}/roles)
 func (h handler) PatchIdentitiesItemRoles(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()

--- a/rebac-admin-backend/v1/identities_test.go
+++ b/rebac-admin-backend/v1/identities_test.go
@@ -61,7 +61,7 @@ func TestHandler_GetIdentities(t *testing.T) {
 
 	err = json.Unmarshal(data, response)
 
-	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling resonse, got: %v", err))
+	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling response, got: %v", err))
 	c.Assert(result.StatusCode, qt.Equals, http.StatusOK)
 	c.Assert(response, qt.DeepEquals, &expectedResponse)
 }
@@ -93,7 +93,7 @@ func TestHandler_PostIdentitiesSuccess(t *testing.T) {
 	response := new(resources.Identity)
 	err = json.Unmarshal(data, response)
 
-	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling resonse, got: %v", err))
+	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling response, got: %v", err))
 	c.Assert(result.StatusCode, qt.Equals, http.StatusCreated)
 	c.Assert(response, qt.DeepEquals, &mockIdentityReturn)
 }
@@ -147,7 +147,7 @@ func TestHandler_GetIdentitiesItemSuccess(t *testing.T) {
 
 	err = json.Unmarshal(data, response)
 
-	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling resonse, got: %v", err))
+	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling response, got: %v", err))
 	c.Assert(result.StatusCode, qt.Equals, http.StatusOK)
 	c.Assert(response, qt.DeepEquals, &mockIdentityReturn)
 }
@@ -182,7 +182,7 @@ func TestHandler_PutIdentitiesItemSuccess(t *testing.T) {
 	response := new(resources.Identity)
 	err = json.Unmarshal(data, response)
 
-	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling resonse, got: %v", err))
+	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling response, got: %v", err))
 	c.Assert(result.StatusCode, qt.Equals, http.StatusOK)
 	c.Assert(response, qt.DeepEquals, &mockIdentityReturn)
 }
@@ -229,7 +229,7 @@ func TestHandler_GetIdentitiesItemEntitlementsSuccess(t *testing.T) {
 	response := new(resources.GetIdentityEntitlementsResponse)
 	err = json.Unmarshal(data, response)
 
-	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling resonse, got: %v", err))
+	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling response, got: %v", err))
 	c.Assert(result.StatusCode, qt.Equals, http.StatusOK)
 	c.Assert(response, qt.DeepEquals, &expectedResponse)
 }
@@ -308,7 +308,7 @@ func TestHandler_GetIdentitiesItemGroupsSuccess(t *testing.T) {
 	response := new(resources.GetIdentityGroupsResponse)
 	err = json.Unmarshal(data, response)
 
-	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling resonse, got: %v", err))
+	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling response, got: %v", err))
 	c.Assert(result.StatusCode, qt.Equals, http.StatusOK)
 	c.Assert(response, qt.DeepEquals, &expectedResponse)
 }
@@ -387,7 +387,7 @@ func TestHandler_GetIdentitiesItemRolesSuccess(t *testing.T) {
 	response := new(resources.GetIdentityRolesResponse)
 	err = json.Unmarshal(data, response)
 
-	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling resonse, got: %v", err))
+	c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling response, got: %v", err))
 	c.Assert(result.StatusCode, qt.Equals, http.StatusOK)
 	c.Assert(response, qt.DeepEquals, &expectedResponse)
 }
@@ -671,7 +671,7 @@ func TestHandler_Identities_ServiceBackendFailures(t *testing.T) {
 			response := new(resources.Response)
 			err = json.Unmarshal(data, response)
 
-			c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling resonse, got: %v", err))
+			c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling response, got: %v", err))
 			c.Assert(response.Status, qt.Equals, 500)
 			c.Assert(response.Message, qt.Equals, "mock-error")
 		})

--- a/rebac-admin-backend/v1/interfaces/groups.go
+++ b/rebac-admin-backend/v1/interfaces/groups.go
@@ -1,0 +1,49 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package interfaces
+
+import (
+	"context"
+
+	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
+)
+
+// GroupsService defines an abstract backend to handle Groups related operations.
+type GroupsService interface {
+
+	// ListGroups returns a page of Group objects of at least `size` elements if available.
+	ListGroups(ctx context.Context, params *resources.GetGroupsParams) (*resources.Groups, error)
+	// CreateGroup creates a single Group.
+	CreateGroup(ctx context.Context, group *resources.Group) (*resources.Group, error)
+
+	// GetGroup returns a single Group.
+	GetGroup(ctx context.Context, groupId string) (*resources.Group, error)
+
+	// UpdateGroup updates a Group.
+	UpdateGroup(ctx context.Context, group *resources.Group) (*resources.Group, error)
+	// DeleteGroup deletes a Group.
+	// returns (true, nil) in case the group was successfully deleted.
+	// returns (false, error) in case something went wrong.
+	// implementors may want to return (false, nil) for idempotency cases.
+	DeleteGroup(ctx context.Context, groupId string) (bool, error)
+
+	// GetGroupIdentities returns a page of identities in a Group identified by `groupId`.
+	GetGroupIdentities(ctx context.Context, groupId string, params *resources.GetGroupsItemIdentitiesParams) (*resources.Identities, error)
+	// PatchGroupIdentities performs addition or removal of identities to/from a Group.
+	PatchGroupIdentities(ctx context.Context, groupId string, groupPatches []resources.GroupIdentitiesPatchItem) (bool, error)
+
+	// GetGroupRoles returns a page of Roles for Group `groupId`.
+	GetGroupRoles(ctx context.Context, groupId string, params *resources.GetGroupsItemRolesParams) (*resources.Roles, error)
+	// PatchGroupRoles performs addition or removal of a Role to/from a Group.
+	PatchGroupRoles(ctx context.Context, groupId string, rolePatches []resources.GroupRolesPatchItem) (bool, error)
+
+	// GetGroupEntitlements returns a page of Entitlements for Group `groupId`.
+	GetGroupEntitlements(ctx context.Context, groupId string, params *resources.GetGroupsItemEntitlementsParams) ([]resources.EntityEntitlement, error)
+	// PatchGroupEntitlements performs addition or removal of an Entitlement to/from a Group.
+	PatchGroupEntitlements(ctx context.Context, identityId string, entitlementPatches []resources.GroupEntitlementsPatchItem) (bool, error)
+}
+
+// GroupsAuthorization defines an abstract backend to handle authorization for Groups.
+type GroupsAuthorization interface {
+}

--- a/rebac-admin-backend/v1/interfaces/groups.go
+++ b/rebac-admin-backend/v1/interfaces/groups.go
@@ -17,12 +17,12 @@ type GroupsService interface {
 	// CreateGroup creates a single Group.
 	CreateGroup(ctx context.Context, group *resources.Group) (*resources.Group, error)
 
-	// GetGroup returns a single Group.
+	// GetGroup returns a single Group identified by `groupId`.
 	GetGroup(ctx context.Context, groupId string) (*resources.Group, error)
 
 	// UpdateGroup updates a Group.
 	UpdateGroup(ctx context.Context, group *resources.Group) (*resources.Group, error)
-	// DeleteGroup deletes a Group.
+	// DeleteGroup deletes a Group identified by `groupId`.
 	// returns (true, nil) in case the group was successfully deleted.
 	// returns (false, error) in case something went wrong.
 	// implementors may want to return (false, nil) for idempotency cases.
@@ -30,17 +30,17 @@ type GroupsService interface {
 
 	// GetGroupIdentities returns a page of identities in a Group identified by `groupId`.
 	GetGroupIdentities(ctx context.Context, groupId string, params *resources.GetGroupsItemIdentitiesParams) (*resources.Identities, error)
-	// PatchGroupIdentities performs addition or removal of identities to/from a Group.
+	// PatchGroupIdentities performs addition or removal of identities to/from a Group identified by `groupId`.
 	PatchGroupIdentities(ctx context.Context, groupId string, groupPatches []resources.GroupIdentitiesPatchItem) (bool, error)
 
 	// GetGroupRoles returns a page of Roles for Group `groupId`.
 	GetGroupRoles(ctx context.Context, groupId string, params *resources.GetGroupsItemRolesParams) (*resources.Roles, error)
-	// PatchGroupRoles performs addition or removal of a Role to/from a Group.
+	// PatchGroupRoles performs addition or removal of a Role to/from a Group identified by `groupId`.
 	PatchGroupRoles(ctx context.Context, groupId string, rolePatches []resources.GroupRolesPatchItem) (bool, error)
 
 	// GetGroupEntitlements returns a page of Entitlements for Group `groupId`.
 	GetGroupEntitlements(ctx context.Context, groupId string, params *resources.GetGroupsItemEntitlementsParams) ([]resources.EntityEntitlement, error)
-	// PatchGroupEntitlements performs addition or removal of an Entitlement to/from a Group.
+	// PatchGroupEntitlements performs addition or removal of an Entitlement to/from a Group identified by `groupId`.
 	PatchGroupEntitlements(ctx context.Context, identityId string, entitlementPatches []resources.GroupEntitlementsPatchItem) (bool, error)
 }
 

--- a/rebac-admin-backend/v1/interfaces/identities.go
+++ b/rebac-admin-backend/v1/interfaces/identities.go
@@ -33,7 +33,7 @@ type IdentitiesService interface {
 	// PatchIdentityGroups performs addition or removal of a Group to/from an Identity.
 	PatchIdentityGroups(ctx context.Context, identityId string, groupPatches []resources.IdentityGroupsPatchItem) (bool, error)
 
-	// GetIdentityRoles returns a page of Groups for identity `identityId`.
+	// GetIdentityRoles returns a page of Roles for identity `identityId`.
 	GetIdentityRoles(ctx context.Context, identityId string, params *resources.GetIdentitiesItemRolesParams) (*resources.Roles, error)
 	// PatchIdentityRoles performs addition or removal of a Role to/from an Identity.
 	PatchIdentityRoles(ctx context.Context, identityId string, rolePatches []resources.IdentityRolesPatchItem) (bool, error)

--- a/rebac-admin-backend/v1/roles_test.go
+++ b/rebac-admin-backend/v1/roles_test.go
@@ -352,7 +352,7 @@ func TestHandler_Roles_ServiceBackendFailures(t *testing.T) {
 			},
 		},
 		{
-			name: "TestPatchIdentitiesItemEntitlementsFailure",
+			name: "TestPatchRolesItemEntitlementsFailure",
 			setupServiceMock: func(mockService *interfaces.MockRolesService) {
 				mockService.EXPECT().PatchRoleEntitlements(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, mockError)
 			},

--- a/rebac-admin-backend/v1/roles_test.go
+++ b/rebac-admin-backend/v1/roles_test.go
@@ -190,7 +190,7 @@ func TestHandler_Roles_Success(t *testing.T) {
 			body, err := io.ReadAll(result.Body)
 			c.Assert(err, qt.IsNil)
 
-			c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling resonse, got: %v", err))
+			c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling response, got: %v", err))
 
 			if tt.expectedBody != nil {
 				c.Assert(string(body), qt.JSONEquals, tt.expectedBody)
@@ -391,7 +391,7 @@ func TestHandler_Roles_ServiceBackendFailures(t *testing.T) {
 			response := new(resources.Response)
 			err = json.Unmarshal(data, response)
 
-			c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling resonse, got: %v", err))
+			c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling response, got: %v", err))
 			c.Assert(response.Status, qt.Equals, http.StatusInternalServerError)
 			c.Assert(response.Message, qt.Equals, "mock-error")
 		})

--- a/rebac-admin-backend/v1/roles_test.go
+++ b/rebac-admin-backend/v1/roles_test.go
@@ -316,7 +316,7 @@ func TestHandler_Roles_ServiceBackendFailures(t *testing.T) {
 			},
 			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
 				mockRequest := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/roles/%s", mockRoleId), nil)
-				h.DeleteRolesItem(w, mockRequest, "test-id")
+				h.DeleteRolesItem(w, mockRequest, mockRoleId)
 			},
 		},
 		{
@@ -326,7 +326,7 @@ func TestHandler_Roles_ServiceBackendFailures(t *testing.T) {
 			},
 			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
 				mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/roles/%s", mockRoleId), nil)
-				h.GetRolesItem(w, mockRequest, "test-id")
+				h.GetRolesItem(w, mockRequest, mockRoleId)
 			},
 		},
 		{
@@ -337,7 +337,7 @@ func TestHandler_Roles_ServiceBackendFailures(t *testing.T) {
 			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
 				role, _ := json.Marshal(&resources.Role{Id: &mockRoleId})
 				request := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/roles/%s", mockRoleId), bytes.NewReader(role))
-				h.PutRolesItem(w, request, "test-id")
+				h.PutRolesItem(w, request, mockRoleId)
 			},
 		},
 		{
@@ -348,7 +348,7 @@ func TestHandler_Roles_ServiceBackendFailures(t *testing.T) {
 			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
 				params := resources.GetRolesItemEntitlementsParams{}
 				mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/roles/%s/entitlements", mockRoleId), nil)
-				h.GetRolesItemEntitlements(w, mockRequest, "test-id", params)
+				h.GetRolesItemEntitlements(w, mockRequest, mockRoleId, params)
 			},
 		},
 		{
@@ -359,7 +359,7 @@ func TestHandler_Roles_ServiceBackendFailures(t *testing.T) {
 			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
 				patches, _ := json.Marshal(&resources.RoleEntitlementsPatchRequestBody{})
 				request := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/roles/%s/entitlements", mockRoleId), bytes.NewReader(patches))
-				h.PatchRolesItemEntitlements(w, request, "test-id")
+				h.PatchRolesItemEntitlements(w, request, mockRoleId)
 			},
 		},
 	}


### PR DESCRIPTION
This PR implements handlers for `/groups` endpoints. It also fixes some minor issues with other endpoints' tests.

Fixes CSS-7255