### PR TITLE
feat: add `/authentication` API set handlers implementation

### DIFF
--- a/rebac-admin-backend/v1/handler.go
+++ b/rebac-admin-backend/v1/handler.go
@@ -23,7 +23,7 @@ type handler struct {
 	RolesAuthorization interfaces.RolesAuthorization
 	RolesErrorMapper   ErrorResponseMapper
 
-	IdentityProviders              interfaces.IdentityProviderService
-	IdentityProvidersAuthorization interfaces.IdentityProviderService
+	IdentityProviders              interfaces.IdentityProvidersService
+	IdentityProvidersAuthorization interfaces.IdentityProvidersAuthorization
 	IdentityProvidersErrorMapper   ErrorResponseMapper
 }

--- a/rebac-admin-backend/v1/handler.go
+++ b/rebac-admin-backend/v1/handler.go
@@ -22,4 +22,8 @@ type handler struct {
 	Roles              interfaces.RolesService
 	RolesAuthorization interfaces.RolesAuthorization
 	RolesErrorMapper   ErrorResponseMapper
+
+	IdentityProviders              interfaces.IdentityProviderService
+	IdentityProvidersAuthorization interfaces.IdentityProviderService
+	IdentityProvidersErrorMapper   ErrorResponseMapper
 }

--- a/rebac-admin-backend/v1/identity_providers.go
+++ b/rebac-admin-backend/v1/identity_providers.go
@@ -31,7 +31,7 @@ func (h handler) GetAvailableIdentityProviders(w http.ResponseWriter, req *http.
 
 }
 
-// GetIdentityProviders returns a list of known authentication providers.
+// GetIdentityProviders returns a list of registered authentication providers configurations.
 // (GET /authentication)
 func (h handler) GetIdentityProviders(w http.ResponseWriter, req *http.Request, params resources.GetIdentityProvidersParams) {
 	ctx := req.Context()

--- a/rebac-admin-backend/v1/identity_providers.go
+++ b/rebac-admin-backend/v1/identity_providers.go
@@ -1,0 +1,134 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
+)
+
+// GetAvailableIdentityProviders returns the list of supported identity providers.
+// (GET /authentication/providers)
+func (h handler) GetAvailableIdentityProviders(w http.ResponseWriter, req *http.Request, params resources.GetAvailableIdentityProvidersParams) {
+	ctx := req.Context()
+
+	identityProviders, err := h.IdentityProviders.ListAvailableIdentityProviders(ctx, &params)
+	if err != nil {
+		response := h.IdentityProvidersErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	response := resources.GetAvailableIdentityProvidersResponse{
+		Data:   identityProviders.Data,
+		Status: http.StatusOK,
+	}
+
+	writeResponse(w, http.StatusOK, response)
+
+}
+
+// GetIdentityProviders returns a list of known authentication providers.
+// (GET /authentication)
+func (h handler) GetIdentityProviders(w http.ResponseWriter, req *http.Request, params resources.GetIdentityProvidersParams) {
+	ctx := req.Context()
+
+	identityProviders, err := h.IdentityProviders.ListIdentityProviders(ctx, &params)
+	if err != nil {
+		response := h.IdentityProvidersErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	response := resources.GetIdentityProvidersResponse{
+		Data:   identityProviders.Data,
+		Status: http.StatusOK,
+	}
+
+	writeResponse(w, http.StatusOK, response)
+
+}
+
+// PostIdentityProviders register a new authentication provider configuration.
+// (POST /authentication)
+func (h handler) PostIdentityProviders(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
+	identityProvider := new(resources.IdentityProvider)
+	defer req.Body.Close()
+
+	if err := json.NewDecoder(req.Body).Decode(identityProvider); err != nil {
+		writeErrorResponse(w, NewValidationError("request doesn't match the expected schema"))
+		return
+	}
+
+	identityProvider, err := h.IdentityProviders.RegisterConfiguration(ctx, identityProvider)
+	if err != nil {
+		response := h.IdentityProvidersErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	writeResponse(w, http.StatusCreated, identityProvider)
+}
+
+// DeleteIdentityProvidersItem removes an authentication provider configuration identified by `id`.
+// (DELETE /authentication/{id})
+func (h handler) DeleteIdentityProvidersItem(w http.ResponseWriter, req *http.Request, id string) {
+	ctx := req.Context()
+
+	_, err := h.IdentityProviders.DeleteConfiguration(ctx, id)
+	if err != nil {
+		response := h.IdentityProvidersErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetIdentityProvidersItem returns the authentication provider configuration identified by `id`.
+// (GET /authentication/{id})
+func (h handler) GetIdentityProvidersItem(w http.ResponseWriter, req *http.Request, id string) {
+	ctx := req.Context()
+
+	identityProvider, err := h.IdentityProviders.GetConfiguration(ctx, id)
+	if err != nil {
+		response := h.IdentityProvidersErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	writeResponse(w, http.StatusOK, identityProvider)
+}
+
+// PutIdentityProvidersItem update the authentication provider configuration identified by `id`.
+// (PUT /authentication/{id})
+func (h handler) PutIdentityProvidersItem(w http.ResponseWriter, req *http.Request, id string) {
+	ctx := req.Context()
+
+	identityProvider := new(resources.IdentityProvider)
+	defer req.Body.Close()
+
+	if err := json.NewDecoder(req.Body).Decode(identityProvider); err != nil {
+		writeErrorResponse(w, NewValidationError("request doesn't match the expected schema"))
+		return
+	}
+
+	if identityProvider.Id != nil && id != *identityProvider.Id {
+		writeErrorResponse(w, NewValidationError("identity provider ID from path does not match the IdentityProvider object"))
+		return
+	}
+
+	identityProvider, err := h.IdentityProviders.UpdateConfiguration(ctx, identityProvider)
+	if err != nil {
+		response := h.IdentityProvidersErrorMapper.MapError(err)
+		writeResponse(w, response.Status, response)
+		return
+	}
+
+	writeResponse(w, http.StatusOK, identityProvider)
+}

--- a/rebac-admin-backend/v1/identity_providers_test.go
+++ b/rebac-admin-backend/v1/identity_providers_test.go
@@ -1,0 +1,361 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"go.uber.org/mock/gomock"
+
+	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/interfaces"
+	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
+)
+
+var (
+	mockIdentityProviderName = "MockProviderName"
+	mockIdentityProviderId   = "test-id"
+)
+
+//go:generate mockgen -package interfaces -destination ./interfaces/mock_identity_providers.go -source=./interfaces/identity_providers.go
+//go:generate mockgen -package v1 -destination ./mock_error_response.go -source=./error.go
+
+func TestHandler_IdP_Success(t *testing.T) {
+	c := qt.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIDPObject := resources.IdentityProvider{
+		Id:   &mockIdentityProviderId,
+		Name: &mockIdentityProviderName,
+	}
+
+	mockAvailableIDPObject := resources.AvailableIdentityProvider{
+		Id:   mockIdentityProviderId,
+		Name: &mockIdentityProviderName,
+	}
+
+	mockIDPs := []resources.IdentityProvider{mockIDPObject}
+	mockAvailableIDPs := []resources.AvailableIdentityProvider{mockAvailableIDPObject}
+
+	type EndpointTest struct {
+		name             string
+		setupServiceMock func(mockService *interfaces.MockIdentityProviderService)
+		triggerFunc      func(h handler, w *httptest.ResponseRecorder)
+		expectedStatus   int
+		expectedBody     any
+	}
+
+	tests := []EndpointTest{
+		{
+			name: "TestHandler_IdP_GetAvailableIdentityProvidersSuccess",
+			setupServiceMock: func(mockService *interfaces.MockIdentityProviderService) {
+				params := resources.GetAvailableIdentityProvidersParams{}
+				mockService.EXPECT().
+					ListAvailableIdentityProviders(gomock.Any(), gomock.Eq(&params)).
+					Return(&resources.AvailableIdentityProviders{
+						Data: []resources.AvailableIdentityProvider{mockAvailableIDPObject},
+					}, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockRequest := httptest.NewRequest(http.MethodGet, "/authentication", nil)
+				h.GetAvailableIdentityProviders(w, mockRequest, resources.GetAvailableIdentityProvidersParams{})
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody: resources.GetAvailableIdentityProvidersResponse{
+				Data:   mockAvailableIDPs,
+				Status: http.StatusOK,
+			},
+		},
+		{
+			name: "TestHandler_IdP_GetIdentityProvidersSuccess",
+			setupServiceMock: func(mockService *interfaces.MockIdentityProviderService) {
+				mockService.EXPECT().
+					ListIdentityProviders(gomock.Any(), gomock.Any()).
+					Return(&resources.IdentityProviders{Data: mockIDPs}, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				params := resources.GetIdentityProvidersParams{}
+				mockRequest := httptest.NewRequest(http.MethodPost, "/authentication", nil)
+				h.GetIdentityProviders(w, mockRequest, params)
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody: resources.GetIdentityProvidersResponse{
+				Data:   mockIDPs,
+				Status: http.StatusOK,
+			},
+		},
+		{
+			name: "TestHandler_IdP_PostIdentityProvidersSuccess",
+			setupServiceMock: func(mockService *interfaces.MockIdentityProviderService) {
+				mockService.EXPECT().
+					RegisterConfiguration(gomock.Any(), gomock.Eq(&mockIDPObject)).
+					Return(&mockIDPObject, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				idpBody, _ := json.Marshal(mockIDPObject)
+				mockRequest := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/authentication/%s", mockIdentityProviderId), bytes.NewReader(idpBody))
+				h.PostIdentityProviders(w, mockRequest)
+			},
+			expectedStatus: http.StatusCreated,
+			expectedBody:   mockIDPObject,
+		},
+		{
+			name: "TestHandler_IdP_DeleteIdentityProvidersItemSuccess",
+			setupServiceMock: func(mockService *interfaces.MockIdentityProviderService) {
+				mockService.EXPECT().
+					DeleteConfiguration(gomock.Any(), gomock.Eq(mockIdentityProviderId)).
+					Return(true, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockRequest := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/authentication/%s", mockIdentityProviderId), nil)
+				h.DeleteIdentityProvidersItem(w, mockRequest, mockIdentityProviderId)
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "TestHandler_IdP_GetIdentityProvidersItemSuccess",
+			setupServiceMock: func(mockService *interfaces.MockIdentityProviderService) {
+				mockService.EXPECT().
+					GetConfiguration(gomock.Any(), gomock.Eq(mockIdentityProviderId)).
+					Return(&mockIDPObject, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/authentication/%s", mockIdentityProviderId), nil)
+				h.GetIdentityProvidersItem(w, mockRequest, mockIdentityProviderId)
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   mockIDPObject,
+		},
+		{
+			name: "TestHandler_IdP_PutIdentityProvidersItemSuccess",
+			setupServiceMock: func(mockService *interfaces.MockIdentityProviderService) {
+				mockService.EXPECT().
+					UpdateConfiguration(gomock.Any(), gomock.Eq(&mockIDPObject)).
+					Return(&mockIDPObject, nil)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				idpBody, _ := json.Marshal(mockIDPObject)
+				mockRequest := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/authentication/%s", mockIdentityProviderId), bytes.NewReader(idpBody))
+				h.PutIdentityProvidersItem(w, mockRequest, mockIdentityProviderId)
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   mockIDPObject,
+		},
+	}
+
+	for _, test := range tests {
+		tt := test
+		c.Run(tt.name, func(c *qt.C) {
+			mockRoleService := interfaces.NewMockIdentityProviderService(ctrl)
+			tt.setupServiceMock(mockRoleService)
+
+			sut := handler{IdentityProviders: mockRoleService}
+
+			mockWriter := httptest.NewRecorder()
+			tt.triggerFunc(sut, mockWriter)
+
+			result := mockWriter.Result()
+			defer result.Body.Close()
+
+			c.Assert(result.StatusCode, qt.Equals, tt.expectedStatus)
+
+			body, err := io.ReadAll(result.Body)
+			c.Assert(err, qt.IsNil)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling resonse, got: %v", err))
+
+			if tt.expectedBody != nil {
+				c.Assert(string(body), qt.JSONEquals, tt.expectedBody)
+			} else {
+				c.Assert(len(body), qt.Equals, 0)
+			}
+		})
+	}
+
+}
+
+func TestHandler_IdP_ValidationErrors(t *testing.T) {
+	c := qt.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// need a value that is not a struct to trigger Decode error
+	mockInvalidRequestBody := true
+
+	invalidRequestBody, _ := json.Marshal(mockInvalidRequestBody)
+
+	type EndpointTest struct {
+		name        string
+		triggerFunc func(h handler, w *httptest.ResponseRecorder)
+	}
+
+	tests := []EndpointTest{
+		{
+			name: "TestPostIdentityProvidersFailureInvalidRequest",
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/authentication/%s", mockIdentityProviderId), bytes.NewReader(invalidRequestBody))
+				h.PostRoles(w, req)
+			},
+		},
+		{
+			name: "TestPutIdentityProvidersItemFailureInvalidRequest",
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/authentication/%s", mockIdentityProviderId), bytes.NewReader(invalidRequestBody))
+				h.PutRolesItem(w, req, mockIdentityProviderId)
+			},
+		},
+	}
+	for _, test := range tests {
+		tt := test
+		c.Run(tt.name, func(c *qt.C) {
+			mockWriter := httptest.NewRecorder()
+			sut := handler{}
+
+			tt.triggerFunc(sut, mockWriter)
+
+			result := mockWriter.Result()
+			defer result.Body.Close()
+
+			c.Assert(result.StatusCode, qt.Equals, http.StatusBadRequest)
+
+			data, err := io.ReadAll(result.Body)
+			c.Assert(err, qt.IsNil)
+
+			response := new(resources.Response)
+
+			err = json.Unmarshal(data, response)
+			c.Assert(err, qt.IsNil)
+
+			c.Assert(response.Status, qt.Equals, http.StatusBadRequest)
+			c.Assert(response.Message, qt.Equals, "Bad Request: request doesn't match the expected schema")
+		})
+	}
+}
+
+func TestHandler_IdP_ServiceBackendFailures(t *testing.T) {
+	c := qt.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockErrorResponse := resources.Response{
+		Message: "mock-error",
+		Status:  http.StatusInternalServerError,
+	}
+
+	mockError := errors.New("test-error")
+
+	type EndpointTest struct {
+		name             string
+		setupServiceMock func(mockService *interfaces.MockIdentityProviderService)
+		triggerFunc      func(h handler, w *httptest.ResponseRecorder)
+		skip             bool
+	}
+
+	tests := []EndpointTest{
+		{
+			name: "GetAvailableIdentityProvidersFailure",
+			setupServiceMock: func(mockService *interfaces.MockIdentityProviderService) {
+				mockService.EXPECT().ListAvailableIdentityProviders(gomock.Any(), gomock.Any()).Return(nil, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockParams := resources.GetAvailableIdentityProvidersParams{}
+				mockRequest := httptest.NewRequest(http.MethodGet, "/authentication/providers", nil)
+				h.GetAvailableIdentityProviders(w, mockRequest, mockParams)
+			},
+		},
+		{
+			name: "TestGetIdentityProvidersFailure",
+			setupServiceMock: func(mockService *interfaces.MockIdentityProviderService) {
+				mockService.EXPECT().ListIdentityProviders(gomock.Any(), gomock.Any()).Return(nil, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				request := httptest.NewRequest(http.MethodGet, "/authentication", nil)
+				h.GetIdentityProviders(w, request, resources.GetIdentityProvidersParams{})
+			},
+		},
+		{
+			name: "TestPostIdentityProvidersFailure",
+			setupServiceMock: func(mockService *interfaces.MockIdentityProviderService) {
+				mockService.EXPECT().RegisterConfiguration(gomock.Any(), gomock.Any()).Return(nil, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				idp, _ := json.Marshal(&resources.IdentityProvider{})
+				mockRequest := httptest.NewRequest(http.MethodPost, "/authentication", bytes.NewReader(idp))
+				h.PostIdentityProviders(w, mockRequest)
+			},
+		},
+		{
+			name: "TestDeleteIdentityProvidersItemFailure",
+			setupServiceMock: func(mockService *interfaces.MockIdentityProviderService) {
+				mockService.EXPECT().DeleteConfiguration(gomock.Any(), gomock.Any()).Return(false, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				mockRequest := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/authentication/%s", mockIdentityProviderId), nil)
+				h.DeleteIdentityProvidersItem(w, mockRequest, mockIdentityProviderId)
+			},
+		},
+		{
+			name: "TestGetIdentityProvidersItemFailure",
+			setupServiceMock: func(mockService *interfaces.MockIdentityProviderService) {
+				mockService.EXPECT().GetConfiguration(gomock.Any(), gomock.Any()).Return(nil, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/authentication/%s", mockIdentityProviderId), nil)
+				h.GetIdentityProvidersItem(w, request, mockIdentityProviderId)
+			},
+		},
+		{
+			name: "TestPutIdentityProvidersItemFailure",
+			setupServiceMock: func(mockService *interfaces.MockIdentityProviderService) {
+				mockService.EXPECT().UpdateConfiguration(gomock.Any(), gomock.Any()).Return(nil, mockError)
+			},
+			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
+				idp, _ := json.Marshal(&resources.IdentityProvider{Id: &mockIdentityProviderId})
+				mockRequest := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/authentication/%s", mockIdentityProviderId), bytes.NewReader(idp))
+				h.PutIdentityProvidersItem(w, mockRequest, mockIdentityProviderId)
+			},
+		},
+	}
+	for _, test := range tests {
+		tt := test
+		c.Run(tt.name, func(c *qt.C) {
+			mockErrorResponseMapper := NewMockErrorResponseMapper(ctrl)
+			mockErrorResponseMapper.EXPECT().MapError(gomock.Any()).Return(&mockErrorResponse)
+
+			mockIDPService := interfaces.NewMockIdentityProviderService(ctrl)
+			tt.setupServiceMock(mockIDPService)
+
+			mockWriter := httptest.NewRecorder()
+			sut := handler{
+				IdentityProviders:            mockIDPService,
+				IdentityProvidersErrorMapper: mockErrorResponseMapper,
+			}
+
+			tt.triggerFunc(sut, mockWriter)
+
+			result := mockWriter.Result()
+			defer result.Body.Close()
+
+			c.Assert(result.StatusCode, qt.Equals, http.StatusInternalServerError)
+
+			data, err := io.ReadAll(result.Body)
+			c.Assert(err, qt.IsNil)
+
+			response := new(resources.Response)
+			err = json.Unmarshal(data, response)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("Unexpected err while unmarshaling resonse, got: %v", err))
+			c.Assert(response.Status, qt.Equals, http.StatusInternalServerError)
+			c.Assert(response.Message, qt.Equals, "mock-error")
+		})
+	}
+}

--- a/rebac-admin-backend/v1/interfaces/identity_providers.go
+++ b/rebac-admin-backend/v1/interfaces/identity_providers.go
@@ -1,0 +1,36 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package interfaces
+
+import (
+	"context"
+
+	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
+)
+
+// IdentityProviderService defines an abstract backend to handle Roles related operations.
+type IdentityProviderService interface {
+
+	// ListAvailableIdentityProviders returns the static list of supported identity providers.
+	ListAvailableIdentityProviders(ctx context.Context, params *resources.GetAvailableIdentityProvidersParams) (*resources.AvailableIdentityProviders, error)
+
+	// ListIdentityProviders returns a list of registered identity providers configurations.
+	ListIdentityProviders(ctx context.Context, params *resources.GetIdentityProvidersParams) (*resources.IdentityProviders, error)
+
+	// RegisterConfiguration register a new authentication provider configuration.
+	RegisterConfiguration(ctx context.Context, provider *resources.IdentityProvider) (*resources.IdentityProvider, error)
+
+	// DeleteConfiguration removes an authentication provider configuration identified by `id`.
+	DeleteConfiguration(ctx context.Context, id string) (bool, error)
+
+	// GetConfiguration returns the authentication provider configuration identified by `id`.
+	GetConfiguration(ctx context.Context, id string) (*resources.IdentityProvider, error)
+
+	// UpdateConfiguration update the authentication provider configuration identified by `id`.
+	UpdateConfiguration(ctx context.Context, provider *resources.IdentityProvider) (*resources.IdentityProvider, error)
+}
+
+// IdentityProviderAuthorization defines an abstract backend to handle authorization for Roles.
+type IdentityProviderAuthorization interface {
+}

--- a/rebac-admin-backend/v1/interfaces/identity_providers.go
+++ b/rebac-admin-backend/v1/interfaces/identity_providers.go
@@ -9,8 +9,8 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
 )
 
-// IdentityProviderService defines an abstract backend to handle Roles related operations.
-type IdentityProviderService interface {
+// IdentityProvidersService defines an abstract backend to handle Roles related operations.
+type IdentityProvidersService interface {
 
 	// ListAvailableIdentityProviders returns the static list of supported identity providers.
 	ListAvailableIdentityProviders(ctx context.Context, params *resources.GetAvailableIdentityProvidersParams) (*resources.AvailableIdentityProviders, error)
@@ -31,6 +31,6 @@ type IdentityProviderService interface {
 	UpdateConfiguration(ctx context.Context, provider *resources.IdentityProvider) (*resources.IdentityProvider, error)
 }
 
-// IdentityProviderAuthorization defines an abstract backend to handle authorization for Roles.
-type IdentityProviderAuthorization interface {
+// IdentityProvidersAuthorization defines an abstract backend to handle authorization for Roles.
+type IdentityProvidersAuthorization interface {
 }

--- a/rebac-admin-backend/v1/resources/generated_server.go
+++ b/rebac-admin-backend/v1/resources/generated_server.go
@@ -15,22 +15,22 @@ import (
 type ServerInterface interface {
 	// List configured authentication providers.
 	// (GET /authentication)
-	GetAuthentication(w http.ResponseWriter, r *http.Request, params GetAuthenticationParams)
+	GetIdentityProviders(w http.ResponseWriter, r *http.Request, params GetIdentityProvidersParams)
 	// Configure a new authentication provider.
 	// (POST /authentication)
-	PostAuthentication(w http.ResponseWriter, r *http.Request)
+	PostIdentityProviders(w http.ResponseWriter, r *http.Request)
 	// Returns the list of supported identity providers.
 	// (GET /authentication/providers)
-	GetAuthenticationProviders(w http.ResponseWriter, r *http.Request, params GetAuthenticationProvidersParams)
+	GetAvailableIdentityProviders(w http.ResponseWriter, r *http.Request, params GetAvailableIdentityProvidersParams)
 	// Remove an authentication provider configuration.
 	// (DELETE /authentication/{id})
-	DeleteAuthenticationItem(w http.ResponseWriter, r *http.Request, id string)
+	DeleteIdentityProvidersItem(w http.ResponseWriter, r *http.Request, id string)
 	// Get a single authentication provider.
 	// (GET /authentication/{id})
-	GetAuthenticationItem(w http.ResponseWriter, r *http.Request, id string)
+	GetIdentityProvidersItem(w http.ResponseWriter, r *http.Request, id string)
 	// Update an authentication provider configuration.
 	// (PUT /authentication/{id})
-	PutAuthenticationItem(w http.ResponseWriter, r *http.Request, id string)
+	PutIdentityProvidersItem(w http.ResponseWriter, r *http.Request, id string)
 	// Returns the list of endpoints implemented by this API.
 	// (GET /capabilities)
 	GetCapabilities(w http.ResponseWriter, r *http.Request)
@@ -141,37 +141,37 @@ type Unimplemented struct{}
 
 // List configured authentication providers.
 // (GET /authentication)
-func (_ Unimplemented) GetAuthentication(w http.ResponseWriter, r *http.Request, params GetAuthenticationParams) {
+func (_ Unimplemented) GetIdentityProviders(w http.ResponseWriter, r *http.Request, params GetIdentityProvidersParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
 // Configure a new authentication provider.
 // (POST /authentication)
-func (_ Unimplemented) PostAuthentication(w http.ResponseWriter, r *http.Request) {
+func (_ Unimplemented) PostIdentityProviders(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
 // Returns the list of supported identity providers.
 // (GET /authentication/providers)
-func (_ Unimplemented) GetAuthenticationProviders(w http.ResponseWriter, r *http.Request, params GetAuthenticationProvidersParams) {
+func (_ Unimplemented) GetAvailableIdentityProviders(w http.ResponseWriter, r *http.Request, params GetAvailableIdentityProvidersParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
 // Remove an authentication provider configuration.
 // (DELETE /authentication/{id})
-func (_ Unimplemented) DeleteAuthenticationItem(w http.ResponseWriter, r *http.Request, id string) {
+func (_ Unimplemented) DeleteIdentityProvidersItem(w http.ResponseWriter, r *http.Request, id string) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
 // Get a single authentication provider.
 // (GET /authentication/{id})
-func (_ Unimplemented) GetAuthenticationItem(w http.ResponseWriter, r *http.Request, id string) {
+func (_ Unimplemented) GetIdentityProvidersItem(w http.ResponseWriter, r *http.Request, id string) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
 // Update an authentication provider configuration.
 // (PUT /authentication/{id})
-func (_ Unimplemented) PutAuthenticationItem(w http.ResponseWriter, r *http.Request, id string) {
+func (_ Unimplemented) PutIdentityProvidersItem(w http.ResponseWriter, r *http.Request, id string) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -388,14 +388,14 @@ type ServerInterfaceWrapper struct {
 
 type MiddlewareFunc func(http.Handler) http.Handler
 
-// GetAuthentication operation middleware
-func (siw *ServerInterfaceWrapper) GetAuthentication(w http.ResponseWriter, r *http.Request) {
+// GetIdentityProviders operation middleware
+func (siw *ServerInterfaceWrapper) GetIdentityProviders(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
-	var params GetAuthenticationParams
+	var params GetIdentityProvidersParams
 
 	// ------------- Optional query parameter "size" -------------
 
@@ -422,7 +422,7 @@ func (siw *ServerInterfaceWrapper) GetAuthentication(w http.ResponseWriter, r *h
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetAuthentication(w, r, params)
+		siw.Handler.GetIdentityProviders(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -432,12 +432,12 @@ func (siw *ServerInterfaceWrapper) GetAuthentication(w http.ResponseWriter, r *h
 	handler.ServeHTTP(w, r.WithContext(ctx))
 }
 
-// PostAuthentication operation middleware
-func (siw *ServerInterfaceWrapper) PostAuthentication(w http.ResponseWriter, r *http.Request) {
+// PostIdentityProviders operation middleware
+func (siw *ServerInterfaceWrapper) PostIdentityProviders(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.PostAuthentication(w, r)
+		siw.Handler.PostIdentityProviders(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -447,14 +447,14 @@ func (siw *ServerInterfaceWrapper) PostAuthentication(w http.ResponseWriter, r *
 	handler.ServeHTTP(w, r.WithContext(ctx))
 }
 
-// GetAuthenticationProviders operation middleware
-func (siw *ServerInterfaceWrapper) GetAuthenticationProviders(w http.ResponseWriter, r *http.Request) {
+// GetAvailableIdentityProviders operation middleware
+func (siw *ServerInterfaceWrapper) GetAvailableIdentityProviders(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
-	var params GetAuthenticationProvidersParams
+	var params GetAvailableIdentityProvidersParams
 
 	// ------------- Optional query parameter "size" -------------
 
@@ -481,7 +481,7 @@ func (siw *ServerInterfaceWrapper) GetAuthenticationProviders(w http.ResponseWri
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetAuthenticationProviders(w, r, params)
+		siw.Handler.GetAvailableIdentityProviders(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -491,8 +491,8 @@ func (siw *ServerInterfaceWrapper) GetAuthenticationProviders(w http.ResponseWri
 	handler.ServeHTTP(w, r.WithContext(ctx))
 }
 
-// DeleteAuthenticationItem operation middleware
-func (siw *ServerInterfaceWrapper) DeleteAuthenticationItem(w http.ResponseWriter, r *http.Request) {
+// DeleteIdentityProvidersItem operation middleware
+func (siw *ServerInterfaceWrapper) DeleteIdentityProvidersItem(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	var err error
@@ -507,7 +507,7 @@ func (siw *ServerInterfaceWrapper) DeleteAuthenticationItem(w http.ResponseWrite
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.DeleteAuthenticationItem(w, r, id)
+		siw.Handler.DeleteIdentityProvidersItem(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -517,8 +517,8 @@ func (siw *ServerInterfaceWrapper) DeleteAuthenticationItem(w http.ResponseWrite
 	handler.ServeHTTP(w, r.WithContext(ctx))
 }
 
-// GetAuthenticationItem operation middleware
-func (siw *ServerInterfaceWrapper) GetAuthenticationItem(w http.ResponseWriter, r *http.Request) {
+// GetIdentityProvidersItem operation middleware
+func (siw *ServerInterfaceWrapper) GetIdentityProvidersItem(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	var err error
@@ -533,7 +533,7 @@ func (siw *ServerInterfaceWrapper) GetAuthenticationItem(w http.ResponseWriter, 
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetAuthenticationItem(w, r, id)
+		siw.Handler.GetIdentityProvidersItem(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -543,8 +543,8 @@ func (siw *ServerInterfaceWrapper) GetAuthenticationItem(w http.ResponseWriter, 
 	handler.ServeHTTP(w, r.WithContext(ctx))
 }
 
-// PutAuthenticationItem operation middleware
-func (siw *ServerInterfaceWrapper) PutAuthenticationItem(w http.ResponseWriter, r *http.Request) {
+// PutIdentityProvidersItem operation middleware
+func (siw *ServerInterfaceWrapper) PutIdentityProvidersItem(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	var err error
@@ -559,7 +559,7 @@ func (siw *ServerInterfaceWrapper) PutAuthenticationItem(w http.ResponseWriter, 
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.PutAuthenticationItem(w, r, id)
+		siw.Handler.PutIdentityProvidersItem(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1820,22 +1820,22 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	}
 
 	r.Group(func(r chi.Router) {
-		r.Get(options.BaseURL+"/authentication", wrapper.GetAuthentication)
+		r.Get(options.BaseURL+"/authentication", wrapper.GetIdentityProviders)
 	})
 	r.Group(func(r chi.Router) {
-		r.Post(options.BaseURL+"/authentication", wrapper.PostAuthentication)
+		r.Post(options.BaseURL+"/authentication", wrapper.PostIdentityProviders)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(options.BaseURL+"/authentication/providers", wrapper.GetAuthenticationProviders)
+		r.Get(options.BaseURL+"/authentication/providers", wrapper.GetAvailableIdentityProviders)
 	})
 	r.Group(func(r chi.Router) {
-		r.Delete(options.BaseURL+"/authentication/{id}", wrapper.DeleteAuthenticationItem)
+		r.Delete(options.BaseURL+"/authentication/{id}", wrapper.DeleteIdentityProvidersItem)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(options.BaseURL+"/authentication/{id}", wrapper.GetAuthenticationItem)
+		r.Get(options.BaseURL+"/authentication/{id}", wrapper.GetIdentityProvidersItem)
 	})
 	r.Group(func(r chi.Router) {
-		r.Put(options.BaseURL+"/authentication/{id}", wrapper.PutAuthenticationItem)
+		r.Put(options.BaseURL+"/authentication/{id}", wrapper.PutIdentityProvidersItem)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/capabilities", wrapper.GetCapabilities)

--- a/rebac-admin-backend/v1/resources/generated_types.go
+++ b/rebac-admin-backend/v1/resources/generated_types.go
@@ -70,15 +70,15 @@ const (
 	Remove RoleEntitlementsPatchItemOp = "remove"
 )
 
-// AuthenticationProvider defines model for AuthenticationProvider.
-type AuthenticationProvider struct {
+// AvailableIdentityProvider defines model for AvailableIdentityProvider.
+type AvailableIdentityProvider struct {
 	Id   string  `json:"id"`
 	Name *string `json:"name,omitempty"`
 }
 
-// AuthenticationProviders defines model for AuthenticationProviders.
-type AuthenticationProviders struct {
-	Data []AuthenticationProvider `json:"data"`
+// AvailableIdentityProviders defines model for AvailableIdentityProviders.
+type AvailableIdentityProviders struct {
+	Data []AvailableIdentityProvider `json:"data"`
 }
 
 // Capabilities defines model for Capabilities.
@@ -96,7 +96,10 @@ type Capability struct {
 type CapabilityMethods string
 
 // Entity defines model for Entity.
-type Entity = map[string]interface{}
+type Entity struct {
+	Id   string `json:"id"`
+	Type string `json:"type"`
+}
 
 // EntityEntitlement defines model for EntityEntitlement.
 type EntityEntitlement struct {
@@ -110,13 +113,13 @@ type EntityEntitlementItem struct {
 	Entitlement EntityEntitlement `json:"entitlement"`
 }
 
-// GetAuthenticationProvidersResponse defines model for GetAuthenticationProvidersResponse.
-type GetAuthenticationProvidersResponse struct {
-	Links   ResponseLinks            `json:"_links"`
-	Meta    ResponseMeta             `json:"_meta"`
-	Data    []AuthenticationProvider `json:"data"`
-	Message string                   `json:"message"`
-	Status  int                      `json:"status"`
+// GetAvailableIdentityProvidersResponse defines model for GetAvailableIdentityProvidersResponse.
+type GetAvailableIdentityProvidersResponse struct {
+	Links   ResponseLinks               `json:"_links"`
+	Meta    ResponseMeta                `json:"_meta"`
+	Data    []AvailableIdentityProvider `json:"data"`
+	Message string                      `json:"message"`
+	Status  int                         `json:"status"`
 }
 
 // GetCapabilitiesResponse defines model for GetCapabilitiesResponse.
@@ -483,8 +486,8 @@ type Unauthorized = Response
 // Default defines model for default.
 type Default = Response
 
-// GetAuthenticationParams defines parameters for GetAuthentication.
-type GetAuthenticationParams struct {
+// GetIdentityProvidersParams defines parameters for GetIdentityProviders.
+type GetIdentityProvidersParams struct {
 	// Size The number of records to return per response
 	Size *PaginationSize `form:"size,omitempty" json:"size,omitempty"`
 
@@ -495,8 +498,8 @@ type GetAuthenticationParams struct {
 	NextToken *PaginationNextToken `form:"nextToken,omitempty" json:"nextToken,omitempty"`
 }
 
-// GetAuthenticationProvidersParams defines parameters for GetAuthenticationProviders.
-type GetAuthenticationProvidersParams struct {
+// GetAvailableIdentityProvidersParams defines parameters for GetAvailableIdentityProviders.
+type GetAvailableIdentityProvidersParams struct {
 	// Size The number of records to return per response
 	Size *PaginationSize `form:"size,omitempty" json:"size,omitempty"`
 
@@ -664,11 +667,11 @@ type GetRolesItemEntitlementsParams struct {
 	NextToken *PaginationNextToken `form:"nextToken,omitempty" json:"nextToken,omitempty"`
 }
 
-// PostAuthenticationJSONRequestBody defines body for PostAuthentication for application/json ContentType.
-type PostAuthenticationJSONRequestBody = IdentityProvider
+// PostIdentityProvidersJSONRequestBody defines body for PostIdentityProviders for application/json ContentType.
+type PostIdentityProvidersJSONRequestBody = IdentityProvider
 
-// PutAuthenticationItemJSONRequestBody defines body for PutAuthenticationItem for application/json ContentType.
-type PutAuthenticationItemJSONRequestBody = IdentityProvider
+// PutIdentityProvidersItemJSONRequestBody defines body for PutIdentityProvidersItem for application/json ContentType.
+type PutIdentityProvidersItemJSONRequestBody = IdentityProvider
 
 // PostGroupsJSONRequestBody defines body for PostGroups for application/json ContentType.
 type PostGroupsJSONRequestBody = Group
@@ -712,70 +715,70 @@ type PatchRolesItemEntitlementsJSONRequestBody = RoleEntitlementsPatchRequestBod
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xdW3PcKBb+KxS7TynF7exkX/ppPUkm49mM7XKc2oeMK0VLdDdjCTSA7PS4+r9vAUJX",
-	"kOS+OLZbL3Z3i8vh8PGdAxzQPQxZkjKKqRRweg9TxFGCJeb62y8klphfqN/U1wiLkJNUEkbhFJ4AITmh",
-	"CyAZmOuEgGORxVKA2QoGkKhEf2WYqy8UJRhOoUkHAyjCJU6QKlSuUvXElAXX6wBeoAWhSNVyhr/LK3aD",
-	"abv2qyUGIaOS0EwnBVKlU7JwLDnBtxjIJQYUf5dAYAnY3ErnEY0WdQ2V7gItsFswjkPGI8Dmc1W1kSnj",
-	"tNDPnLPEI0aqCq1KkBBKkiyB0zeBlYZQiReYN8T5TP72iEOzZIa5UYESTFRESk23pYwK7BFJqIJrIqHv",
-	"uUjHx0G3gOsA2tI1on5G0SX+K8NCqm+qAzHVH1GaxiTUDZn8KZjucfwdJWmsG/UtJvRGl6D6Sf1fcjyH",
-	"U6iV8C3BEhn4qi45DozM6oNkEsVwerwOYIRUoq/XAUywEDqlkgfwXKAAColkJuD07bFKXzb4n6auf0zK",
-	"wTIxT8Xk0ipPN7aufFW6be46gGdM/sIyGj2Npp8xCeZanGrD3+6k4WXZ6wB+oSiTS8bJ3/iJNL0mUbX1",
-	"b3bS+lrx+ukcZbF8Km3H31McShwBzDnjlfb/e0ewb1WxLorVDTrJ5BJTmTf+grNbEmGuW8NZirkkhixI",
-	"5KBgS0sublYjmXCFsq8q83VBSGz2Jw71GHTXLdqVG93dQyJxIvq04WnRuhAAcY5WLRl1HS4p36EUzUhM",
-	"rDA5LgScfrWSfb2HmEYpIwpNcEIiVb9Or3pbLlmkUsOPH67g9fp6fR1s075CntUO2rRqK7tsiaO/i9ZU",
-	"hMVUWRzTvABenH9W/95/+PTh6oP6fnL17teKEGVZnaIXUpR1uhryQSl61eoWhVaYZUQxSp5HjXbO4lhB",
-	"QXVAzbnS6XPJHJJWBdMPAx+kjTz6b4yTnF2a+i0efjP5HXrWiVbfPMOreO7J39JlmbhedNCWZlCrTiVO",
-	"OlvWB+K2npxC589cMn3E0sMfBR0qYo/j87mGxDACDTbhFgHX10aiKlfsUYwaJdm6K8rctu4t2MnRsZuR",
-	"VN6qj5xl6Qtu2mlhK/aIl7KSeuWXLN5rvbr8epX7rM5UUNT3o1Sb/7R6mai1rftBvbl6DJpv1dWS4nFH",
-	"ziUWLOPhfmu0dZS1shi/TAw/Zu8pFO94OqVTOX2iprG8QDJcWmdtWCPdvl67A1la9f1RpFxtjhN2ix3O",
-	"fqMBLPX1jbMB+bLNzyxyTFdSlQKLwVjq0FEfqGxVXtWXxqCm+GbX42LS0gLANlotCg7cCnYLuXvlurSw",
-	"tWr1kOrQ6oMUF0DO4gEDTafq1mYp1+4V2Wjz1jrcdmXFcNnGiw4VV2k7OawR3loUR0ehKMLRz80VBchu",
-	"aiWVQApV1rmaEHom6gkisfPJnHAhz3wT/EXRYc11/MBnPP5khGL3oxgJ+YktCPU+9QqSYp4QIQijHmm4",
-	"NnbOR8ajaOoSf5eYUxTrLY78Yy+5GT0WRQZFR3V173M2hd427JRnujW1DePU5wkdzL2wHtJOjaEp1cvd",
-	"Dun2otdm63ehUf8iPQpDnEpxwVmSyjNGqyN6xliMEVUFoTBkGZWfCL0hdHFO45U7XRgTBfr3zs4xDz/j",
-	"kGP3UnFEBJrF2Ep9SufMXQ2mKl3kfujhOuvrvFMNcZOPd+2U44hwHMov3E3MQjKO9fazcMtUSXCJUaSk",
-	"9yRc0fB3FuEqjEmSMi7dC+I8E/JDw2AUxa0HQGJXlnX7XZPaRPlp+W1t0fYy9Hfovdm5uWfJfTVs/twx",
-	"nOxYqZppdCcmOHt9h4UbrSniAxb6C9Ede4J5vXZLorPp2yK7lGNTRFfXC+qClNvDQ1YPPunE1X3jIbl+",
-	"V2nXlc1jJ3GZveN7V3BKtY15QitCYFtQFt+lgE+2tXUt2K3xwTo4Uxlaaxvqx97az/K66hKYTfk+ctCp",
-	"umr43W7nN2igpvWKoVFPisiodqfkoUDtfHlwQH9vqRKcAudk6N2FG05ajbW+9igJ9rRk1ay4b1PRsxM6",
-	"nAF5hUvbMvfJ9+ymEU75d2rv/BrayuTZWeU2nK/Gx4Z8r5KR3GUNGZUo1PDLp/Mwzm7w0R0WMV69XrI4",
-	"xqv/hIgySkIUH4U6ojCP2PuU3WDwP5PyV50StoJ0rpYYzFkcsztCF0CkODRLCoRRwDIZE4qFDqE8uTgF",
-	"VngwZ1z/+MvHE4CihFAiJDeZ5lzHNkVAMqDn2CiU4I7IJUAUnKeYqjyEColoiIFccpYtlgCBlLMoC6VQ",
-	"FR2BqyURgAiVB9+y+LYtHBKA43ls4osI1eLcYi7UMxPpePQHhQHU6IBT+M7qqBDipC74hREAvGNJiiQx",
-	"MSpKGhjAvGA4hcdHx0dvjs0UEVOUEjiFPx29OTqGio3lUiNjgmqb9XqqaaYqTeUTAWy4CYiJkAKgOAb5",
-	"tETpxPjWpikKjbrA0whO21EIsB5a4qGGMsmkETTq21pw5tBRrw/KUUbxrq8b4aD/Oj4eEBU3LCKtc7/O",
-	"EaV2/l/VmW+NBK6CC0knlahVneVNf5ZmDODb47f9mYoA0XrQYHcmm1AH2WVJgvhKUQAREoSMzskiUwO3",
-	"DswKwNRIQQvjfddRpag8ZcIB33e2XIAAxXe+wo9a0L1goo1dXrcMOwFDe1JZ52DJM7zeIxjd9R8SAB+A",
-	"ES/+1kGTUSdpddVhALeKJcviyEa7I821gM1t/QLcUHanzw0oOyJWQuIk0GYun5eC8xuJAvCRsUWMA/CR",
-	"yF+zGcAyPPojOz7+KZxxMNGf8B/01aur8/fnr15NwWvwWRutlS42r12Z+yF8Xq6sjMRuiL0v6u7gRtel",
-	"RpRx0CykRZamjGuvKGefgTTvGGb3JFqboRVj6ThWcqnnCMpL84zrwvbon9uW4L0uuN6v2oF3A+mw+vbB",
-	"uu2w4E6O/IglQEAQuojxcOvdGogdHTZa0Z1gYWhHdblwdQuiT3ipCUs5XSQRbPpGXWfgrgOYZg5QfUkj",
-	"JLfhhIvMh6/RQXx50N4ALp0WLGycmRngHN6ROAYzDDKBIzAzvlp1GSNSwyYhFIO7JQmX4MspwPmKk3Us",
-	"Z7iYtJdLGglKU0IXR+AkjgG6RSRWKYp6q5mV8cYRWGLlKMeMLsySiZKkzJifRnEyci0uf79emPOkgQe3",
-	"vd5KqQyi3GylVNsJxKwFVTq81remu5tLzp7uxqDZ5OK4q/bHDQasg77E4LfP52cgHxnCADJhEY6dyq+u",
-	"QT4fZ70/W/Xg9759e2e470Ea+vrwKLUCCDWwnDOeIFkdGLVR0B4YE47uOgeHxN/lJI0R6RsWHN0NHhWX",
-	"6K4xMHrwU0pRR07T8xgxUWICCd0nSnU9gCjD+vxzgTgGJpmzQ/NIzpHgNiK4xqmVw5zD1ABmwZojs2Oh",
-	"mWPtI+oVRJ3avaZcAHQfU4U8BPlx5weVSg9q1djZ4S28lLQ2eKXKBx+zEGUANC5A1RagOjpgyLqSR+EF",
-	"I+579WikXk9/uOj3sReJvGyeNdExEvpLWOUZTubDZvZ6f9vEVNf9YuUw69LAEoke9nme0/fHcFfHSfnq",
-	"QSB7LEpFMlw6ruKLIsA44NZuO0VmkzlnSQfzqrK9Y+NhPFzGdOvTbSc0Mj6FBmKh3hNabLKzOZgxEyqG",
-	"ogggGtnWFELCAN6iOMO1eMGvrWDN9lU31Z9eq59eo8aVNHmS1Wv1rfq0WsDK5s1PCeloSTWGNxBg1inA",
-	"rFOAWSFAHqi5vl6vB9/b1X/aed2+te8AfeANh1SvcSO1A6leJ1oRTJlUDQ80yJ8+rV4DNtqzSceVNwe7",
-	"nOjF1VMyYhUhH2q5amPg6dqt8k6G4qM2PTXb4ko0g9vyf8d1DMNnRYdrDbqx2WsCisPrneyvUw0nfnN2",
-	"YeT8CufXb9w5WLp3AelpTVeUhMVIKqZWvTxvIf90Kb6gcnuIWP/TU4j7GoXXn882oHT3weKRzYf49n78",
-	"Obl8oAtvd23L5E4Kf44e+9PaXx19+y7AWQhXUOvfbz3RBFfEj7s3W7fwrx8WG/mjYjIPDz6Ofnfipk5/",
-	"Dzgl4EeU2X8tMTXuwTYOAfR2ypC9WL/+awT6WAH9B74TO6BLf0DUfgfrZy6MjMT/koLwN+H+B2zVtrbP",
-	"ijNqvm3aOuLGrdqO8+7jbu1qMM4ek2+HLH9UBC5XEzvJWN910jU4xr3al7FXO+g6znG7drXJmBps4nqi",
-	"5zXpmDR1uiECIJDg/M17AyzccwuyfyTbdughnA8A2FMzbTVx7Tj0HTNxmLUNo/of06DlFwmb/+3t2/rj",
-	"rTZue24PHs3A6qH4G2wCujds9QA1m2xICLKgOLLXyTxg1WXcv3WR/4Fv4Q6E1rPgfd2MQbQ/7uv6LnUe",
-	"CX8Dwi+A5+V7Xr3vuTMox26xlVczFHndJ6GLkp/T3q7rJeBGqVfmdZ4lfh0nylcpLg4rryovh9cvhXdQ",
-	"yj7tSPslZgd/iNwDXTs4yrGQj41BwWq2cA/J29efjREOG8J4jGRzoqwArQbXwGPkKrE7sGEzx2Pg+9L1",
-	"vdC739ba5lLqQz5bblHQhFDBeb3BDSZwIQ8f88U1aEiNIQ1a/y2FtYdvfyCDW9mWI/cdv1CO4oONXfB3",
-	"3uOfIfdQedYAw/Nh8xF73vPjwwh7WESCdShqm8U6Qr6fXsZABI+DOgYhrAZB65GIcxcnxT38qpeiPONh",
-	"jD14GbEHve/wGdcfVxuPJ5cNE3doscD8yA6NAdfX8sq1qtVLVM9TTE8uTvV7c4L86trQXjir77qdMw4i",
-	"PMsWC0IXAZhxdif0J5UtIiJkt5ivAv2ag9b4/2wk/U3kb+/YwqwMuuDRe5VstZ0ACYDyWzJJXcv6fXM5",
-	"9jG/tTRbryiNUYiXLI4whwHMeAyncCllKqaTSeXZUciSye0bbVDz8lsUS8se0ncIq4czszhdvcdWcVn+",
-	"fqWS6GsX3SrScOw1ojhuXpmcXxBcLu6VJTbuSm6XeQJCFsc4NG9+qh4fqdqf4rf+AhZ22z7PnH/vz8jz",
-	"9Zc8n/nanw3XLVCVKO2vA+qurNTb+ouf1tfr/wcAAP//g/SxrimVAAA=",
+	"H4sIAAAAAAAC/+xdT3PbuJL/KijunqYYy9mXvfi0nkwm47cZ2+U4tYeMKwWRLQljEuADQDt6KX33LQAE",
+	"/wIkLcmObfGSWCIINBq//nUDaEA/goilGaNApQhOfgQZ5jgFCVx/+p0kEvil+k59jEFEnGSSMBqcBKdI",
+	"SE7oEkmGFrog4iDyRAo0XwdhQFShf+XA1QeKUwhOAlMuCAMRrSDFqlK5ztQTU1ew2YTBJV4SilUr5/Bd",
+	"XrNboN3Wr1eAIkYlobkuiqQqp2ThIDmBO0ByBYjCd4kESMQWVjqPaLRsa6x0l3gJbsE4RIzHiC0Wqmkj",
+	"U85pqZ8FZ6lHjExVWpcgJZSkeRqcvA2tNIRKWAJvifOZ/NsjDs3TOXCjAiWYqImUmWHLGBXgEUmoihsi",
+	"4e+FSMfHYb+AmzCwtWtE/YrjK/hXDkKqT2oAgeo/cZYlJNIdmf0tmB5x+I7TLNGd+pYQeqtrUOOk/l9x",
+	"WAQngVbCtxQkNvBVQ3IcGpnVH5JJnAQnx5swiLEq9PUmDFIQQpdU8iBeCBQGQmKZi+Dk3bEqX3X4P01b",
+	"/zGrjGVmnorZlVWe7mxT+ap2291NGJwz+TvLafw8un7OJFpoceodf7eXjld1b8LgC8W5XDFO/g3PpOsN",
+	"ieq9f7uX3jeq108XOE/kc+k7fM8gkhAj4JzxWv//e0+w7zSxKavVHTq9wyTB8wTOYqCSyPUlZ3ckBq47",
+	"xFkGXBLDFyR2sLBlJhc9K2MmXAHtq3r5puQkNv8bIm2G3uZFt32jwR8BkZCKIZ34+7UpxcCc43VHUt2M",
+	"S9b3OMNzkhArTwEQEZx8tcJ9/REAjTNGFKyCGTFtq/Jq2OWKxap08PHDdXCzudnchLt0sZRnvYc+rbv6",
+	"rnriGPWyNzVhgSrXY7oXBpcXn9V/v3349OH6g/p8ev3+j5oQVV29opdSVG26OvJBD3JnWBRmgzwnilqK",
+	"d5TZc5YkCgqdAfBg3HwxhHH9NPRB3Uio/00gLYinrfHy4TdPk6EptP7mMbvy+TiR64WbVYddaUb16kxC",
+	"2tuzIVh39eQUunjmkukjSD+vlGSpaD9JLhYaJ+PoNdySc0SwuTFy1TnkESVpUJVtu6bSXdvegbUcw7sd",
+	"eRW9+shZnr3irp2VPuQR8VI10mz8iiWP2q6uv9nkYzZnGijb+1mqtfTwOlFre/eTRvNJmN5P8PbJ01rO",
+	"FQiW8+hxW7RtVK2yBF4nhp9y9BSK9zzZ0qWckVHbWV5iGa1syDauk+6IrzuALKvPCXCsQnAOKbsDxySg",
+	"1QGW+cbG2YFiXedXFjumMZkqAWI0lnp0NAQq25RX9ZUzaCi+PfRQTmY6ANhFq2XFoVvBbiH3r1yXFnZW",
+	"rTapHq0+SHFhwFkywtB0qX5tVnLtX5GtPu+sw10XXQyXbb0YUQuVdpPDOuGdRXEMFI5jiH9trzQE7LZR",
+	"UwWkSL26IBGWnul6iknifLIgXMhz3zR/WQ5Ye6E/9DmPvxmh4H6UYCE/sSWh3qdeQTLgKRGCMOqRhmtn",
+	"53xkIoq2LuG7BE5xovdAij8Hyc3osawyLAeqb3hfsiv09mGvPNOvqV0YpzlP6GHupY2Q9uoMTa1e7nZI",
+	"9yh6bfd+Hxr1L+HjKIJMikvO0kyeM1q36DljCWCqKsJRxHIqPxF6S+jygiZrd7koIQr0vzkHxzz8DBEH",
+	"9xJyTER9seyMLpi7GaCqXOx+6OE6G+u8Vx1xk493BZVDTDhE8gt3E7OQjIPenxZumWoFrgDHSnpPwTWN",
+	"/mQx1GFM0oxx6V4o57mQH1oOo6xuMwIS+/Ksu++mNCbKzytu64r2KKa/x+jNzs09C+/rcfPnHnOytlJ3",
+	"0/hezCB/cw/CjdYM8xHL/aXojh3Dol27MdHb9V2RXcmxLaLr6wVNQar94zGrB5904frG8pi3/lRlN7Xd",
+	"ZSdxmc3lH67slXofi4JWhND2oKq+TwGfbG+bWrB756N1cK5e6KxtqC8HWz8v2mpKYHbth8hBl+pr4U+7",
+	"39+igYbWa45GPSlTp7qDUuQKdd8rsgeGR0vV4BS4IEPvXtx40mqt9XWtJHykJat2w0Nbi5790PEMyGtc",
+	"2pV5SL4XN41wyr9Xf+fX0E4uz84qd+F8ZR9b8r0qRoqQNWJU4kjDr5jOB0l+C0f3IBJYv1mxJIH1/0SY",
+	"MkoinBxFOuWwSOn7lN8C+j9T8g9dMuhk8VyvAC1YkrB7QpdIZBCZJQXCKGK5TAgFoXMsTy/PkBUeLRjX",
+	"X/7+8RThOCWUCMnNSwuuk59iJBnSc2wcSXRP5Aphii4yoOodQoXENAIkV5zlyxXCKOMsziMpVENH6HpF",
+	"BCJCvQN3LLnrCocF4rBITAISoVqcO+BCPTOpkEd/0SAMNDqCk+C91VEpxGlT8EsjAHrP0gxLYnJXlDRB",
+	"GBQVByfB8dHx0dtjM0UEijMSnAT/OHp7dBwoNpYrjYwZzuVKsYORVU81zVSlrXwikE1DQQkRUiCcJKiY",
+	"liidmNjadEWhUVd4Fgcnzo0pLUSV2+thh6rIrJVY6ttdcL6hM2Mf9EaV6bu5aaWM/tfx8YjMuXFZa71b",
+	"do5Mtov/VeP5zkjgqriUdFbLbNWvvB1+pZ0n+O743fBLZRJpM7Gw/yVbUCfi5WmK+VqxABESRYwuyDJX",
+	"ttvEZg1jyljw0gTgTfwqNs+YcCD4va0XYUTh3lf5UQe9l0w44cub/mEveOhOLZtMLHkOm0fEo7v9Q8Lg",
+	"A2DiheAmbPPqLKuvPYxgWLFieRLbpHisGRexhW1foFvK7vXxAuVNxFpISEPt7IrZKbq4lThEHxlbJhCi",
+	"j0T+kc8RyOjor/z4+B/RnKOZ/gv+or/8cn3x28Uvv5ygN+izdl1rXW3RunL6blbvSfaa6N3Q+4gkvIOz",
+	"sSuNKxOsWWCLPMsY1xFSoaiRfO8wth8k3hgDS0A6zqBc6fmCitg81l06If111yX8pivujKiO591wOqzh",
+	"fbB6e7y5kyw/gkQYCUKXCYz35K5oq2fMJo+6FziMHau+iK7pSvShMDWFqSaQJA7acVLfsbmbMMhyB66+",
+	"ZDGWuzDDZd4DsSlefH3o3gIxva4sah2wGREr3pMkQXNAuYAYzU3oVl/biJXlpIQCul+RaIW+nCEolqFs",
+	"nDmHciZfrXOkOMsIXR6h0yRB2MYxZbv1l5UXhxitQMXNCaNLs46iJKleLI6uOHm5kaz/uBGZ8/iBB7eD",
+	"YUulDKKibqVUOwjELBDVBrwxtma42+vQnuEG1O5yeUhWh+cGAzZeXwH65+eLc1RYhjCATFkMiVP59YXJ",
+	"lxO4D79WPy7+2HG+Mwf4IH190zwqrSBCDSwXjKdY1g2jYQVdw5hxfN9rHBK+y1mWYDJkFhzfj7aKK3zf",
+	"MowB/FRSNJHTDj4mTFSYwEKPiVLdACCqXD//jCBJkCnmHNAivXMiuK0IrnWU5TCnMQ2AWbAWyOxZeuag",
+	"Y0S9oKhLu1eZS4A+xlShyEt+2vlBrdGDWkR2DngHLxWtjV6y8sHHrEgZAE3LUI1lqJ4BGLO65FF4yYiP",
+	"vYA0Ua9nPFz0+9TrRF42z9vomAj9NazyjCfzcTN7veNtEq2bcbEKmHVtaIXFAPu8zOn7U4Sr06R8/SCQ",
+	"PRWlYhmtHBf4xTFiHHHrt50is9mCs7SHeVXdXtt4GA9Xid76yNspjU1MoYFYqveUlnvubIHmzOSP4ThG",
+	"mMa2N6WQQRjc4SSHRhLh104GZ/cWnPpXb9RXb3DrtpqiyPqN+lR/Wq9gbd8tjg7pFEplw1sIMO8VYN4r",
+	"wLwUoMje3NxsNqNv+xo+Ar3p3vV3gDHwliY16NxI45SqN4hWBFMVVeaBR8XTZ/U7wyZ/Nuu5B+dglxO9",
+	"uHpOTqwm5EM9V8MGnq/fqi5qKP/UrqfhW1yF5sGu/N9zR8P4WdHheoN+bA66gPJEey/761Ljid8caJg4",
+	"v8b5zWt4DpbuXUB6XtMVJWFpSeXUapDnLeSfL8WXVG5PFuv/9BTiR4PCm8/nW1C6+7TxxOZjYns//pxc",
+	"PjKEt7u2VfG+vMoXFbE/r/3VKbbvA5yFcA21/v3WU01wZSJ575GebeLrh+VG/qyczMODj2Pcnbhp0t8D",
+	"jgv4EdU4EUBg2oNtHwUYHJQxe7F+/TcI9Kly+g98J3bEkP6ExP0e1s9dGJmI/zUl4W/D/Q/Yqu1sn5WH",
+	"1XzbtE3ETVu1PSfgp93a9WicPSXfjln+qAlcrSb2krG+AKXPOKa92texVzvqjs5pu3a9jU2NdnED2fOa",
+	"dEyZJt0QgTBKofi9vhEe7qUl2T+Rbzv0FM4HAOy5ubaGuNYOfcdMHG5ty6z+p3Roxe3C5v/u9m3z8U4b",
+	"twNXCk9uYP1Q/I12Af0bttpAzSYbFoIsKcT2dpkHrLpM+7cu8j/wLdyR0HoRvK+7MYr2p31d303PE+Fv",
+	"Qfgl8Lx8z+uXQPcm5dgttupqhvJd90nosuaXtLfr+ulwo9Rr80ufFX4dJ8rXGZSHlde1n5TXPyXvoJTH",
+	"9CPdXzY7+EPkHuha46hsobCNUclqtnIPydvfRJsyHLaE8ZTJ5kRZCVoNrpHHyFVhd2LDdoHHyF9Z15dF",
+	"739ba5ebqg/5bLlFQRtCJecNJjeYxIUifcyX16AhNaU0aP13FNY13+FEBreyLUc+dv5CZcUHm7vgH7yn",
+	"P0PuofK8BYaXw+YT9rznx8cR9riMBBtQNDaLdYb8ML1MiQieAHVKQliPgtYTEec+Top7+FUvRXnsYco9",
+	"eB25B4M/7DOtP663tieXDxP3eLkEfmRNY8T1tbx2rWr9EtWLDOjp5Zn+MZ2wuLo2shfO6rtuF4yjGOb5",
+	"cknoMkRzzu6F/ku9FhMRsTvg61D/6kHH/j8bSf8ptK3t5FZGXfDovUq23k+EBcLFLZmkqWX9I3QF9oHf",
+	"WZptNpQlOIIVS2LgQRjkPAlOgpWUmTiZzWrPjiKWzu7eaoda1N+hWFqNkL5DWD2cm8Xp+j22isuKH12q",
+	"iL5x0a0iDcdeI06S9pXJxQXB1eJeVWPrruRunacoYkkCkfk5qPrxkbr/Kb8brmBpt+2Ll4vPwy/yYv2l",
+	"eM98HH4Nmh6oTpT22xFt11bqbfvlV5ubzf8HAAD//66gBPhflQAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/rebac-admin-backend/v1/resources/generated_types.go
+++ b/rebac-admin-backend/v1/resources/generated_types.go
@@ -70,6 +70,17 @@ const (
 	Remove RoleEntitlementsPatchItemOp = "remove"
 )
 
+// AuthenticationProvider defines model for AuthenticationProvider.
+type AuthenticationProvider struct {
+	Id   string  `json:"id"`
+	Name *string `json:"name,omitempty"`
+}
+
+// AuthenticationProviders defines model for AuthenticationProviders.
+type AuthenticationProviders struct {
+	Data []AuthenticationProvider `json:"data"`
+}
+
 // Capabilities defines model for Capabilities.
 type Capabilities struct {
 	Data []Capability `json:"data"`
@@ -97,6 +108,15 @@ type EntityEntitlement struct {
 // EntityEntitlementItem defines model for EntityEntitlementItem.
 type EntityEntitlementItem struct {
 	Entitlement EntityEntitlement `json:"entitlement"`
+}
+
+// GetAuthenticationProvidersResponse defines model for GetAuthenticationProvidersResponse.
+type GetAuthenticationProvidersResponse struct {
+	Links   ResponseLinks            `json:"_links"`
+	Meta    ResponseMeta             `json:"_meta"`
+	Data    []AuthenticationProvider `json:"data"`
+	Message string                   `json:"message"`
+	Status  int                      `json:"status"`
 }
 
 // GetCapabilitiesResponse defines model for GetCapabilitiesResponse.
@@ -182,14 +202,11 @@ type GetIdentityGroupsResponse struct {
 
 // GetIdentityProvidersResponse defines model for GetIdentityProvidersResponse.
 type GetIdentityProvidersResponse struct {
-	Links ResponseLinks `json:"_links"`
-	Meta  ResponseMeta  `json:"_meta"`
-	Data  []struct {
-		Id   string `json:"id"`
-		Name string `json:"name"`
-	} `json:"data"`
-	Message string `json:"message"`
-	Status  int    `json:"status"`
+	Links   ResponseLinks      `json:"_links"`
+	Meta    ResponseMeta       `json:"_meta"`
+	Data    []IdentityProvider `json:"data"`
+	Message string             `json:"message"`
+	Status  int                `json:"status"`
 }
 
 // GetIdentityRolesResponse defines model for GetIdentityRolesResponse.
@@ -350,6 +367,11 @@ type IdentityProvider struct {
 
 // IdentityProviderSyncMode defines model for IdentityProvider.SyncMode.
 type IdentityProviderSyncMode string
+
+// IdentityProviders defines model for IdentityProviders.
+type IdentityProviders struct {
+	Data []IdentityProvider `json:"data"`
+}
 
 // IdentityRolesPatchItem defines model for IdentityRolesPatchItem.
 type IdentityRolesPatchItem struct {
@@ -690,70 +712,70 @@ type PatchRolesItemEntitlementsJSONRequestBody = RoleEntitlementsPatchRequestBod
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xdS3PbOBL+KyjsnlKM5exkLzqtJ8l4PJuxXY5Te8i4UhAJSRiTAAcA7Whc+u9bAAg+",
-	"AZLWw7EjXmxJxKPR6P66gW6ADzBkScooplLA6QNMEUcJlpjrb7+QWGJ+qX5TXyMsQk5SSRiFU3gChOSE",
-	"LoBkYK4LAo5FFksBZisYQKIK/ZVhrr5QlGA4haYcDKAIlzhBqlG5StUT0xZcrwN4iRaEItXLOf4mr9kt",
-	"pu3er5cYhIxKQjNdFEhVTtHCseQE32EglxhQ/E0CgSVgc0udhzRa9DWUuku0wG7COA4ZjwCbz1XXhqaM",
-	"04I/c84SDxmparRKQUIoSbIETt8ElhpCJV5g3iDnE/nbQw7NkhnmhgWKMFEhKTXTljIqsIckoRqukYS+",
-	"5SQdHwfdBK4DaFvXEvUziq7wXxkWUn1TE4ip/ojSNCahHsjkT8H0jONvKEljPaivMaG3ugU1T+r/kuM5",
-	"nELNhK8JlsiIr5qS48DQrD5IJlEMp8frAEZIFfpyE8AEC6FLKnoAzwkKoJBIZgJO3x6r8uWA/2n6+sek",
-	"VJaJeSomV5Z5erB15qvW7XDXATxn8heW0eh5DP2cSTDX5FQH/nYnAy/bXgfwM0WZXDJO/sbPZOg1iqqj",
-	"f7OT0dea10/nKIvlcxk7/pbiUOIIYM4Zr4z/3zsS+1YX66JZPaB3KEUzEhNJDCjkoxZw+uXB0vwAMY1S",
-	"RhSv4IREmEpTXo1FLlmkSsPTD9fwZn2zvglgylmKuW3StPIAicSJ6BtLQc9KzVaOYYhztIIGwP7KCFey",
-	"+8W0e1MUYrM/cah1u9KGmpUaMeVIWgalMpoKsZgqPDXDC+DlxSf17/2Hjx+uP6jvJ9fvfq0QUbbVSXpB",
-	"RdmnayAfFKNXrWkhEZzCLCNKX/I6SpY5i2MF9GoCaq6DLp9T5qC0Sph+GKgafnr03xgnue40+Vs8/Grq",
-	"O/isC62+Gpvmf+6p3+JlWbjedNCmZtCoziROOkfWJ8RtPjmJzp+5aDrFsqqZhYYrrIrji7mWg2GYEAxU",
-	"ODXM9Y3pu0L6tn1vgQUONm4GCfmoTjnL0h94aGcFMu9RXspO6p1fsXiv/er2613uszvTQdHf92Jt/tPq",
-	"x5RaO7rvNJurS87uSIT5nllaf0wip83zGMMGP7XN10VdVmMHU/G0anyFBct4uN8ebR9lryzGP6ZCPeXs",
-	"KZXasXR7BbtluS+RDJfWTxs2SLeb155AllbdfhQpjeM4YXfY4ec3BsBS39w4B5DvR/zMIsdKJVUlsBgs",
-	"Sx086hMq25WX9aVlqjG+OfW4WK+0BGAbrhYNB24Gu4ncPXNdXNiatVqlOrj6KMYFkLN4gKLpUt3cLOna",
-	"PSMbY96ahw4r+ygYNli28X5DxW/bjg5rhLcmxTFRKIpw9HNzMwGy21pLpSCFquqchEh61ugJIrHzyZxw",
-	"Ic99a/tFMWHNDerAZzz+ZIRi96MYCfmRLQj1PvUSkmKeECEIox5quDZ2zkfGo2jyEn+TmFMU6737/GMv",
-	"uBk+Fk0GxUR1Te9LNoXeMewUZ7o5tQ3i1BctHci9sB7STo2hadWL3Q7q9sLX5uh3wVG7HHOAVxjiVIpL",
-	"zpJUnjNa1egZYzFGVDWEwpBlVH4k9JbQxQWNV+5yYUyU0L93To55+AmHHLt3iSMi0CzGluozOmfubjBV",
-	"5SL3Qw/WWV/nnRqIG3y826YcR4TjUH7mbmAWknGs46rCTVOlwBVGkaLeU3BFw99ZhKtiTJKUceneC+eZ",
-	"kB8aBqNobt0hEs/QO2qTthcF26GPZFfAnj3t1bBVaofQWomsGkN0LyY4e32PhVsmUsQH7KQXpPs3Quye",
-	"f+fQt/XMSjo29cyqq/I6IWV0ccga/aMuXA07Dqn1uyq7rsQenfBgQo8PrtyG6hjzgpaEwI6gbL6LAR/t",
-	"aOtcsJHVwTw4VxVaOwjqx97ez/O+6hSYmG4fOOhSXT38bqPBDRiocb0C5+pJkVjTnpQ8k6RdL48t98+W",
-	"asFJcA6G3jDXcNBq7Ki1tSTY08ZQs+O+qJ0n1DgcAXkFS9s099H34px1J/07tXd+Dm1l8uzabRvMV/qx",
-	"Id6rYiR3DENGJQq1+OWLZhhnt/joHosYr14vWRzj1X9CRBklIYqPQp2Qlid8fcxuMfifKfmrLglbOR7X",
-	"SwzmLI7ZPaELIFIcmoU7YRSwTMaEYqEz8E4uz4AlHswZ1z/+cnoCUJQQSoTkptKc69SYCEgG9EoWhRLc",
-	"E7kEiIKLFFNVh1AhEQ0xkEvOssUSIJByFmWhFKqjI3C9JAIQoergOxbftYlDAnA8j016CqGanDvM1Zo8",
-	"T5Q7+oPCAGrpgFP4zvKoIOKkTvilIQC8Y0mKJDFJIIoaGMC8YTiFx0fHR2+OzUIMU5QSOIU/Hb05OoYK",
-	"jeVSS8YEZXKp0MHQqhd0ZkHQZD4RwOZzgJgIKQCKY5A7/4onJsZkhqKkUTd4FsEpPMXypN5NPXfDAw1l",
-	"kUkj59C3ge+soZMmH1WjTAJd3zSyCf91fDwgqWpYQlNniM6R5HTxXzWZbw0FroYLSieVpEdd5U1/lWYK",
-	"2dvjt/2VivzCes5ZdyVbUOdoZUmC+EpBABEShIzOySJTilsXzIqAKU1BC+N916VKQXnKhEN839l2AQIU",
-	"3/saP2qJ7iUTbdnldcuwE2Fo7Q6s6xgseYbXexRGd/+HJICPkBGv/K2DJqJOCsEdiK1iybI4ssnSSGMt",
-	"YHPbvwC3lN3rtHNlR8RKSJwE2szl61JwcStRAE4ZW8Q4AKdE/prNAJbh0R/Z8fFP4YyDif6E/6CvXl1f",
-	"vL949WoKXoNP2mitdLN578rcD8HzAr4OB9h3H0HfUZ7DoantlRZV4/lZXRFZmjKu3a0c1gbaD4f+PpBo",
-	"bXQ2xtJx3OFKLz6U++cBjMKo6Z/bJua9briuUHpl4JbQw5rbR/O2wzVwgu8plgABQegixsPdghYCdkzY",
-	"aJ53IgtDJ6rLN6ybJn3ySK2EynUoiWDT6eo6m3UTwDRzCNXnNEJyG0y4zHzy9aw8z0OSvw3mtNPMhI0j",
-	"KQNcw3sSx2CGQSZwBGbGU6tuYkRKthNCMbhfknAJPp8BnO83Wbdyhosle7mhkaA0JXRxBE7iGKA7RGJV",
-	"oui3WllZWByBJVZucszowmyYKErKivlhDyds1hLx97u4dh4t8OBmr0tRMoMoJ1sx1U4CMTtBlQmvza2Z",
-	"7uaGs2e6MWgOuTgrqb1xIwPWPV9i8Nuni3OQa4YwApmwCMdO5ld3IF+Oq95frXpqeN9bNs6U2oO0xnX1",
-	"KLkCCDViOWc8QbKqGDUtaCvGhKP7TuWQ+JucpDEifWrB0f1grbhC9w3F6JGfkoq65DTdg1EmSplAQs+J",
-	"Yl2PQJSpc36HPY6BKeac0DxbcgS4jQCucUzlMBcaNQGzwppLZsc2M8faR9T7h7q0e0e5ENB9+PN5mu/T",
-	"bh9XOj2oPWPnhLfkpYS1wdtJPvExu0VGgMZdotouUccEDNn88TC8QMR9b/GM0OuZDxf8PvVOjhfNs6Z0",
-	"jID+I+zyDAfzYSt7Hd02ect1v1g5zLo1sESiB31e5vL9KdzVcVG+epSQPRWkIhkuHfe4RRFgHHBrt50k",
-	"s8mcs6QDeVXbXt14HA6XGd36BNkJjYxPoQWxYO8JLULsbA5mzCSKoSgCiEZ2NAWRMIB3KM5wLVvwSytV",
-	"s32TTPWn1+qn16hx40teZPVafas+rTawsnXzkzg6V1Lp8AYEzDoJmHUSMCsIyNM08xj1I8xQZ2rmun3l",
-	"2wH6wBuqVK9xI7VDn14nWgFMWVSpBxrkT59Vb9ka7dmk446bg91O9MrVczJiFSIfa7lqOvB87VZ570Hx",
-	"UZuemm1xFZrBbfG/48qDMVbdbw26ZbPXBBQHxDvRX5caDvzm5MKI+RXMr99qc7Bw7xKk57VcURQWmlQs",
-	"rXpx3or884X4AsrtEWL9Ty8hHmoQXn8+2wDS3ceKRzQf4tv75c+J5QNdeBu1LYs7IfwleuzPK746+vZd",
-	"AmdFuCK1/njriQa4IsnbHWzdwr9+XALl9zqyc3ji45h3p9zU4e8Rqfx+iTLx11KmxhhsI1O/d1KGxGL9",
-	"/K8B6FNl3R94JHbAlH6H1PoO1M9cMjIC/4+UhL8J9j8iVNsKnxUHyXxh2rrEjaHajtPuY7R2NVjOnhJv",
-	"h2x/VAgudxM7wVjfdNKlHGOs9seI1Q668nIM16420anBJq4ne16DjilThxsiAAIJzl/bNsDCvbQk+yey",
-	"bYeewvkIAXtupq1GrtVD3zETh1nbMKv/KQ1aflmv+d8O39YfbxW47bmhdzQDq8fK32AT0B2w1QpqgmxI",
-	"CLKgOLKXyTxi12WM37rA/8BDuANF60Xgvh7GINgf47q+K51HwN8A8AvB8+I9r9723JmUY0Ns5dUMRV33",
-	"Seii5ZcU23W9Qdow9dq8LbOUX8eJ8lWKi8PKq8qbxfUbxR2Qsk870n5R2MEfIveIrlWOUhdy3RiUrGYb",
-	"94C8fcXYmOGwoRiPmWxOKSuEVgvXwGPkqrA7sWEzx2Pgy7b1rdC7D2ttcyX1IZ8tt1LQFKEC83qTG0zi",
-	"Qp4+5str0CI1pjRo/rcY1lbf/kQGN7MtRu47f6HU4oPNXfBP3tOfIfdAedYQhpeD5qPsec+PDwPsYRkJ",
-	"1qGoBYt1hnw/vIyJCB4HdUxCWA0SrScCzl2cFPfgq96K8ujDmHvwY+Qe9L7BZ9x/XG2sTy4bJu7RYoH5",
-	"kVWNAdfX8sq1qtVLVC9STE8uz/Rbc4L86trQXjir77qdMw4iPMsWC0IXAZhxdi/0J1UtIiJkd5ivAv2S",
-	"g5b+fzKU/ibyd3dsYVYGXfDovUq2Ok6ABED5LZmkzmX9trlc9jG/szBb7yiNUYiXLI4whwHMeAyncCll",
-	"KqaTSeXZUciSyd0bbVDz9lsQS8sZ0ncIq4czszldvcdWYVn+dqUS6GsX3SrQcMQaURw3r0zOLwguN/fK",
-	"Fht3JbfbPAEhi2Mcmvc+VY+PVO1P8Vt/Awsbts8r59/7K/J8/yWvZ772V8N1C1QFSvvrgL4rO/W2/+Kn",
-	"9c36/wEAAP//XApbXGaTAAA=",
+	"H4sIAAAAAAAC/+xdW3PcKBb+KxS7TynF7exkX/ppPUkm49mM7XKc2oeMK0VLdDdjCTSA7PS4+r9vAUJX",
+	"kOS+OLZbL3Z3i8vh8PGdAxzQPQxZkjKKqRRweg9TxFGCJeb62y8klphfqN/U1wiLkJNUEkbhFJ4AITmh",
+	"CyAZmOuEgGORxVKA2QoGkKhEf2WYqy8UJRhOoUkHAyjCJU6QKlSuUvXElAXX6wBeoAWhSNVyhr/LK3aD",
+	"abv2qyUGIaOS0EwnBVKlU7JwLDnBtxjIJQYUf5dAYAnY3ErnEY0WdQ2V7gItsFswjkPGI8Dmc1W1kSnj",
+	"tNDPnLPEI0aqCq1KkBBKkiyB0zeBlYZQiReYN8T5TP72iEOzZIa5UYESTFRESk23pYwK7BFJqIJrIqHv",
+	"uUjHx0G3gOsA2tI1on5G0SX+K8NCqm+qAzHVH1GaxiTUDZn8KZjucfwdJWmsG/UtJvRGl6D6Sf1fcjyH",
+	"U6iV8C3BEhn4qi45DozM6oNkEsVwerwOYIRUoq/XAUywEDqlkgfwXKAAColkJuD07bFKXzb4n6auf0zK",
+	"wTIxT8Xk0ipPN7aufFW6be46gGdM/sIyGj2Npp8xCeZanGrD3+6k4WXZ6wB+oSiTS8bJ3/iJNL0mUbX1",
+	"b3bS+lrx+ukcZbF8Km3H31McShwBzDnjlfb/e0ewb1WxLorVDTrJ5BJTmTf+grNbEmGuW8NZirkkhixI",
+	"5KBgS0sublYjmXCFsq8q83VBSGz2Jw71GHTXLdqVG93dQyJxIvq04WnRuhAAcY5WLRl1HS4p36EUzUhM",
+	"rDA5LgScfrWSfb2HmEYpIwpNcEIiVb9Or3pbLlmkUsOPH67g9fp6fR1s075CntUO2rRqK7tsiaO/i9ZU",
+	"hMVUWRzTvABenH9W/95/+PTh6oP6fnL17teKEGVZnaIXUpR1uhryQSl61eoWhVaYZUQxSp5HjXbO4lhB",
+	"QXVAzbnS6XPJHJJWBdMPAx+kjTz6b4yTnF2a+i0efjP5HXrWiVbfPMOreO7J39JlmbhedNCWZlCrTiVO",
+	"OlvWB+K2npxC589cMn3E0sMfBR0qYo/j87mGxDACDTbhFgHX10aiKlfsUYwaJdm6K8rctu4t2MnRsZuR",
+	"VN6qj5xl6Qtu2mlhK/aIl7KSeuWXLN5rvbr8epX7rM5UUNT3o1Sb/7R6mai1rftBvbl6DJpv1dWS4nFH",
+	"ziUWLOPhfmu0dZS1shi/TAw/Zu8pFO94OqVTOX2iprG8QDJcWmdtWCPdvl67A1la9f1RpFxtjhN2ix3O",
+	"fqMBLPX1jbMB+bLNzyxyTFdSlQKLwVjq0FEfqGxVXtWXxqCm+GbX42LS0gLANlotCg7cCnYLuXvlurSw",
+	"tWr1kOrQ6oMUF0DO4gEDTafq1mYp1+4V2Wjz1jrcdmXFcNnGiw4VV2k7OawR3loUR0ehKMLRz80VBchu",
+	"aiWVQApV1rmaEHom6gkisfPJnHAhz3wT/EXRYc11/MBnPP5khGL3oxgJ+YktCPU+9QqSYp4QIQijHmm4",
+	"NnbOR8ajaOoSf5eYUxTrLY78Yy+5GT0WRQZFR3V173M2hd427JRnujW1DePU5wkdzL2wHtJOjaEp1cvd",
+	"Dun2otdm63ehUf8iPQpDnEpxwVmSyjNGqyN6xliMEVUFoTBkGZWfCL0hdHFO45U7XRgTBfr3zs4xDz/j",
+	"kGP3UnFEBJrF2Ep9SufMXQ2mKl3kfujhOuvrvFMNcZOPd+2U44hwHMov3E3MQjKO9fazcMtUSXCJUaSk",
+	"9yRc0fB3FuEqjEmSMi7dC+I8E/JDw2AUxa0HQGJXlnX7XZPaRPlp+W1t0fYy9Hfovdm5uWfJfTVs/twx",
+	"nOxYqZppdCcmOHt9h4UbrSniAxb6C9Ede4J5vXZLorPp2yK7lGNTRFfXC+qClNvDQ1YPPunE1X3jIbl+",
+	"V2nXlc1jJ3GZveN7V3BKtY15QitCYFtQFt+lgE+2tXUt2K3xwTo4Uxlaaxvqx97az/K66hKYTfk+ctCp",
+	"umr43W7nN2igpvWKoVFPisiodqfkoUDtfHlwQH9vqRKcAudk6N2FG05ajbW+9igJ9rRk1ay4b1PRsxM6",
+	"nAF5hUvbMvfJ9+ymEU75d2rv/BrayuTZWeU2nK/Gx4Z8r5KR3GUNGZUo1PDLp/Mwzm7w0R0WMV69XrI4",
+	"xqv/hIgySkIUH4U6ojCP2PuU3WDwP5PyV50StoJ0rpYYzFkcsztCF0CkODRLCoRRwDIZE4qFDqE8uTgF",
+	"VngwZ1z/+MvHE4CihFAiJDeZ5lzHNkVAMqDn2CiU4I7IJUAUnKeYqjyEColoiIFccpYtlgCBlLMoC6VQ",
+	"FR2BqyURgAiVB9+y+LYtHBKA43ls4osI1eLcYi7UMxPpePQHhQHU6IBT+M7qqBDipC74hREAvGNJiiQx",
+	"MSpKGhjAvGA4hcdHx0dvjs0UEVOUEjiFPx29OTqGio3lUiNjgmqb9XqqaaYqTeUTAWy4CYiJkAKgOAb5",
+	"tETpxPjWpikKjbrA0whO21EIsB5a4qGGMsmkETTq21pw5tBRrw/KUUbxrq8b4aD/Oj4eEBU3LCKtc7/O",
+	"EaV2/l/VmW+NBK6CC0knlahVneVNf5ZmDODb47f9mYoA0XrQYHcmm1AH2WVJgvhKUQAREoSMzskiUwO3",
+	"DswKwNRIQQvjfddRpag8ZcIB33e2XIAAxXe+wo9a0L1goo1dXrcMOwFDe1JZ52DJM7zeIxjd9R8SAB+A",
+	"ES/+1kGTUSdpddVhALeKJcviyEa7I821gM1t/QLcUHanzw0oOyJWQuIk0GYun5eC8xuJAvCRsUWMA/CR",
+	"yF+zGcAyPPojOz7+KZxxMNGf8B/01aur8/fnr15NwWvwWRutlS42r12Z+yF8Xq6sjMRuiL0v6u7gRtel",
+	"RpRx0CykRZamjGuvKGefgTTvGGb3JFqboRVj6ThWcqnnCMpL84zrwvbon9uW4L0uuN6v2oF3A+mw+vbB",
+	"uu2w4E6O/IglQEAQuojxcOvdGogdHTZa0Z1gYWhHdblwdQuiT3ipCUs5XSQRbPpGXWfgrgOYZg5QfUkj",
+	"JLfhhIvMh6/RQXx50N4ALp0WLGycmRngHN6ROAYzDDKBIzAzvlp1GSNSwyYhFIO7JQmX4MspwPmKk3Us",
+	"Z7iYtJdLGglKU0IXR+AkjgG6RSRWKYp6q5mV8cYRWGLlKMeMLsySiZKkzJifRnEyci0uf79emPOkgQe3",
+	"vd5KqQyi3GylVNsJxKwFVTq81remu5tLzp7uxqDZ5OK4q/bHDQasg77E4LfP52cgHxnCADJhEY6dyq+u",
+	"QT4fZ70/W/Xg9759e2e470Ea+vrwKLUCCDWwnDOeIFkdGLVR0B4YE47uOgeHxN/lJI0R6RsWHN0NHhWX",
+	"6K4xMHrwU0pRR07T8xgxUWICCd0nSnU9gCjD+vxzgTgGJpmzQ/NIzpHgNiK4xqmVw5zD1ABmwZojs2Oh",
+	"mWPtI+oVRJ3avaZcAHQfU4U8BPlx5weVSg9q1djZ4S28lLQ2eKXKBx+zEGUANC5A1RagOjpgyLqSR+EF",
+	"I+579WikXk9/uOj3sReJvGyeNdExEvpLWOUZTubDZvZ6f9vEVNf9YuUw69LAEoke9nme0/fHcFfHSfnq",
+	"QSB7LEpFMlw6ruKLIsA44NZuO0VmkzlnSQfzqrK9Y+NhPFzGdOvTbSc0Mj6FBmKh3hNabLKzOZgxEyqG",
+	"ogggGtnWFELCAN6iOMO1eMGvrWDN9lU31Z9eq59eo8aVNHmS1Wv1rfq0WsDK5s1PCeloSTWGNxBg1inA",
+	"rFOAWSFAHqi5vl6vB9/b1X/aed2+te8AfeANh1SvcSO1A6leJ1oRTJlUDQ80yJ8+rV4DNtqzSceVNwe7",
+	"nOjF1VMyYhUhH2q5amPg6dqt8k6G4qM2PTXb4ko0g9vyf8d1DMNnRYdrDbqx2WsCisPrneyvUw0nfnN2",
+	"YeT8CufXb9w5WLp3AelpTVeUhMVIKqZWvTxvIf90Kb6gcnuIWP/TU4j7GoXXn882oHT3weKRzYf49n78",
+	"Obl8oAtvd23L5E4Kf44e+9PaXx19+y7AWQhXUOvfbz3RBFfEj7s3W7fwrx8WG/mjYjIPDz6Ofnfipk5/",
+	"Dzgl4EeU2X8tMTXuwTYOAfR2ypC9WL/+awT6WAH9B74TO6BLf0DUfgfrZy6MjMT/koLwN+H+B2zVtrbP",
+	"ijNqvm3aOuLGrdqO8+7jbu1qMM4ek2+HLH9UBC5XEzvJWN910jU4xr3al7FXO+g6znG7drXJmBps4nqi",
+	"5zXpmDR1uiECIJDg/M17AyzccwuyfyTbdughnA8A2FMzbTVx7Tj0HTNxmLUNo/of06DlFwmb/+3t2/rj",
+	"rTZue24PHs3A6qH4G2wCujds9QA1m2xICLKgOLLXyTxg1WXcv3WR/4Fv4Q6E1rPgfd2MQbQ/7uv6LnUe",
+	"CX8Dwi+A5+V7Xr3vuTMox26xlVczFHndJ6GLkp/T3q7rJeBGqVfmdZ4lfh0nylcpLg4rryovh9cvhXdQ",
+	"yj7tSPslZgd/iNwDXTs4yrGQj41BwWq2cA/J29efjREOG8J4jGRzoqwArQbXwGPkKrE7sGEzx2Pg+9L1",
+	"vdC739ba5lLqQz5bblHQhFDBeb3BDSZwIQ8f88U1aEiNIQ1a/y2FtYdvfyCDW9mWI/cdv1CO4oONXfB3",
+	"3uOfIfdQedYAw/Nh8xF73vPjwwh7WESCdShqm8U6Qr6fXsZABI+DOgYhrAZB65GIcxcnxT38qpeiPONh",
+	"jD14GbEHve/wGdcfVxuPJ5cNE3doscD8yA6NAdfX8sq1qtVLVM9TTE8uTvV7c4L86trQXjir77qdMw4i",
+	"PMsWC0IXAZhxdif0J5UtIiJkt5ivAv2ag9b4/2wk/U3kb+/YwqwMuuDRe5VstZ0ACYDyWzJJXcv6fXM5",
+	"9jG/tTRbryiNUYiXLI4whwHMeAyncCllKqaTSeXZUciSye0bbVDz8lsUS8se0ncIq4czszhdvcdWcVn+",
+	"fqWS6GsX3SrScOw1ojhuXpmcXxBcLu6VJTbuSm6XeQJCFsc4NG9+qh4fqdqf4rf+AhZ22z7PnH/vz8jz",
+	"9Zc8n/nanw3XLVCVKO2vA+qurNTb+ouf1tfr/wcAAP//g/SxrimVAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file


### PR DESCRIPTION
## Description
Implementations on the `/authentication` endpoints handlers. This builds on top of the work done for #200 .

## Changes
- updated generated code after [PR28](https://github.com/canonical/openfga-admin-openapi-spec/pull/28)
- added implementation for mentioned endpoints
- added unit tests
