### PR TITLE
fix: reback CI failing for missing mocks

### DIFF
--- a/.github/workflows/ci-rebac-admin-backend.yaml
+++ b/.github/workflows/ci-rebac-admin-backend.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Generate mocks
+        working-directory: ./rebac-admin-backend
+        run: make mocks
+
       - uses: golangci/golangci-lint-action@v3
         name: Perform linting and annotate code
         with:


### PR DESCRIPTION
## Description
This PR fixes the CI action introduces in #224 to generate mocks before running the linting.