### PR TITLE
feat: add paginated response generic struct

### DIFF
--- a/rebac-admin-backend/v1/identities.go
+++ b/rebac-admin-backend/v1/identities.go
@@ -22,6 +22,8 @@ func (h handler) GetIdentities(w http.ResponseWriter, req *http.Request, params 
 	}
 
 	response := resources.GetIdentitiesResponse{
+		Links:  resources.NewResponseLinks[resources.Identity](req.URL, identities),
+		Meta:   identities.Meta,
 		Data:   identities.Data,
 		Status: 200,
 	}
@@ -118,7 +120,9 @@ func (h handler) GetIdentitiesItemEntitlements(w http.ResponseWriter, req *http.
 	}
 
 	response := resources.GetIdentityEntitlementsResponse{
-		Data:   entitlements,
+		Links:  resources.NewResponseLinks[resources.EntityEntitlement](req.URL, entitlements),
+		Meta:   entitlements.Meta,
+		Data:   entitlements.Data,
 		Status: 200,
 	}
 
@@ -159,6 +163,8 @@ func (h handler) GetIdentitiesItemGroups(w http.ResponseWriter, req *http.Reques
 	}
 
 	response := resources.GetIdentityGroupsResponse{
+		Links:  resources.NewResponseLinks[resources.Group](req.URL, groups),
+		Meta:   groups.Meta,
 		Data:   groups.Data,
 		Status: 200,
 	}
@@ -200,6 +206,8 @@ func (h handler) GetIdentitiesItemRoles(w http.ResponseWriter, req *http.Request
 	}
 
 	response := resources.GetIdentityRolesResponse{
+		Links:  resources.NewResponseLinks[resources.Role](req.URL, roles),
+		Meta:   roles.Meta,
 		Data:   roles.Data,
 		Status: 200,
 	}

--- a/rebac-admin-backend/v1/identities_test.go
+++ b/rebac-admin-backend/v1/identities_test.go
@@ -35,7 +35,7 @@ func TestHandler_GetIdentities(t *testing.T) {
 
 	mockParams := resources.GetIdentitiesParams{}
 	mockIdentityService := interfaces.NewMockIdentitiesService(ctrl)
-	mockIdentitiesReturn := resources.Identities{Data: []resources.Identity{
+	mockIdentitiesReturn := resources.PaginatedResponse[resources.Identity]{Data: []resources.Identity{
 		{FirstName: &mockFirstName},
 	}}
 	mockIdentityService.EXPECT().ListIdentities(gomock.Any(), gomock.Any()).Return(&mockIdentitiesReturn, nil)
@@ -198,21 +198,24 @@ func TestHandler_GetIdentitiesItemEntitlementsSuccess(t *testing.T) {
 		entityType      = "mock-entity-type"
 	)
 
-	mockIdentityEntitlements := []resources.EntityEntitlement{
-		{
-			EntitlementType: entitlementType,
-			EntityName:      entityName,
-			EntityType:      entityType,
+	mockIdentityEntitlements := resources.PaginatedResponse[resources.EntityEntitlement]{
+		Data: []resources.EntityEntitlement{
+			{
+				EntitlementType: entitlementType,
+				EntityName:      entityName,
+				EntityType:      entityType,
+			},
 		},
 	}
+
 	expectedResponse := resources.GetIdentityEntitlementsResponse{
-		Data:   mockIdentityEntitlements,
+		Data:   mockIdentityEntitlements.Data,
 		Status: http.StatusOK,
 	}
 
 	params := resources.GetIdentitiesItemEntitlementsParams{}
 	mockIdentityService := interfaces.NewMockIdentitiesService(ctrl)
-	mockIdentityService.EXPECT().GetIdentityEntitlements(gomock.Any(), gomock.Eq(mockIdentityId), gomock.Eq(&params)).Return(mockIdentityEntitlements, nil)
+	mockIdentityService.EXPECT().GetIdentityEntitlements(gomock.Any(), gomock.Eq(mockIdentityId), gomock.Eq(&params)).Return(&mockIdentityEntitlements, nil)
 
 	mockWriter := httptest.NewRecorder()
 	mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/identities/%s/entitlements", mockIdentityId), nil)
@@ -276,7 +279,7 @@ func TestHandler_GetIdentitiesItemGroupsSuccess(t *testing.T) {
 		mockName = "test-groupname"
 	)
 
-	mockIdentityGroups := resources.Groups{
+	mockIdentityGroups := resources.PaginatedResponse[resources.Group]{
 		Data: []resources.Group{
 			{
 				Id:   &mockId,
@@ -355,7 +358,7 @@ func TestHandler_GetIdentitiesItemRolesSuccess(t *testing.T) {
 		mockName = "test-rolename"
 	)
 
-	mockIdentityRoles := resources.Roles{
+	mockIdentityRoles := resources.PaginatedResponse[resources.Role]{
 		Data: []resources.Role{
 			{
 				Id:   &mockId,

--- a/rebac-admin-backend/v1/interfaces/identities.go
+++ b/rebac-admin-backend/v1/interfaces/identities.go
@@ -13,7 +13,7 @@ import (
 type IdentitiesService interface {
 
 	// ListIdentities returns a page of Identity objects of at least `size` elements if available
-	ListIdentities(ctx context.Context, params *resources.GetIdentitiesParams) (*resources.Identities, error)
+	ListIdentities(ctx context.Context, params *resources.GetIdentitiesParams) (*resources.PaginatedResponse[resources.Identity], error)
 	// CreateIdentity creates a single Identity.
 	CreateIdentity(ctx context.Context, identity *resources.Identity) (*resources.Identity, error)
 
@@ -29,17 +29,17 @@ type IdentitiesService interface {
 	DeleteIdentity(ctx context.Context, identityId string) (bool, error)
 
 	// GetIdentityGroups returns a page of Groups for identity `identityId`.
-	GetIdentityGroups(ctx context.Context, identityId string, params *resources.GetIdentitiesItemGroupsParams) (*resources.Groups, error)
+	GetIdentityGroups(ctx context.Context, identityId string, params *resources.GetIdentitiesItemGroupsParams) (*resources.PaginatedResponse[resources.Group], error)
 	// PatchIdentityGroups performs addition or removal of a Group to/from an Identity.
 	PatchIdentityGroups(ctx context.Context, identityId string, groupPatches []resources.IdentityGroupsPatchItem) (bool, error)
 
 	// GetIdentityRoles returns a page of Roles for identity `identityId`.
-	GetIdentityRoles(ctx context.Context, identityId string, params *resources.GetIdentitiesItemRolesParams) (*resources.Roles, error)
+	GetIdentityRoles(ctx context.Context, identityId string, params *resources.GetIdentitiesItemRolesParams) (*resources.PaginatedResponse[resources.Role], error)
 	// PatchIdentityRoles performs addition or removal of a Role to/from an Identity.
 	PatchIdentityRoles(ctx context.Context, identityId string, rolePatches []resources.IdentityRolesPatchItem) (bool, error)
 
 	// GetIdentityEntitlements returns a page of Entitlements for identity `identityId`.
-	GetIdentityEntitlements(ctx context.Context, identityId string, params *resources.GetIdentitiesItemEntitlementsParams) ([]resources.EntityEntitlement, error)
+	GetIdentityEntitlements(ctx context.Context, identityId string, params *resources.GetIdentitiesItemEntitlementsParams) (*resources.PaginatedResponse[resources.EntityEntitlement], error)
 	// PatchIdentityEntitlements performs addition or removal of an Entitlement to/from an Identity.
 	PatchIdentityEntitlements(ctx context.Context, identityId string, entitlementPatches []resources.IdentityEntitlementsPatchItem) (bool, error)
 }

--- a/rebac-admin-backend/v1/resources/types.go
+++ b/rebac-admin-backend/v1/resources/types.go
@@ -30,7 +30,7 @@ type PaginatedResponse[T any] struct {
 
 // populateQuery populates query parameters for paginated responses based on the next page available
 // it overrides existing page or nextToken query param, without changing existing parameters in the original query
-func (p *PaginatedResponse[T]) populateQuery(q *url.Values) {
+func (p *PaginatedResponse[T]) populateQuery(q url.Values) {
 	q.Del(pageQueryKey)
 	q.Del(nextTokenQueryKey)
 
@@ -77,11 +77,11 @@ func (p *PaginatedResponse[T]) hasPageNumber() bool {
 func NewResponseLinks[T any](u *url.URL, p *PaginatedResponse[T]) ResponseLinks {
 	query := u.Query()
 
-	p.populateQuery(&query)
+	p.populateQuery(query)
 
 	ret := ResponseLinks{}
 	if queryParams := strings.TrimSpace(query.Encode()); queryParams != "" {
-		ret.Next.Href = fmt.Sprintf("%s?%s", u.Path, query.Encode())
+		ret.Next.Href = fmt.Sprintf("%s?%s", u.Path, queryParams)
 	}
 
 	return ret

--- a/rebac-admin-backend/v1/resources/types.go
+++ b/rebac-admin-backend/v1/resources/types.go
@@ -1,0 +1,88 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	pageQueryKey      = "page"
+	nextTokenQueryKey = "nextToken"
+)
+
+// Next contains data used to retrieve the next available set of results
+type Next struct {
+	Page      *int    `json:"page,omitempty"`
+	PageToken *string `json:"pageToken,omitempty"`
+}
+
+// PaginatedResponse contains info about a page of results and possibly the next page to retrieve
+type PaginatedResponse[T any] struct {
+	Meta ResponseMeta
+	Next Next
+	Data []T
+}
+
+// populateQuery populates query parameters for paginated responses based on the next page available
+// it overrides existing page or nextToken query param, without changing existing parameters in the original query
+func (p *PaginatedResponse[T]) populateQuery(q *url.Values) {
+	q.Del(pageQueryKey)
+	q.Del(nextTokenQueryKey)
+
+	key := p.nextPageKey()
+	if key == "" {
+		return
+	}
+
+	q.Set(key, p.nextPage())
+}
+
+func (p *PaginatedResponse[T]) nextPageKey() string {
+	key := ""
+	if p.hasPageNumber() {
+		key = pageQueryKey
+	} else if p.hasNextPageToken() {
+		key = nextTokenQueryKey
+	}
+
+	return key
+}
+
+// nextPage returns a string representing the next page (token or integer) or an empty string if there's no next page
+func (p *PaginatedResponse[T]) nextPage() string {
+	nextPage := ""
+	if p.hasPageNumber() {
+		nextPage = strconv.Itoa(*p.Next.Page)
+	} else if p.hasNextPageToken() {
+		nextPage = *p.Next.PageToken
+	}
+
+	return nextPage
+}
+
+func (p *PaginatedResponse[T]) hasNextPageToken() bool {
+	return p.Next.PageToken != nil
+}
+
+func (p *PaginatedResponse[T]) hasPageNumber() bool {
+	return p.Next.Page != nil
+}
+
+// NewResponseLinks returns a resources.ResponseLinks object with the href to retreive the next set of results, if any
+func NewResponseLinks[T any](u *url.URL, p *PaginatedResponse[T]) ResponseLinks {
+	query := u.Query()
+
+	p.populateQuery(&query)
+
+	ret := ResponseLinks{}
+	if queryParams := strings.TrimSpace(query.Encode()); queryParams != "" {
+		ret.Next.Href = fmt.Sprintf("%s?%s", u.Path, query.Encode())
+	}
+
+	return ret
+}

--- a/rebac-admin-backend/v1/resources/types_test.go
+++ b/rebac-admin-backend/v1/resources/types_test.go
@@ -1,0 +1,139 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestPaginatedResponse_PopulateQuery(t *testing.T) {
+	c := qt.New(t)
+
+	mockNextPageNumber := 42
+	mockNextPageToken := "mock-next-page-token"
+	mockURL, err := url.Parse("http://localhost/mock-endpoint?filter=mock-filter")
+	c.Assert(err, qt.IsNil)
+
+	type queryTest struct {
+		title string
+		key   string
+		value string
+		p     PaginatedResponse[string]
+	}
+
+	for _, test := range []queryTest{
+		{
+			title: "PageNumber",
+			key:   "page",
+			value: "42",
+			p: PaginatedResponse[string]{
+				Next: Next{Page: &mockNextPageNumber},
+			},
+		},
+		{
+			title: "PageToken",
+			key:   "nextToken",
+			value: "mock-next-page-token",
+			p: PaginatedResponse[string]{
+				Next: Next{PageToken: &mockNextPageToken},
+			},
+		},
+		{
+			title: "Empty",
+			p:     PaginatedResponse[string]{},
+		},
+	} {
+		tt := test
+		c.Run(fmt.Sprintf("TestPaginatedResponse_PopulateQuery%s", tt.title), func(c *qt.C) {
+			expectedQuery := url.Values{}
+			expectedQuery.Set("filter", "mock-filter")
+			if tt.key != "" {
+				expectedQuery.Set(tt.key, tt.value)
+			}
+
+			query := mockURL.Query()
+			tt.p.populateQuery(&query)
+
+			c.Assert(query, qt.DeepEquals, expectedQuery)
+		})
+	}
+}
+
+func TestNewResponseLinks(t *testing.T) {
+	c := qt.New(t)
+
+	type responseLinksTest struct {
+		title    string
+		expected ResponseLinks
+		url      *url.URL
+		p        *PaginatedResponse[string]
+	}
+
+	getURL := func(rawURL string) *url.URL {
+		u, err := url.Parse(rawURL)
+		c.Assert(err, qt.IsNil)
+		return u
+	}
+
+	mockPageNumber := 41
+	mockNextPageNumber := 42
+	mockPageToken := "mock-token"
+	mockNextPageToken := "mock-next-token"
+
+	for _, test := range []responseLinksTest{
+		{
+			title:    "NextPageNumber",
+			expected: ResponseLinks{ResponseLinksNext{Href: "/endpoint/mock?page=42"}},
+			url:      getURL("https://localhost:8080/endpoint/mock?page=41"),
+			p: &PaginatedResponse[string]{
+				Meta: ResponseMeta{
+					Page: &mockPageNumber,
+				},
+				Next: Next{Page: &mockNextPageNumber},
+			},
+		},
+		{
+			title:    "NextPageToken",
+			expected: ResponseLinks{ResponseLinksNext{Href: "/endpoint/test?nextToken=mock-next-token"}},
+			url:      getURL("https://localhost:8080/endpoint/test?nextToken=mock-token"),
+			p: &PaginatedResponse[string]{
+				Meta: ResponseMeta{
+					PageToken: &mockPageToken,
+				},
+				Next: Next{PageToken: &mockNextPageToken},
+			},
+		},
+		{
+			title:    "NoNextPageNumber",
+			expected: ResponseLinks{},
+			url:      getURL("https://localhost:8080/endpoint/test?page=42"),
+			p: &PaginatedResponse[string]{
+				Meta: ResponseMeta{
+					Page: &mockPageNumber,
+				},
+			},
+		},
+		{
+			title:    "NoNextPageToken",
+			expected: ResponseLinks{},
+			url:      getURL("https://localhost:8080/endpoint/test?nextToken=mock-token"),
+			p: &PaginatedResponse[string]{
+				Meta: ResponseMeta{
+					PageToken: &mockPageToken,
+				},
+			},
+		},
+	} {
+		tt := test
+		c.Run(tt.title, func(c *qt.C) {
+			response := NewResponseLinks(tt.url, tt.p)
+
+			c.Assert(response, qt.DeepEquals, tt.expected)
+		})
+	}
+}

--- a/rebac-admin-backend/v1/resources/types_test.go
+++ b/rebac-admin-backend/v1/resources/types_test.go
@@ -20,25 +20,25 @@ func TestPaginatedResponse_PopulateQuery(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	type queryTest struct {
-		title string
-		key   string
-		value string
-		p     PaginatedResponse[string]
+		title         string
+		expectedKey   string
+		expectedValue string
+		p             PaginatedResponse[string]
 	}
 
 	for _, test := range []queryTest{
 		{
-			title: "PageNumber",
-			key:   "page",
-			value: "42",
+			title:         "PageNumber",
+			expectedKey:   "page",
+			expectedValue: "42",
 			p: PaginatedResponse[string]{
 				Next: Next{Page: &mockNextPageNumber},
 			},
 		},
 		{
-			title: "PageToken",
-			key:   "nextToken",
-			value: "mock-next-page-token",
+			title:         "PageToken",
+			expectedKey:   "nextToken",
+			expectedValue: "mock-next-page-token",
 			p: PaginatedResponse[string]{
 				Next: Next{PageToken: &mockNextPageToken},
 			},
@@ -52,12 +52,12 @@ func TestPaginatedResponse_PopulateQuery(t *testing.T) {
 		c.Run(fmt.Sprintf("TestPaginatedResponse_PopulateQuery%s", tt.title), func(c *qt.C) {
 			expectedQuery := url.Values{}
 			expectedQuery.Set("filter", "mock-filter")
-			if tt.key != "" {
-				expectedQuery.Set(tt.key, tt.value)
+			if tt.expectedKey != "" {
+				expectedQuery.Set(tt.expectedKey, tt.expectedValue)
 			}
 
 			query := mockURL.Query()
-			tt.p.populateQuery(&query)
+			tt.p.populateQuery(query)
 
 			c.Assert(query, qt.DeepEquals, expectedQuery)
 		})


### PR DESCRIPTION
## Description
This PR adds the wrapper struct for paginated response, so that service backends can actually pass all the info needed to build the http response for collections data returned as pages.

This allows the library to fill the `_meta` and the `_links` fields correctly.

## Changes
- add `PaginatedResponse` generic type with one public method
- add tests for it
- adopted the new type for paginated responses **on the identity endpoint only** to avoid time waste, other endpoint will follow after this PR is merged
- adjusted tests