### PR TITLE
fix: polish writing service error responses

### DIFF
--- a/rebac-admin-backend/v1/capabilities.go
+++ b/rebac-admin-backend/v1/capabilities.go
@@ -16,8 +16,7 @@ func (h handler) GetCapabilities(w http.ResponseWriter, req *http.Request) {
 
 	capabilities, err := h.Capabilities.ListCapabilities(ctx)
 	if err != nil {
-		response := h.CapabilitiesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.CapabilitiesErrorMapper, err)
 		return
 	}
 

--- a/rebac-admin-backend/v1/core.go
+++ b/rebac-admin-backend/v1/core.go
@@ -16,15 +16,27 @@ import (
 // ReBACAdminBackendParams contains references to user-defined implementation
 // of required abstractions, called "backend"s.
 type ReBACAdminBackendParams struct {
-	IdentitiesService       interfaces.IdentitiesService
+	Identities              interfaces.IdentitiesService
 	IdentitiesAuthorization interfaces.IdentitiesAuthorization
 	IdentitiesErrorMapper   ErrorResponseMapper
 
-	RolesService       interfaces.RolesService
+	Roles              interfaces.RolesService
 	RolesAuthorization interfaces.RolesAuthorization
 	RolesErrorMapper   ErrorResponseMapper
 
-	GroupsService       interfaces.GroupsService
+	IdentityProviders              interfaces.IdentityProvidersService
+	IdentityProvidersAuthorization interfaces.IdentityProvidersAuthorization
+	IdentityProvidersErrorMapper   ErrorResponseMapper
+
+	Capabilities              interfaces.CapabilitiesService
+	CapabilitiesAuthorization interfaces.CapabilitiesAuthorization
+	CapabilitiesErrorMapper   ErrorResponseMapper
+
+	Entitlements              interfaces.EntitlementsService
+	EntitlementsAuthorization interfaces.EntitlementsAuthorization
+	EntitlementsErrorMapper   ErrorResponseMapper
+
+	Groups              interfaces.GroupsService
 	GroupsAuthorization interfaces.GroupsAuthorization
 	GroupsErrorMapper   ErrorResponseMapper
 
@@ -42,7 +54,35 @@ type ReBACAdminBackend struct {
 // NewReBACAdminBackend returns a new ReBACAdminBackend instance, configured
 // with given backends.
 func NewReBACAdminBackend(params ReBACAdminBackendParams) *ReBACAdminBackend {
-	return newReBACAdminBackendWithService(params, &handler{})
+	return newReBACAdminBackendWithService(params, &handler{
+		Identities:              params.Identities,
+		IdentitiesAuthorization: params.IdentitiesAuthorization,
+		IdentitiesErrorMapper:   params.IdentitiesErrorMapper,
+
+		Roles:              params.Roles,
+		RolesAuthorization: params.RolesAuthorization,
+		RolesErrorMapper:   params.RolesErrorMapper,
+
+		IdentityProviders:              params.IdentityProviders,
+		IdentityProvidersAuthorization: params.IdentityProvidersAuthorization,
+		IdentityProvidersErrorMapper:   params.IdentityProvidersErrorMapper,
+
+		Capabilities:              params.Capabilities,
+		CapabilitiesAuthorization: params.CapabilitiesAuthorization,
+		CapabilitiesErrorMapper:   params.CapabilitiesErrorMapper,
+
+		Entitlements:              params.Entitlements,
+		EntitlementsAuthorization: params.EntitlementsAuthorization,
+		EntitlementsErrorMapper:   params.EntitlementsErrorMapper,
+
+		Groups:              params.Groups,
+		GroupsAuthorization: params.GroupsAuthorization,
+		GroupsErrorMapper:   params.GroupsErrorMapper,
+
+		Resources:              params.Resources,
+		ResourcesAuthorization: params.ResourcesAuthorization,
+		ResourcesErrorMapper:   params.ResourcesErrorMapper,
+	})
 }
 
 // newReBACAdminBackendWithService returns a new ReBACAdminBackend instance, configured

--- a/rebac-admin-backend/v1/entitlements.go
+++ b/rebac-admin-backend/v1/entitlements.go
@@ -16,8 +16,7 @@ func (h handler) GetEntitlements(w http.ResponseWriter, req *http.Request, param
 
 	entitlements, err := h.Entitlements.ListEntitlements(ctx, &params)
 	if err != nil {
-		response := h.EntitlementsErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.EntitlementsErrorMapper, err)
 		return
 	}
 
@@ -37,8 +36,7 @@ func (h handler) GetRawEntitlements(w http.ResponseWriter, req *http.Request) {
 
 	entitlementsRawString, err := h.Entitlements.RawEntitlements(ctx)
 	if err != nil {
-		response := h.EntitlementsErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.EntitlementsErrorMapper, err)
 		return
 	}
 

--- a/rebac-admin-backend/v1/entitlements_test.go
+++ b/rebac-admin-backend/v1/entitlements_test.go
@@ -124,7 +124,6 @@ func TestHandler_Entitlements_ServiceBackendFailures(t *testing.T) {
 		name             string
 		setupServiceMock func(mockService *interfaces.MockEntitlementsService)
 		triggerFunc      func(h handler, w *httptest.ResponseRecorder)
-		skip             bool
 	}
 
 	tests := []EndpointTest{

--- a/rebac-admin-backend/v1/error.go
+++ b/rebac-admin-backend/v1/error.go
@@ -61,35 +61,6 @@ type ErrorResponseMapper interface {
 	MapError(error) *resources.Response
 }
 
-type delegateErrorResponseMapper struct {
-	delegate ErrorResponseMapper
-}
-
-func (d delegateErrorResponseMapper) MapError(err error) *resources.Response {
-	var response *resources.Response
-	if d.delegate != nil {
-		response = d.delegate.MapError(err)
-	}
-
-	if nil == response {
-		response = mapErrorResponse(err)
-	}
-
-	return response
-}
-
-// NewDefaultErrorResponseMapper returns a pointer to an errorMapper that maps known errors
-// to specific error responses and all custom errors to 500 Internal server error responses
-func NewDefaultErrorResponseMapper() ErrorResponseMapper {
-	return &delegateErrorResponseMapper{}
-}
-
-// NewDelegateErrorResponseMapper creates an error mapper that relies on the default error mapping
-// only if the provided error mapper returns nil for the error used as input
-func NewDelegateErrorResponseMapper(m ErrorResponseMapper) ErrorResponseMapper {
-	return &delegateErrorResponseMapper{delegate: m}
-}
-
 // mapHandlerBadRequestError checks if the given error is an "Bad Request" error
 // thrown at the handler root (i.e., an auto-generated error type) and return the
 // equivalent errorWithStatus instance. If the given error is not an internal

--- a/rebac-admin-backend/v1/groups.go
+++ b/rebac-admin-backend/v1/groups.go
@@ -17,8 +17,7 @@ func (h handler) GetGroups(w http.ResponseWriter, req *http.Request, params reso
 
 	groups, err := h.Groups.ListGroups(ctx, &params)
 	if err != nil {
-		response := h.GroupsErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -45,8 +44,7 @@ func (h handler) PostGroups(w http.ResponseWriter, req *http.Request) {
 
 	group, err := h.Groups.CreateGroup(ctx, group)
 	if err != nil {
-		response := h.GroupsErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -60,8 +58,7 @@ func (h handler) DeleteGroupsItem(w http.ResponseWriter, req *http.Request, id s
 
 	_, err := h.Groups.DeleteGroup(ctx, id)
 	if err != nil {
-		response := h.GroupsErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -75,8 +72,7 @@ func (h handler) GetGroupsItem(w http.ResponseWriter, req *http.Request, id stri
 
 	group, err := h.Groups.GetGroup(ctx, id)
 	if err != nil {
-		response := h.GroupsErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -103,8 +99,7 @@ func (h handler) PutGroupsItem(w http.ResponseWriter, req *http.Request, id stri
 
 	group, err := h.Groups.UpdateGroup(ctx, group)
 	if err != nil {
-		response := h.GroupsErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -118,8 +113,7 @@ func (h handler) GetGroupsItemEntitlements(w http.ResponseWriter, req *http.Requ
 
 	entitlements, err := h.Groups.GetGroupEntitlements(ctx, id, &params)
 	if err != nil {
-		response := h.GroupsErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -146,8 +140,7 @@ func (h handler) PatchGroupsItemEntitlements(w http.ResponseWriter, req *http.Re
 
 	_, err := h.Groups.PatchGroupEntitlements(ctx, id, patchesRequest.Patches)
 	if err != nil {
-		response := h.GroupsErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -161,8 +154,7 @@ func (h handler) GetGroupsItemIdentities(w http.ResponseWriter, req *http.Reques
 
 	groups, err := h.Groups.GetGroupIdentities(ctx, id, &params)
 	if err != nil {
-		response := h.GroupsErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -189,8 +181,7 @@ func (h handler) PatchGroupsItemIdentities(w http.ResponseWriter, req *http.Requ
 
 	_, err := h.Groups.PatchGroupIdentities(ctx, id, patchesRequest.Patches)
 	if err != nil {
-		response := h.GroupsErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -204,8 +195,7 @@ func (h handler) GetGroupsItemRoles(w http.ResponseWriter, req *http.Request, id
 
 	roles, err := h.Groups.GetGroupRoles(ctx, id, &params)
 	if err != nil {
-		response := h.GroupsErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -232,8 +222,7 @@ func (h handler) PatchGroupsItemRoles(w http.ResponseWriter, req *http.Request, 
 
 	_, err := h.Groups.PatchGroupRoles(ctx, id, patchesRequest.Patches)
 	if err != nil {
-		response := h.GroupsErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
 		return
 	}
 

--- a/rebac-admin-backend/v1/identities.go
+++ b/rebac-admin-backend/v1/identities.go
@@ -17,8 +17,7 @@ func (h handler) GetIdentities(w http.ResponseWriter, req *http.Request, params 
 
 	identities, err := h.Identities.ListIdentities(ctx, &params)
 	if err != nil {
-		response := h.IdentitiesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -45,8 +44,7 @@ func (h handler) PostIdentities(w http.ResponseWriter, req *http.Request) {
 
 	identity, err := h.Identities.CreateIdentity(ctx, identity)
 	if err != nil {
-		response := h.IdentitiesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -60,8 +58,7 @@ func (h handler) DeleteIdentitiesItem(w http.ResponseWriter, req *http.Request, 
 
 	_, err := h.Identities.DeleteIdentity(ctx, id)
 	if err != nil {
-		response := h.IdentitiesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -75,8 +72,7 @@ func (h handler) GetIdentitiesItem(w http.ResponseWriter, req *http.Request, id 
 
 	identity, err := h.Identities.GetIdentity(ctx, id)
 	if err != nil {
-		response := h.IdentitiesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -103,8 +99,7 @@ func (h handler) PutIdentitiesItem(w http.ResponseWriter, req *http.Request, id 
 
 	identity, err := h.Identities.UpdateIdentity(ctx, identity)
 	if err != nil {
-		response := h.IdentitiesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -118,8 +113,7 @@ func (h handler) GetIdentitiesItemEntitlements(w http.ResponseWriter, req *http.
 
 	entitlements, err := h.Identities.GetIdentityEntitlements(ctx, id, &params)
 	if err != nil {
-		response := h.IdentitiesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -146,8 +140,7 @@ func (h handler) PatchIdentitiesItemEntitlements(w http.ResponseWriter, req *htt
 
 	_, err := h.Identities.PatchIdentityEntitlements(ctx, id, patchesRequest.Patches)
 	if err != nil {
-		response := h.IdentitiesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -161,8 +154,7 @@ func (h handler) GetIdentitiesItemGroups(w http.ResponseWriter, req *http.Reques
 
 	groups, err := h.Identities.GetIdentityGroups(ctx, id, &params)
 	if err != nil {
-		response := h.IdentitiesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -189,8 +181,7 @@ func (h handler) PatchIdentitiesItemGroups(w http.ResponseWriter, req *http.Requ
 
 	_, err := h.Identities.PatchIdentityGroups(ctx, id, patchesRequest.Patches)
 	if err != nil {
-		response := h.IdentitiesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -204,8 +195,7 @@ func (h handler) GetIdentitiesItemRoles(w http.ResponseWriter, req *http.Request
 
 	roles, err := h.Identities.GetIdentityRoles(ctx, id, &params)
 	if err != nil {
-		response := h.IdentitiesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -232,8 +222,7 @@ func (h handler) PatchIdentitiesItemRoles(w http.ResponseWriter, req *http.Reque
 
 	_, err := h.Identities.PatchIdentityRoles(ctx, id, patchesRequest.Patches)
 	if err != nil {
-		response := h.IdentitiesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
 		return
 	}
 

--- a/rebac-admin-backend/v1/identity_providers.go
+++ b/rebac-admin-backend/v1/identity_providers.go
@@ -17,8 +17,7 @@ func (h handler) GetAvailableIdentityProviders(w http.ResponseWriter, req *http.
 
 	identityProviders, err := h.IdentityProviders.ListAvailableIdentityProviders(ctx, &params)
 	if err != nil {
-		response := h.IdentityProvidersErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentityProvidersErrorMapper, err)
 		return
 	}
 
@@ -38,8 +37,7 @@ func (h handler) GetIdentityProviders(w http.ResponseWriter, req *http.Request, 
 
 	identityProviders, err := h.IdentityProviders.ListIdentityProviders(ctx, &params)
 	if err != nil {
-		response := h.IdentityProvidersErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentityProvidersErrorMapper, err)
 		return
 	}
 
@@ -67,8 +65,7 @@ func (h handler) PostIdentityProviders(w http.ResponseWriter, req *http.Request)
 
 	identityProvider, err := h.IdentityProviders.RegisterConfiguration(ctx, identityProvider)
 	if err != nil {
-		response := h.IdentityProvidersErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentityProvidersErrorMapper, err)
 		return
 	}
 
@@ -82,8 +79,7 @@ func (h handler) DeleteIdentityProvidersItem(w http.ResponseWriter, req *http.Re
 
 	_, err := h.IdentityProviders.DeleteConfiguration(ctx, id)
 	if err != nil {
-		response := h.IdentityProvidersErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentityProvidersErrorMapper, err)
 		return
 	}
 
@@ -97,8 +93,7 @@ func (h handler) GetIdentityProvidersItem(w http.ResponseWriter, req *http.Reque
 
 	identityProvider, err := h.IdentityProviders.GetConfiguration(ctx, id)
 	if err != nil {
-		response := h.IdentityProvidersErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentityProvidersErrorMapper, err)
 		return
 	}
 
@@ -125,8 +120,7 @@ func (h handler) PutIdentityProvidersItem(w http.ResponseWriter, req *http.Reque
 
 	identityProvider, err := h.IdentityProviders.UpdateConfiguration(ctx, identityProvider)
 	if err != nil {
-		response := h.IdentityProvidersErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.IdentityProvidersErrorMapper, err)
 		return
 	}
 

--- a/rebac-admin-backend/v1/identity_providers_test.go
+++ b/rebac-admin-backend/v1/identity_providers_test.go
@@ -257,7 +257,6 @@ func TestHandler_IdP_ServiceBackendFailures(t *testing.T) {
 		name             string
 		setupServiceMock func(mockService *interfaces.MockIdentityProvidersService)
 		triggerFunc      func(h handler, w *httptest.ResponseRecorder)
-		skip             bool
 	}
 
 	tests := []EndpointTest{

--- a/rebac-admin-backend/v1/resources.go
+++ b/rebac-admin-backend/v1/resources.go
@@ -16,8 +16,7 @@ func (h handler) GetResources(w http.ResponseWriter, req *http.Request, params r
 
 	res, err := h.Resources.ListResources(ctx, &params)
 	if err != nil {
-		response := h.ResourcesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.ResourcesErrorMapper, err)
 		return
 	}
 

--- a/rebac-admin-backend/v1/response.go
+++ b/rebac-admin-backend/v1/response.go
@@ -63,3 +63,27 @@ func writeResponse(w http.ResponseWriter, status int, responseObject interface{}
 		writeErrorResponse(w, err)
 	}
 }
+
+// mapServiceErrorResponse maps errors thrown by services to the designated
+// response type. If the given mapper is nil, the method uses the default
+// mapping strategy.
+//
+// This method should never returns nil response.
+func mapServiceErrorResponse(mapper ErrorResponseMapper, err error) *resources.Response {
+	var response *resources.Response
+	if mapper != nil {
+		response = mapper.MapError(err)
+	}
+
+	if response == nil {
+		response = mapErrorResponse(err)
+	}
+	return response
+}
+
+// writeServiceErrorResponse is a helper method that maps errors thrown by
+// services and writes them to the HTTP response stream.
+func writeServiceErrorResponse(w http.ResponseWriter, mapper ErrorResponseMapper, err error) {
+	response := mapServiceErrorResponse(mapper, err)
+	writeResponse(w, response.Status, response)
+}

--- a/rebac-admin-backend/v1/response.go
+++ b/rebac-admin-backend/v1/response.go
@@ -18,9 +18,11 @@ func writeErrorResponse(w http.ResponseWriter, err error) {
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("unexpected marshalling error"))
+		return
 	}
 
 	w.WriteHeader(int(resp.Status))
+	setJSONContentTypeHeader(w)
 	w.Write(body)
 }
 
@@ -57,11 +59,8 @@ func writeResponse(w http.ResponseWriter, status int, responseObject interface{}
 	}
 
 	w.WriteHeader(status)
-
-	_, err = w.Write(data)
-	if err != nil {
-		writeErrorResponse(w, err)
-	}
+	setJSONContentTypeHeader(w)
+	w.Write(data)
 }
 
 // mapServiceErrorResponse maps errors thrown by services to the designated
@@ -86,4 +85,8 @@ func mapServiceErrorResponse(mapper ErrorResponseMapper, err error) *resources.R
 func writeServiceErrorResponse(w http.ResponseWriter, mapper ErrorResponseMapper, err error) {
 	response := mapServiceErrorResponse(mapper, err)
 	writeResponse(w, response.Status, response)
+}
+
+func setJSONContentTypeHeader(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
 }

--- a/rebac-admin-backend/v1/response.go
+++ b/rebac-admin-backend/v1/response.go
@@ -67,7 +67,7 @@ func writeResponse(w http.ResponseWriter, status int, responseObject interface{}
 // response type. If the given mapper is nil, the method uses the default
 // mapping strategy.
 //
-// This method should never returns nil response.
+// This method should never return nil response.
 func mapServiceErrorResponse(mapper ErrorResponseMapper, err error) *resources.Response {
 	var response *resources.Response
 	if mapper != nil {

--- a/rebac-admin-backend/v1/response.go
+++ b/rebac-admin-backend/v1/response.go
@@ -21,8 +21,8 @@ func writeErrorResponse(w http.ResponseWriter, err error) {
 		return
 	}
 
-	w.WriteHeader(int(resp.Status))
 	setJSONContentTypeHeader(w)
+	w.WriteHeader(int(resp.Status))
 	w.Write(body)
 }
 
@@ -58,8 +58,8 @@ func writeResponse(w http.ResponseWriter, status int, responseObject interface{}
 		return
 	}
 
-	w.WriteHeader(status)
 	setJSONContentTypeHeader(w)
+	w.WriteHeader(status)
 	w.Write(data)
 }
 

--- a/rebac-admin-backend/v1/roles.go
+++ b/rebac-admin-backend/v1/roles.go
@@ -17,8 +17,7 @@ func (h handler) GetRoles(w http.ResponseWriter, req *http.Request, params resou
 
 	roles, err := h.Roles.ListRoles(ctx, &params)
 	if err != nil {
-		response := h.RolesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
 		return
 	}
 
@@ -45,8 +44,7 @@ func (h handler) PostRoles(w http.ResponseWriter, req *http.Request) {
 
 	role, err := h.Roles.CreateRole(ctx, role)
 	if err != nil {
-		response := h.RolesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
 		return
 	}
 
@@ -60,8 +58,7 @@ func (h handler) DeleteRolesItem(w http.ResponseWriter, req *http.Request, id st
 
 	_, err := h.Roles.DeleteRole(ctx, id)
 	if err != nil {
-		response := h.RolesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
 		return
 	}
 
@@ -75,8 +72,7 @@ func (h handler) GetRolesItem(w http.ResponseWriter, req *http.Request, id strin
 
 	role, err := h.Roles.GetRole(ctx, id)
 	if err != nil {
-		response := h.RolesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
 		return
 	}
 
@@ -103,8 +99,7 @@ func (h handler) PutRolesItem(w http.ResponseWriter, req *http.Request, id strin
 
 	role, err := h.Roles.UpdateRole(ctx, role)
 	if err != nil {
-		response := h.RolesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
 		return
 	}
 
@@ -118,8 +113,7 @@ func (h handler) GetRolesItemEntitlements(w http.ResponseWriter, req *http.Reque
 
 	entitlements, err := h.Roles.GetRoleEntitlements(ctx, id, &params)
 	if err != nil {
-		response := h.RolesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
 		return
 	}
 
@@ -146,8 +140,7 @@ func (h handler) PatchRolesItemEntitlements(w http.ResponseWriter, req *http.Req
 
 	_, err := h.Roles.PatchRoleEntitlements(ctx, id, patchesRequest.Patches)
 	if err != nil {
-		response := h.RolesErrorMapper.MapError(err)
-		writeResponse(w, response.Status, response)
+		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
 		return
 	}
 

--- a/rebac-admin-backend/v1/roles_test.go
+++ b/rebac-admin-backend/v1/roles_test.go
@@ -283,7 +283,6 @@ func TestHandler_Roles_ServiceBackendFailures(t *testing.T) {
 		name             string
 		setupServiceMock func(mockService *interfaces.MockRolesService)
 		triggerFunc      func(h handler, w *httptest.ResponseRecorder)
-		skip             bool
 	}
 
 	tests := []EndpointTest{


### PR DESCRIPTION
This PR polished the way we map errors thrown by services (e.g., `IdentitiesService`) to the OpenAPI spec response type.

This PR also:
- Removes the unused `delegateErrorResponseMapper` type and applies the same approach within the `mapServiceErrorResponse` function.
- Drops unused `skip` variable from table tests.
- Fixes `handler` struct instantiation by providing it with all services. 
- Adds explicit `Content-Type: application/json` header to responses.
- Improve some field names by removing the `Service` suffix.

Fixes CSS-7635