### PR TITLE
Complete paginated response refactoring after #214

### DIFF
--- a/rebac-admin-backend/v1/capabilities.go
+++ b/rebac-admin-backend/v1/capabilities.go
@@ -21,6 +21,8 @@ func (h handler) GetCapabilities(w http.ResponseWriter, req *http.Request) {
 	}
 
 	response := resources.GetCapabilitiesResponse{
+		Links:  resources.NewResponseLinks[resources.Capability](req.URL, capabilities),
+		Meta:   capabilities.Meta,
 		Data:   capabilities.Data,
 		Status: http.StatusOK,
 	}

--- a/rebac-admin-backend/v1/capabilities_test.go
+++ b/rebac-admin-backend/v1/capabilities_test.go
@@ -42,7 +42,7 @@ func TestHandler_Capabilities_GetCapabilitiesSuccess(t *testing.T) {
 		},
 	}
 
-	mockReturnCapabilities := resources.Capabilities{Data: mockCapabilities}
+	mockReturnCapabilities := resources.PaginatedResponse[resources.Capability]{Data: mockCapabilities}
 	mockCapabilitiesService.EXPECT().ListCapabilities(gomock.Any()).Return(&mockReturnCapabilities, nil)
 
 	expectedResponse := resources.GetCapabilitiesResponse{

--- a/rebac-admin-backend/v1/entitlements.go
+++ b/rebac-admin-backend/v1/entitlements.go
@@ -21,7 +21,9 @@ func (h handler) GetEntitlements(w http.ResponseWriter, req *http.Request, param
 	}
 
 	response := resources.GetEntitlementsResponse{
-		Data:   entitlements,
+		Links:  resources.NewResponseLinks[resources.EntityEntitlement](req.URL, entitlements),
+		Meta:   entitlements.Meta,
+		Data:   entitlements.Data,
 		Status: http.StatusOK,
 	}
 

--- a/rebac-admin-backend/v1/entitlements_test.go
+++ b/rebac-admin-backend/v1/entitlements_test.go
@@ -26,11 +26,13 @@ func TestHandler_Entitlements_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockEntitlements := []resources.EntityEntitlement{
-		{
-			EntitlementType: "mock-entl-type",
-			EntityName:      "mock-entity-name",
-			EntityType:      "mock-entity-type",
+	mockEntitlements := &resources.PaginatedResponse[resources.EntityEntitlement]{
+		Data: []resources.EntityEntitlement{
+			{
+				EntitlementType: "mock-entl-type",
+				EntityName:      "mock-entity-name",
+				EntityType:      "mock-entity-type",
+			},
 		},
 	}
 
@@ -58,7 +60,7 @@ func TestHandler_Entitlements_Success(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 			expectedBody: resources.GetEntitlementsResponse{
-				Data:   mockEntitlements,
+				Data:   mockEntitlements.Data,
 				Status: http.StatusOK,
 			},
 		},

--- a/rebac-admin-backend/v1/groups.go
+++ b/rebac-admin-backend/v1/groups.go
@@ -22,6 +22,8 @@ func (h handler) GetGroups(w http.ResponseWriter, req *http.Request, params reso
 	}
 
 	response := resources.GetGroupsResponse{
+		Links:  resources.NewResponseLinks[resources.Group](req.URL, groups),
+		Meta:   groups.Meta,
 		Data:   groups.Data,
 		Status: http.StatusOK,
 	}
@@ -118,7 +120,9 @@ func (h handler) GetGroupsItemEntitlements(w http.ResponseWriter, req *http.Requ
 	}
 
 	response := resources.GetGroupEntitlementsResponse{
-		Data:   entitlements,
+		Links:  resources.NewResponseLinks[resources.EntityEntitlement](req.URL, entitlements),
+		Meta:   entitlements.Meta,
+		Data:   entitlements.Data,
 		Status: http.StatusOK,
 	}
 
@@ -152,14 +156,16 @@ func (h handler) PatchGroupsItemEntitlements(w http.ResponseWriter, req *http.Re
 func (h handler) GetGroupsItemIdentities(w http.ResponseWriter, req *http.Request, id string, params resources.GetGroupsItemIdentitiesParams) {
 	ctx := req.Context()
 
-	groups, err := h.Groups.GetGroupIdentities(ctx, id, &params)
+	identities, err := h.Groups.GetGroupIdentities(ctx, id, &params)
 	if err != nil {
 		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
 		return
 	}
 
 	response := resources.GetGroupIdentitiesResponse{
-		Data:   groups.Data,
+		Links:  resources.NewResponseLinks[resources.Identity](req.URL, identities),
+		Meta:   identities.Meta,
+		Data:   identities.Data,
 		Status: http.StatusOK,
 	}
 
@@ -200,6 +206,8 @@ func (h handler) GetGroupsItemRoles(w http.ResponseWriter, req *http.Request, id
 	}
 
 	response := resources.GetIdentityRolesResponse{
+		Links:  resources.NewResponseLinks[resources.Role](req.URL, roles),
+		Meta:   roles.Meta,
 		Data:   roles.Data,
 		Status: http.StatusOK,
 	}

--- a/rebac-admin-backend/v1/groups_test.go
+++ b/rebac-admin-backend/v1/groups_test.go
@@ -42,20 +42,24 @@ func TestHandler_Groups_Success(t *testing.T) {
 		Name: mockGroupName,
 	}
 
-	mockEntitlements := []resources.EntityEntitlement{{
-		EntitlementType: "mock-entl-type",
-		EntityName:      "mock-entity-name",
-		EntityType:      "mock-entity-type",
-	}}
+	mockEntitlements := resources.PaginatedResponse[resources.EntityEntitlement]{
+		Data: []resources.EntityEntitlement{
+			{
+				EntitlementType: "mock-entl-type",
+				EntityName:      "mock-entity-name",
+				EntityType:      "mock-entity-type",
+			},
+		},
+	}
 
-	mockIdentities := resources.Identities{
+	mockIdentities := resources.PaginatedResponse[resources.Identity]{
 		Data: []resources.Identity{{
 			Id:        &mockGroupIdentityId,
 			FirstName: &mockGroupIdentityFirstName,
 		}},
 	}
 
-	mockRoles := resources.Roles{
+	mockRoles := resources.PaginatedResponse[resources.Role]{
 		Data: []resources.Role{{
 			Id:   &mockGroupRoleId,
 			Name: mockGroupRoleName,
@@ -76,7 +80,7 @@ func TestHandler_Groups_Success(t *testing.T) {
 			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
 				mockService.EXPECT().
 					ListGroups(gomock.Any(), gomock.Eq(&resources.GetGroupsParams{})).
-					Return(&resources.Groups{
+					Return(&resources.PaginatedResponse[resources.Group]{
 						Data: []resources.Group{mockGroupObject},
 					}, nil)
 			},
@@ -228,7 +232,7 @@ func TestHandler_Groups_Success(t *testing.T) {
 			setupServiceMock: func(mockService *interfaces.MockGroupsService) {
 				mockService.EXPECT().
 					GetGroupEntitlements(gomock.Any(), gomock.Eq(mockGroupId), gomock.Eq(&resources.GetGroupsItemEntitlementsParams{})).
-					Return(mockEntitlements, nil)
+					Return(&mockEntitlements, nil)
 			},
 			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
 				mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/groups/%s/entitlements", mockGroupId), nil)
@@ -236,7 +240,7 @@ func TestHandler_Groups_Success(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 			expectedBody: resources.GetGroupEntitlementsResponse{
-				Data:   mockEntitlements,
+				Data:   mockEntitlements.Data,
 				Status: http.StatusOK,
 			},
 		},
@@ -251,7 +255,7 @@ func TestHandler_Groups_Success(t *testing.T) {
 				patchesBody, _ := json.Marshal(resources.GroupEntitlementsPatchRequestBody{
 					Patches: []resources.GroupEntitlementsPatchItem{
 						{
-							Entitlement: mockEntitlements[0],
+							Entitlement: mockEntitlements.Data[0],
 							Op:          "add",
 						},
 					},

--- a/rebac-admin-backend/v1/identity_providers.go
+++ b/rebac-admin-backend/v1/identity_providers.go
@@ -22,6 +22,8 @@ func (h handler) GetAvailableIdentityProviders(w http.ResponseWriter, req *http.
 	}
 
 	response := resources.GetAvailableIdentityProvidersResponse{
+		Links:  resources.NewResponseLinks[resources.AvailableIdentityProvider](req.URL, identityProviders),
+		Meta:   identityProviders.Meta,
 		Data:   identityProviders.Data,
 		Status: http.StatusOK,
 	}
@@ -42,6 +44,8 @@ func (h handler) GetIdentityProviders(w http.ResponseWriter, req *http.Request, 
 	}
 
 	response := resources.GetIdentityProvidersResponse{
+		Links:  resources.NewResponseLinks[resources.IdentityProvider](req.URL, identityProviders),
+		Meta:   identityProviders.Meta,
 		Data:   identityProviders.Data,
 		Status: http.StatusOK,
 	}

--- a/rebac-admin-backend/v1/identity_providers_test.go
+++ b/rebac-admin-backend/v1/identity_providers_test.go
@@ -61,7 +61,7 @@ func TestHandler_IdP_Success(t *testing.T) {
 				params := resources.GetAvailableIdentityProvidersParams{}
 				mockService.EXPECT().
 					ListAvailableIdentityProviders(gomock.Any(), gomock.Eq(&params)).
-					Return(&resources.AvailableIdentityProviders{
+					Return(&resources.PaginatedResponse[resources.AvailableIdentityProvider]{
 						Data: []resources.AvailableIdentityProvider{mockAvailableIDPObject},
 					}, nil)
 			},
@@ -80,7 +80,7 @@ func TestHandler_IdP_Success(t *testing.T) {
 			setupServiceMock: func(mockService *interfaces.MockIdentityProvidersService) {
 				mockService.EXPECT().
 					ListIdentityProviders(gomock.Any(), gomock.Any()).
-					Return(&resources.IdentityProviders{Data: mockIDPs}, nil)
+					Return(&resources.PaginatedResponse[resources.IdentityProvider]{Data: mockIDPs}, nil)
 			},
 			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
 				params := resources.GetIdentityProvidersParams{}

--- a/rebac-admin-backend/v1/interfaces/capabilities.go
+++ b/rebac-admin-backend/v1/interfaces/capabilities.go
@@ -11,7 +11,7 @@ import (
 
 // CapabilitiesService defines an abstract backend to handle capabilities related operations.
 type CapabilitiesService interface {
-	ListCapabilities(ctx context.Context) (*resources.Capabilities, error)
+	ListCapabilities(ctx context.Context) (*resources.PaginatedResponse[resources.Capability], error)
 }
 
 type CapabilitiesAuthorization interface{}

--- a/rebac-admin-backend/v1/interfaces/entitlements.go
+++ b/rebac-admin-backend/v1/interfaces/entitlements.go
@@ -11,7 +11,7 @@ import (
 
 type EntitlementsService interface {
 	// ListEntitlements returns the list of entitlements in JSON format.
-	ListEntitlements(ctx context.Context, params *resources.GetEntitlementsParams) ([]resources.EntityEntitlement, error)
+	ListEntitlements(ctx context.Context, params *resources.GetEntitlementsParams) (*resources.PaginatedResponse[resources.EntityEntitlement], error)
 
 	// RawEntitlements returns the list of entitlements as raw text.
 	RawEntitlements(ctx context.Context) (string, error)

--- a/rebac-admin-backend/v1/interfaces/groups.go
+++ b/rebac-admin-backend/v1/interfaces/groups.go
@@ -13,7 +13,7 @@ import (
 type GroupsService interface {
 
 	// ListGroups returns a page of Group objects of at least `size` elements if available.
-	ListGroups(ctx context.Context, params *resources.GetGroupsParams) (*resources.Groups, error)
+	ListGroups(ctx context.Context, params *resources.GetGroupsParams) (*resources.PaginatedResponse[resources.Group], error)
 	// CreateGroup creates a single Group.
 	CreateGroup(ctx context.Context, group *resources.Group) (*resources.Group, error)
 
@@ -29,17 +29,17 @@ type GroupsService interface {
 	DeleteGroup(ctx context.Context, groupId string) (bool, error)
 
 	// GetGroupIdentities returns a page of identities in a Group identified by `groupId`.
-	GetGroupIdentities(ctx context.Context, groupId string, params *resources.GetGroupsItemIdentitiesParams) (*resources.Identities, error)
+	GetGroupIdentities(ctx context.Context, groupId string, params *resources.GetGroupsItemIdentitiesParams) (*resources.PaginatedResponse[resources.Identity], error)
 	// PatchGroupIdentities performs addition or removal of identities to/from a Group identified by `groupId`.
 	PatchGroupIdentities(ctx context.Context, groupId string, groupPatches []resources.GroupIdentitiesPatchItem) (bool, error)
 
 	// GetGroupRoles returns a page of Roles for Group `groupId`.
-	GetGroupRoles(ctx context.Context, groupId string, params *resources.GetGroupsItemRolesParams) (*resources.Roles, error)
+	GetGroupRoles(ctx context.Context, groupId string, params *resources.GetGroupsItemRolesParams) (*resources.PaginatedResponse[resources.Role], error)
 	// PatchGroupRoles performs addition or removal of a Role to/from a Group identified by `groupId`.
 	PatchGroupRoles(ctx context.Context, groupId string, rolePatches []resources.GroupRolesPatchItem) (bool, error)
 
 	// GetGroupEntitlements returns a page of Entitlements for Group `groupId`.
-	GetGroupEntitlements(ctx context.Context, groupId string, params *resources.GetGroupsItemEntitlementsParams) ([]resources.EntityEntitlement, error)
+	GetGroupEntitlements(ctx context.Context, groupId string, params *resources.GetGroupsItemEntitlementsParams) (*resources.PaginatedResponse[resources.EntityEntitlement], error)
 	// PatchGroupEntitlements performs addition or removal of an Entitlement to/from a Group identified by `groupId`.
 	PatchGroupEntitlements(ctx context.Context, identityId string, entitlementPatches []resources.GroupEntitlementsPatchItem) (bool, error)
 }

--- a/rebac-admin-backend/v1/interfaces/identity_providers.go
+++ b/rebac-admin-backend/v1/interfaces/identity_providers.go
@@ -13,10 +13,10 @@ import (
 type IdentityProvidersService interface {
 
 	// ListAvailableIdentityProviders returns the static list of supported identity providers.
-	ListAvailableIdentityProviders(ctx context.Context, params *resources.GetAvailableIdentityProvidersParams) (*resources.AvailableIdentityProviders, error)
+	ListAvailableIdentityProviders(ctx context.Context, params *resources.GetAvailableIdentityProvidersParams) (*resources.PaginatedResponse[resources.AvailableIdentityProvider], error)
 
 	// ListIdentityProviders returns a list of registered identity providers configurations.
-	ListIdentityProviders(ctx context.Context, params *resources.GetIdentityProvidersParams) (*resources.IdentityProviders, error)
+	ListIdentityProviders(ctx context.Context, params *resources.GetIdentityProvidersParams) (*resources.PaginatedResponse[resources.IdentityProvider], error)
 
 	// RegisterConfiguration register a new authentication provider configuration.
 	RegisterConfiguration(ctx context.Context, provider *resources.IdentityProvider) (*resources.IdentityProvider, error)

--- a/rebac-admin-backend/v1/interfaces/resources.go
+++ b/rebac-admin-backend/v1/interfaces/resources.go
@@ -12,7 +12,7 @@ import (
 // ResourcesService defines an abstract backend to handle Resources related operations.
 type ResourcesService interface {
 	// ListResources returns a page of Resource objects of at least `size` elements if available.
-	ListResources(ctx context.Context, params *resources.GetResourcesParams) (*resources.Resources, error)
+	ListResources(ctx context.Context, params *resources.GetResourcesParams) (*resources.PaginatedResponse[resources.Resource], error)
 }
 
 // ResourcesAuthorization defines an abstract backend to handle authorization for Resources.

--- a/rebac-admin-backend/v1/interfaces/roles.go
+++ b/rebac-admin-backend/v1/interfaces/roles.go
@@ -12,7 +12,7 @@ import (
 // RolesService defines an abstract backend to handle Roles related operations.
 type RolesService interface {
 	// ListRoles returns a page of Role objects of at least `size` elements if available.
-	ListRoles(ctx context.Context, params *resources.GetRolesParams) (*resources.Roles, error)
+	ListRoles(ctx context.Context, params *resources.GetRolesParams) (*resources.PaginatedResponse[resources.Role], error)
 	// CreateRole creates a single Role.
 	CreateRole(ctx context.Context, role *resources.Role) (*resources.Role, error)
 
@@ -27,7 +27,7 @@ type RolesService interface {
 	DeleteRole(ctx context.Context, roleId string) (bool, error)
 
 	// GetRoleEntitlements returns a page of Entitlements for Role `roleId`.
-	GetRoleEntitlements(ctx context.Context, roleId string, params *resources.GetRolesItemEntitlementsParams) ([]resources.EntityEntitlement, error)
+	GetRoleEntitlements(ctx context.Context, roleId string, params *resources.GetRolesItemEntitlementsParams) (*resources.PaginatedResponse[resources.EntityEntitlement], error)
 	// PatchRoleEntitlements performs addition or removal of an Entitlement to/from a Role.
 	PatchRoleEntitlements(ctx context.Context, roleId string, entitlementPatches []resources.RoleEntitlementsPatchItem) (bool, error)
 }

--- a/rebac-admin-backend/v1/resources.go
+++ b/rebac-admin-backend/v1/resources.go
@@ -21,6 +21,8 @@ func (h handler) GetResources(w http.ResponseWriter, req *http.Request, params r
 	}
 
 	response := resources.GetResourcesResponse{
+		Links:  resources.NewResponseLinks[resources.Resource](req.URL, res),
+		Meta:   res.Meta,
 		Data:   res.Data,
 		Status: http.StatusOK,
 	}

--- a/rebac-admin-backend/v1/resources_test.go
+++ b/rebac-admin-backend/v1/resources_test.go
@@ -26,7 +26,7 @@ func TestHandler_Resources_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mockResources := resources.Resources{
+	mockResources := resources.PaginatedResponse[resources.Resource]{
 		Data: []resources.Resource{{
 			Id:   "resource-id",
 			Name: "resource-name",

--- a/rebac-admin-backend/v1/roles.go
+++ b/rebac-admin-backend/v1/roles.go
@@ -22,6 +22,8 @@ func (h handler) GetRoles(w http.ResponseWriter, req *http.Request, params resou
 	}
 
 	response := resources.GetRolesResponse{
+		Links:  resources.NewResponseLinks[resources.Role](req.URL, roles),
+		Meta:   roles.Meta,
 		Data:   roles.Data,
 		Status: http.StatusOK,
 	}
@@ -118,7 +120,9 @@ func (h handler) GetRolesItemEntitlements(w http.ResponseWriter, req *http.Reque
 	}
 
 	response := resources.GetIdentityEntitlementsResponse{
-		Data:   entitlements,
+		Links:  resources.NewResponseLinks[resources.EntityEntitlement](req.URL, entitlements),
+		Meta:   entitlements.Meta,
+		Data:   entitlements.Data,
 		Status: http.StatusOK,
 	}
 

--- a/rebac-admin-backend/v1/roles_test.go
+++ b/rebac-admin-backend/v1/roles_test.go
@@ -38,11 +38,13 @@ func TestHandler_Roles_Success(t *testing.T) {
 		Name: mockRoleName,
 	}
 
-	mockEntitlements := []resources.EntityEntitlement{
-		{
-			EntitlementType: "mock-entl-type",
-			EntityName:      "mock-entity-name",
-			EntityType:      "mock-entity-type",
+	mockEntitlements := resources.PaginatedResponse[resources.EntityEntitlement]{
+		Data: []resources.EntityEntitlement{
+			{
+				EntitlementType: "mock-entl-type",
+				EntityName:      "mock-entity-name",
+				EntityType:      "mock-entity-type",
+			},
 		},
 	}
 
@@ -60,7 +62,7 @@ func TestHandler_Roles_Success(t *testing.T) {
 			setupServiceMock: func(mockService *interfaces.MockRolesService) {
 				mockService.EXPECT().
 					ListRoles(gomock.Any(), gomock.Eq(&resources.GetRolesParams{})).
-					Return(&resources.Roles{
+					Return(&resources.PaginatedResponse[resources.Role]{
 						Data: []resources.Role{mockRoleObject},
 					}, nil)
 			},
@@ -136,7 +138,7 @@ func TestHandler_Roles_Success(t *testing.T) {
 			setupServiceMock: func(mockService *interfaces.MockRolesService) {
 				mockService.EXPECT().
 					GetRoleEntitlements(gomock.Any(), gomock.Eq(mockRoleId), gomock.Eq(&resources.GetRolesItemEntitlementsParams{})).
-					Return(mockEntitlements, nil)
+					Return(&mockEntitlements, nil)
 			},
 			triggerFunc: func(h handler, w *httptest.ResponseRecorder) {
 				mockRequest := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/roles/%s/entitlements", mockRoleId), nil)
@@ -144,7 +146,7 @@ func TestHandler_Roles_Success(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 			expectedBody: resources.GetRoleEntitlementsResponse{
-				Data:   mockEntitlements,
+				Data:   mockEntitlements.Data,
 				Status: http.StatusOK,
 			},
 		},
@@ -159,7 +161,7 @@ func TestHandler_Roles_Success(t *testing.T) {
 				patchesBody, _ := json.Marshal(resources.RoleEntitlementsPatchRequestBody{
 					Patches: []resources.RoleEntitlementsPatchItem{
 						{
-							Entitlement: mockEntitlements[0],
+							Entitlement: mockEntitlements.Data[0],
 							Op:          "add",
 						},
 					},

--- a/rebac-admin-backend/v1/swagger.go
+++ b/rebac-admin-backend/v1/swagger.go
@@ -10,7 +10,7 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/rebac-admin-backend/v1/resources"
 )
 
-// Returns the OpenAPI spec as a JSON file.
+// SwaggerJson Returns the OpenAPI spec as a JSON file.
 // (GET /swagger.json)
 func (h handler) SwaggerJson(w http.ResponseWriter, req *http.Request) {
 	swagger, err := resources.GetSwagger()


### PR DESCRIPTION
## Description
This PR follows the work done on #214 , to complete the refactoring to adopt the newly introduced `PaginatedResponse`.


## Changes
This refactoring affects endpoint hanlder, interface and tests for the following endpoints:
- capabilities
- entitlements
- gruops
- identity-providers
- resources
- roles