### PR TITLE
fix: use the microk8s-hostpath storageclass to dynamically provision the persistent volumn

### DIFF
--- a/deployments/kubectl/storage.yaml
+++ b/deployments/kubectl/storage.yaml
@@ -1,26 +1,10 @@
 ---
 apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: openfga-pv-volume
-  labels:
-    type: local
-spec:
-  storageClassName: manual
-  capacity:
-    storage: 1Mi
-  accessModes:
-    - ReadWriteOnce
-  hostPath:
-    path: "/mnt/data"
-
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: openfga-pv-claim
 spec:
-  storageClassName: manual
+  storageClassName: microk8s-hostpath
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
Using the static provision might cause some issues in different versions of microk8s clusters. This pull request tries to use the microk8s default StorageClass `microk8s-hostpath` enabled by the addon [`hostpath-storage`](https://microk8s.io/docs/addon-hostpath-storage).