### PR TITLE
fix: remove `resources.Unimplemented` embedded struct

### DIFF
--- a/rebac-admin-backend/v1/handler.go
+++ b/rebac-admin-backend/v1/handler.go
@@ -4,14 +4,9 @@ package v1
 
 import (
 	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/interfaces"
-	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
 )
 
 type handler struct {
-	// TODO(CSS-7311): the Unimplemented struct should be removed from here after all
-	// endpoints are implemented.
-	resources.Unimplemented
-
 	Identities              interfaces.IdentitiesService
 	IdentitiesAuthorization interfaces.IdentitiesAuthorization
 	IdentitiesErrorMapper   ErrorResponseMapper


### PR DESCRIPTION
This PR drops `resources.Unimplemented` as an embedded struct in `handler`. This based on top of #210, so this should be merged after that.

Fixes CSS-7311