### PR TITLE
IAM 366: Groups API

### DIFF
--- a/internal/authorization/converters_test.go
+++ b/internal/authorization/converters_test.go
@@ -462,3 +462,135 @@ func TestRoleConverterMapReturnsPermissions(t *testing.T) {
 		})
 	}
 }
+
+func TestGroupConverterMapReturnsPermissions(t *testing.T) {
+	type input struct {
+		method        string
+		endpoint      string
+		ID            string
+		RoleID        string
+		EntitlementID string
+		IdentityID    string
+	}
+
+	tests := []struct {
+		name   string
+		input  input
+		output []Permission
+	}{
+		{
+			name:  "GET /api/v0/groups",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/groups"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "global")},
+			},
+		},
+		{
+			name:  "POST /api/v0/groups",
+			input: input{method: http.MethodPost, endpoint: "/api/v0/groups"},
+			output: []Permission{
+				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "global")},
+			},
+		},
+		{
+			name:  "GET /api/v0/groups/id-1234",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/groups/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "PATCH /api/v0/groups/id-1234",
+			input: input{method: http.MethodPatch, endpoint: "/api/v0/groups/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "DELETE /api/v0/groups/id-1234",
+			input: input{method: http.MethodDelete, endpoint: "/api/v0/groups/id-1234", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_DELETE, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "GET /api/v0/groups/id-1234/entitlements",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/groups/id-1234/entitlements", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "DELETE /api/v0/groups/id-1234/entitlements/can_view::role:1",
+			input: input{method: http.MethodDelete, endpoint: "/api/v0/groups/id-1234/entitlements", ID: "id-1234", EntitlementID: "can_view::role:1"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "DELETE /api/v0/groups/id-1234/identities/user-1",
+			input: input{method: http.MethodDelete, endpoint: "/api/v0/groups/id-1234/identities", ID: "id-1234", IdentityID: "user-1"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "id-1234")},
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "user-1")},
+			},
+		},
+		{
+			name:  "POST /api/v0/groups/id-1234/entitlements",
+			input: input{method: http.MethodPost, endpoint: "/api/v0/groups/id-1234/entitlements", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "POST /api/v0/groups/id-1234/roles",
+			input: input{method: http.MethodPost, endpoint: "/api/v0/groups/id-1234/roles", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "id-1234")},
+			},
+		},
+		{
+			name:  "DELETE /api/v0/groups/id-1234/roles/viewer",
+			input: input{method: http.MethodDelete, endpoint: "/api/v0/groups/id-1234/roles", ID: "id-1234", RoleID: "viewer"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "id-1234")},
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "viewer")},
+			},
+		},
+		{
+			name:  "DELETE /api/v0/groups/id-1234/identities/user-1",
+			input: input{method: http.MethodDelete, endpoint: "/api/v0/groups/id-1234/identities/user-1", ID: "id-1234", IdentityID: "user-1"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "id-1234")},
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "user-1")},
+			},
+		},
+		{
+			name:  "PATCH /api/v0/groups/id-1234/identities",
+			input: input{method: http.MethodPatch, endpoint: "/api/v0/groups/id-1234/identities", ID: "id-1234"},
+			output: []Permission{
+				{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "id-1234")},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := httptest.NewRequest(test.input.method, test.input.endpoint, nil)
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", test.input.ID)
+			rctx.URLParams.Add("r_id", test.input.RoleID)
+			rctx.URLParams.Add("e_id", test.input.EntitlementID)
+			rctx.URLParams.Add("i_id", test.input.IdentityID)
+
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			result := new(GroupConverter).Map(r)
+
+			if !reflect.DeepEqual(result, test.output) {
+				t.Errorf("Map returned %v", result)
+			}
+		})
+	}
+}

--- a/internal/authorization/middlewares.go
+++ b/internal/authorization/middlewares.go
@@ -43,6 +43,7 @@ type Middleware struct {
 	RuleConverter
 	SchemeConverter
 	RoleConverter
+	GroupConverter
 
 	monitor monitoring.MonitorInterface
 	logger  logging.LoggerInterface
@@ -101,6 +102,9 @@ func (mdw *Middleware) mapper(r *http.Request) []Permission {
 	}
 	if strings.HasPrefix(r.URL.Path, "/api/v0/roles") {
 		return mdw.RoleConverter.Map(r)
+	}
+	if strings.HasPrefix(r.URL.Path, "/api/v0/groups") {
+		return mdw.GroupConverter.Map(r)
 	}
 
 	return []Permission{}

--- a/internal/authorization/middlewares_test.go
+++ b/internal/authorization/middlewares_test.go
@@ -29,6 +29,7 @@ func (a *API) RegisterEndpoints(router *chi.Mux) {
 	router.Delete("/api/v0/rules/1", a.handleAll)
 	router.Patch("/api/v0/schemas/x", a.handleAll)
 	router.Post("/api/v0/roles/viewer/identities/1", a.handleAll)
+	router.Get("/api/v0/groups/viewer/roles", a.handleAll)
 	router.Get("/api/v0/allow", a.handleAll)
 	router.Get("/api/v0/forbidden", a.handleAll)
 }
@@ -79,6 +80,14 @@ func TestMiddlewareAuthorize(t *testing.T) {
 			input: input{method: http.MethodGet, endpoint: "/api/v0/idps/github", ID: "github"},
 			expect: []Permission{
 				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", PROVIDER_TYPE, "github")},
+			},
+			output: true,
+		},
+		{
+			name:  "GET /api/v0/groups/viewer/roles",
+			input: input{method: http.MethodGet, endpoint: "/api/v0/groups/viewer/roles", ID: "viewer"},
+			expect: []Permission{
+				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "viewer")},
 			},
 			output: true,
 		},

--- a/pkg/groups/handlers.go
+++ b/pkg/groups/handlers.go
@@ -1,0 +1,698 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL
+
+package groups
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/authorization"
+	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
+	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const (
+	ROLE_TOKEN_KEY  = "roles"
+	GROUP_TOKEN_KEY = "groups"
+)
+
+type UpdateRolesRequest struct {
+	Roles []string `json:"roles" validate:"required"`
+}
+
+type Permission struct {
+	Relation string `json:"relation" validate:"required"`
+	Object   string `json:"object" validate:"required"`
+}
+
+type UpdatePermissionsRequest struct {
+	Permissions []Permission `json:"permissions" validate:"required"`
+}
+
+type GroupRequest struct {
+	ID string `json:"id" validate:"required"`
+}
+
+type UpdateIdentitiesRequest struct {
+	Identities []string `json:"identities" validate:"required"`
+}
+
+// API is the core HTTP object that implements all the HTTP and business logic for the groups
+// HTTP API functionality
+type API struct {
+	service ServiceInterface
+
+	logger  logging.LoggerInterface
+	tracer  tracing.TracingInterface
+	monitor monitoring.MonitorInterface
+}
+
+// RegisterEndpoints hooks up all the endpoints to the server mux passed via the arg
+func (a *API) RegisterEndpoints(mux *chi.Mux) {
+	mux.Get("/api/v0/groups", a.handleList)
+	mux.Get("/api/v0/groups/{id}", a.handleDetail)
+	mux.Post("/api/v0/groups", a.handleCreate)
+	mux.Patch("/api/v0/groups/{id}", a.handleUpdate)
+	mux.Delete("/api/v0/groups/{id}", a.handleRemove)
+	mux.Get("/api/v0/groups/{id}/roles", a.handleListRoles)
+	mux.Post("/api/v0/groups/{id}/roles", a.handleAssignRoles)
+	mux.Delete("/api/v0/groups/{id}/roles/{r_id}", a.handleRemoveRole)
+	mux.Get("/api/v0/groups/{id}/entitlements", a.handleListPermission)
+	mux.Patch("/api/v0/groups/{id}/entitlements", a.handleAssignPermission)
+	mux.Delete("/api/v0/groups/{id}/entitlements/{e_id}", a.handleRemovePermission)
+	mux.Get("/api/v0/groups/{id}/identities", a.handleListIdentities)
+	mux.Patch("/api/v0/groups/{id}/identities", a.handleAssignIdentities)
+	mux.Delete("/api/v0/groups/{id}/identities/{i_id}", a.handleRemoveIdentities)
+}
+
+func (a *API) userFromContext(ctx context.Context) *authorization.User {
+	// TODO @shipperizer implement the FromContext and NewContext in authorization package
+	// see snippet below copied from https://pkg.go.dev/context#Context
+	// NewContext returns a new Context that carries value u.
+	// func NewContext(ctx context.Context, u *User) context.Context {
+	//     return context.WithValue(ctx, userKey, u)
+	// }
+
+	// // FromContext returns the User value stored in ctx, if any.
+	// func FromContext(ctx context.Context) (*User, bool) {
+	//     u, ok := ctx.Value(userKey).(*User)
+	//     return u, ok
+	// }
+	if user := ctx.Value(authorization.USER_CTX); user != nil {
+		return user.(*authorization.User)
+	}
+
+	user := new(authorization.User)
+	user.ID = "anonymous"
+
+	return user
+}
+
+func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	user := a.userFromContext(r.Context())
+
+	groups, err := a.service.ListGroups(
+		r.Context(),
+		user.ID,
+	)
+
+	if err != nil {
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Data:    groups,
+			Message: "List of groups",
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handleDetail(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ID := chi.URLParam(r, "id")
+	user := a.userFromContext(r.Context())
+	role, err := a.service.GetGroup(r.Context(), user.ID, ID)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Data:    []string{role},
+			Message: "Group detail",
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing request payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+	}
+
+	group := new(GroupRequest)
+	if err := json.Unmarshal(body, group); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing JSON payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+
+	}
+	user := a.userFromContext(r.Context())
+	err = a.service.CreateGroup(r.Context(), user.ID, group.ID)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Message: fmt.Sprintf("Created group %s", group.ID),
+			Status:  http.StatusCreated,
+		},
+	)
+}
+
+// handleUpdate is not implemented by choice, product might decide to do it to enhance
+// group metadata, we do not support anything on top of simple ID attribute and this is
+// not changeable right now due to coupled implementation with OpenFGA
+func (a *API) handleUpdate(w http.ResponseWriter, r *http.Request) {
+	ID := chi.URLParam(r, "id")
+
+	w.Header().Set("Content-Type", "application/json")
+
+	w.WriteHeader(http.StatusNotImplemented)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Message: fmt.Sprintf("use POST /api/v0/groups/%s/entitlements to assign permissions", ID),
+			Status:  http.StatusNotImplemented,
+		},
+	)
+}
+
+// TODO @shipperizer we need to remove all relationships leading to the group
+func (a *API) handleRemove(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ID := chi.URLParam(r, "id")
+
+	err := a.service.DeleteGroup(r.Context(), ID)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Message: fmt.Sprintf("Deleted group %s", ID),
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handleListPermission(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ID := chi.URLParam(r, "id")
+
+	paginator := types.NewTokenPaginator(a.tracer, a.logger)
+
+	if err := paginator.LoadFromRequest(r.Context(), r); err != nil {
+		a.logger.Error(err)
+	}
+
+	permissions, pageTokens, err := a.service.ListPermissions(
+		r.Context(),
+		ID,
+		paginator.GetAllTokens(r.Context()),
+	)
+
+	if err != nil {
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	for apiType, token := range pageTokens {
+		paginator.SetToken(r.Context(), apiType, token)
+	}
+
+	pageHeader, err := paginator.PaginationHeader(r.Context())
+
+	if err != nil {
+		a.logger.Errorf("error producing pagination header: %s", err)
+		pageHeader = ""
+	}
+
+	w.Header().Add(types.PAGINATION_HEADER, pageHeader)
+	w.WriteHeader(http.StatusOK)
+
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Data:    permissions,
+			Message: "List of entitlements",
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handleListRoles(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ID := chi.URLParam(r, "id")
+
+	roles, err := a.service.ListRoles(
+		r.Context(),
+		ID,
+	)
+
+	if err != nil {
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Data:    roles,
+			Message: "List of roles",
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handleAssignPermission(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ID := chi.URLParam(r, "id")
+
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing request payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+	}
+
+	// we might want to switch to an UpdatePermissionsRequest with additions and removals
+	permissions := new(UpdatePermissionsRequest)
+	if err := json.Unmarshal(body, permissions); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing JSON payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+
+	}
+
+	err = a.service.AssignPermissions(r.Context(), ID, permissions.Permissions...)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Message: fmt.Sprintf("Updated permissions for group %s", ID),
+			Status:  http.StatusCreated,
+		},
+	)
+}
+
+func (a *API) handleRemovePermission(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ID := chi.URLParam(r, "id")
+	permissionUrn := authorization.NewUrnFromURLParam(chi.URLParam(r, "e_id"))
+
+	if permissionUrn == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing entitlement ID",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+	}
+
+	err := a.service.RemovePermissions(
+		r.Context(),
+		ID,
+		Permission{Relation: permissionUrn.Relation(), Object: permissionUrn.Object()},
+	)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Message: fmt.Sprintf("Removed permission %s for group %s", permissionUrn.ID(), ID),
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handleAssignRoles(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ID := chi.URLParam(r, "id")
+
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing request payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+	}
+
+	roles := new(UpdateRolesRequest)
+	if err := json.Unmarshal(body, roles); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing JSON payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+
+	}
+
+	err = a.service.AssignRoles(r.Context(), ID, roles.Roles...)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Message: fmt.Sprintf("Updated roles for group %s", ID),
+			Status:  http.StatusCreated,
+		},
+	)
+}
+
+func (a *API) handleRemoveRole(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ID := chi.URLParam(r, "id")
+	roleID := chi.URLParam(r, "r_id")
+
+	err := a.service.RemoveRoles(r.Context(), ID, roleID)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Message: fmt.Sprintf("Removed role %s from group %s", roleID, ID),
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handleListIdentities(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ID := chi.URLParam(r, "id")
+
+	paginator := types.NewTokenPaginator(a.tracer, a.logger)
+
+	if err := paginator.LoadFromRequest(r.Context(), r); err != nil {
+		a.logger.Error(err)
+	}
+
+	identities, pageToken, err := a.service.ListIdentities(
+		r.Context(),
+		ID,
+		paginator.GetToken(r.Context(), GROUP_TOKEN_KEY),
+	)
+
+	if err != nil {
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	if pageToken != "" {
+		paginator.SetToken(r.Context(), GROUP_TOKEN_KEY, pageToken)
+	}
+
+	pageHeader, err := paginator.PaginationHeader(r.Context())
+
+	if err != nil {
+		a.logger.Errorf("error producing pagination header: %s", err)
+		pageHeader = ""
+	}
+
+	w.Header().Add(types.PAGINATION_HEADER, pageHeader)
+	w.WriteHeader(http.StatusOK)
+
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Data:    identities,
+			Message: "List of identities",
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+func (a *API) handleAssignIdentities(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ID := chi.URLParam(r, "id")
+
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing request payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+	}
+
+	identities := new(UpdateIdentitiesRequest)
+	if err := json.Unmarshal(body, identities); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Error parsing JSON payload",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+
+	}
+
+	err = a.service.AssignIdentities(r.Context(), ID, identities.Identities...)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Message: fmt.Sprintf("Updated identities for group %s", ID),
+			Status:  http.StatusCreated,
+		},
+	)
+}
+
+func (a *API) handleRemoveIdentities(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	ID := chi.URLParam(r, "id")
+	identityID := chi.URLParam(r, "i_id")
+
+	err := a.service.RemoveIdentities(
+		r.Context(),
+		ID,
+		identityID,
+	)
+
+	if err != nil {
+
+		rr := types.Response{
+			Status:  http.StatusInternalServerError,
+			Message: err.Error(),
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(rr)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(
+		types.Response{
+			Message: fmt.Sprintf("Removed identity %s for group %s", identityID, ID),
+			Status:  http.StatusOK,
+		},
+	)
+}
+
+// NewAPI returns an API object responsible for all the roles HTTP handlers
+func NewAPI(service ServiceInterface, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *API {
+	a := new(API)
+
+	a.service = service
+
+	a.logger = logger
+	a.tracer = tracer
+	a.monitor = monitor
+
+	return a
+}

--- a/pkg/groups/handlers_test.go
+++ b/pkg/groups/handlers_test.go
@@ -1,0 +1,1986 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL
+
+package groups
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	reflect "reflect"
+	"strings"
+	"testing"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/authorization"
+	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	"github.com/go-chi/chi/v5"
+	trace "go.opentelemetry.io/otel/trace"
+	gomock "go.uber.org/mock/gomock"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package groups -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package groups -destination ./mock_interfaces.go -source=./interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package groups -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package groups -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+
+// + http :8000/api/v0/groups X-Authorization:c2hpcHBlcml6ZXI=
+// HTTP/1.1 200 OK
+// Content-Length: 97
+// Content-Type: application/json
+// Date: Tue, 20 Feb 2024 22:10:32 GMT
+
+// {
+//     "_meta": null,
+//     "data": [
+//         "global",
+//         "administrator",
+//         "viewer"
+//     ],
+//     "message": "List of groups",
+//     "status": 200
+// }
+
+func TestHandleList(t *testing.T) {
+	type expected struct {
+		err    error
+		groups []string
+	}
+
+	tests := []struct {
+		name     string
+		expected expected
+		output   *types.Response
+	}{
+		{
+			name: "empty result",
+			expected: expected{
+				groups: []string{},
+				err:    nil,
+			},
+			output: &types.Response{
+				Data:    []string{},
+				Message: "List of groups",
+				Status:  http.StatusOK,
+			},
+		},
+		{
+			name: "error",
+			expected: expected{
+				groups: []string{},
+				err:    fmt.Errorf("error"),
+			},
+			output: &types.Response{
+				Data:    []string{},
+				Message: "error",
+				Status:  http.StatusInternalServerError,
+			},
+		},
+		{
+			name: "full result",
+			expected: expected{
+				groups: []string{"global", "administrator", "viewer"},
+				err:    nil,
+			},
+
+			output: &types.Response{
+				Data:    []string{"global", "administrator", "viewer"},
+				Message: "List of groups",
+				Status:  http.StatusOK,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v0/groups", nil)
+
+			mockService.EXPECT().ListGroups(gomock.Any(), "anonymous").Return(test.expected.groups, test.expected.err)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if test.expected.err == nil && !reflect.DeepEqual(rr.Data, test.output.Data) {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+// + http :8000/api/v0/groups/administrator X-Authorization:c2hpcHBlcml6ZXI=
+// HTTP/1.1 200 OK
+// Content-Length: 77
+// Content-Type: application/json
+// Date: Tue, 20 Feb 2024 22:10:32 GMT
+
+// {
+//     "_meta": null,
+//     "data": [
+//         "administrator"
+//     ],
+//     "message": "Group detail",
+//     "status": 200
+// }
+
+func TestHandleDetail(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected error
+		output   *types.Response
+	}{
+		{
+			name:     "unknown group",
+			input:    "unknown",
+			expected: fmt.Errorf("group does not exist"),
+			output: &types.Response{
+				Message: "group does not exist",
+				Status:  http.StatusInternalServerError,
+			},
+		},
+		{
+			name:     "found",
+			input:    "administrator",
+			expected: nil,
+			output: &types.Response{
+				Data:    []string{"administrator"},
+				Message: "Group detail",
+				Status:  http.StatusOK,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/groups/%s", test.input), nil)
+
+			mockService.EXPECT().GetGroup(gomock.Any(), "anonymous", test.input).DoAndReturn(
+				func(context.Context, string, string) (string, error) {
+					if test.expected != nil {
+						return "", test.expected
+					}
+
+					return test.input, nil
+
+				},
+			)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if test.expected == nil && !reflect.DeepEqual(rr.Data, test.output.Data) {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+func TestHandleUpdate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected error
+		output   *types.Response
+	}{
+		{
+			name:     "unknown group",
+			input:    "unknown",
+			expected: fmt.Errorf("group does not exist"),
+			output: &types.Response{
+				Message: "use POST /api/v0/groups/unknown/entitlements to assign permissions",
+				Status:  http.StatusNotImplemented,
+			},
+		},
+		{
+			name:     "found",
+			input:    "administrator",
+			expected: nil,
+			output: &types.Response{
+				Message: "use POST /api/v0/groups/administrator/entitlements to assign permissions",
+				Status:  http.StatusNotImplemented,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v0/groups/%s", test.input), nil)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Message string `json:"message"`
+				Status  int    `json:"status"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+// + http :8000/api/v0/groups/administrator/entitlements X-Authorization:c2hpcHBlcml6ZXI=
+// HTTP/1.1 200 OK
+// Content-Length: 156
+// Content-Type: application/json
+// Date: Tue, 20 Feb 2024 22:10:33 GMT
+
+// {
+//     "_meta": null,
+//     "data": [
+//        "can_view::client:github-canonical",
+//        "can_delete::client:okta",
+//        "can_edit::client:okta"
+//     ],
+//     "message": "List of entitlements",
+//     "status": 200
+// }
+
+func TestHandleListPermissionsSuccess(t *testing.T) {
+	type expected struct {
+		permissions []string
+		cTokens     map[string]string
+	}
+
+	tests := []struct {
+		name     string
+		expected expected
+		output   *types.Response
+	}{
+		{
+			name:     "no permissions",
+			expected: expected{permissions: []string{}},
+			output: &types.Response{
+				Data:    []string{},
+				Message: "List of entitlements",
+				Status:  http.StatusOK,
+			},
+		},
+		{
+			name: "full permissions",
+			expected: expected{
+				permissions: []string{
+					"can_view::client:github-canonical",
+					"can_delete::client:okta",
+					"can_edit::client:okta",
+				},
+				cTokens: map[string]string{"client": "test"},
+			},
+			output: &types.Response{
+				Data: []string{
+					"can_view::client:github-canonical",
+					"can_delete::client:okta",
+					"can_edit::client:okta",
+				},
+				Message: "List of entitlements",
+				Status:  http.StatusOK,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			groupID := "administrator"
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/groups/%s/entitlements", groupID), nil)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "types.TokenPaginator.LoadFromRequest").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "types.TokenPaginator.PaginationHeader").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+
+			mockService.EXPECT().ListPermissions(gomock.Any(), groupID, map[string]string{}).Return(test.expected.permissions, test.expected.cTokens, nil)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != http.StatusOK {
+				t.Errorf("expected HTTP status code 200 got %v", res.StatusCode)
+			}
+
+			tokenMap, err := base64.StdEncoding.DecodeString(res.Header.Get(types.PAGINATION_HEADER))
+
+			if test.expected.cTokens != nil {
+				if err != nil {
+					t.Errorf("expected continuation token in headers")
+				}
+
+				tokens := map[string]string{}
+
+				_ = json.Unmarshal(tokenMap, &tokens)
+
+				if !reflect.DeepEqual(tokens, test.expected.cTokens) {
+					t.Errorf("expected continuation tokens to match: %v - %v", tokens, test.expected.cTokens)
+				}
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if !reflect.DeepEqual(rr.Data, test.output.Data) {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+// + http :8000/api/v0/groups/administrator/roles X-Authorization:c2hpcHBlcml6ZXI=
+// HTTP/1.1 200 OK
+// Content-Length: 87
+// Content-Type: application/json
+// Date: Tue, 20 Feb 2024 22:10:35 GMT
+
+// {
+//     "_meta": null,
+//     "data": [
+//         "viewer",
+//         "devops",
+//     ],
+//     "message": "List of roles",
+//     "status": 200
+// }
+
+func TestHandleListRolesSuccess(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected []string
+		output   *types.Response
+	}{
+		{
+			name:     "no roles",
+			expected: []string{},
+			output: &types.Response{
+				Data:    []string{},
+				Message: "List of roles",
+				Status:  http.StatusOK,
+			},
+		},
+		{
+			name: "full roles",
+			expected: []string{
+				"viewer",
+				"devops",
+			},
+			output: &types.Response{
+				Data: []string{
+					"viewer",
+					"devops",
+				},
+				Message: "List of roles",
+				Status:  http.StatusOK,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			groupID := "administrator"
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/groups/%s/roles", groupID), nil)
+
+			mockService.EXPECT().ListRoles(gomock.Any(), groupID).Return(test.expected, nil)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != http.StatusOK {
+				t.Errorf("expected HTTP status code 200 got %v", res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if !reflect.DeepEqual(rr.Data, test.output.Data) {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+// + http DELETE :8000/api/v0/groups/administrator/entitlements/can_edit::client:okta X-Authorization:c2hpcHBlcml6ZXI=
+// HTTP/1.1 200 OK
+// Content-Length: 116
+// Content-Type: application/json
+// Date: Tue, 20 Feb 2024 22:10:33 GMT
+
+//	{
+//	    "_meta": null,
+//	    "data": null,
+//	    "message": "Removed permission can_edit::client:okta for group administrator",
+//	    "status": 200
+//	}
+
+func TestHandleRemovePermissionBadPermissionFormat(t *testing.T) {
+	type input struct {
+		groupID      string
+		permissionID string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+		output   *types.Response
+	}{
+		{
+			name: "wrong permission format",
+			input: input{
+				groupID:      "administrator",
+				permissionID: "can_edit-something-wrong:okta",
+			},
+			expected: fmt.Errorf("group does not exist"),
+			output: &types.Response{
+				Message: "Error parsing entitlement ID",
+				Status:  http.StatusBadRequest,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v0/groups/%s/entitlements/%s", test.input.groupID, test.input.permissionID), nil)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if test.expected == nil && !reflect.DeepEqual(rr.Data, test.output.Data) {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+func TestHandleRemovePermission(t *testing.T) {
+	type input struct {
+		groupID      string
+		permissionID string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+		output   *types.Response
+	}{
+		{
+			name: "unknown group",
+			input: input{
+				groupID:      "unknown",
+				permissionID: "can_edit::client::okta",
+			},
+			expected: fmt.Errorf("group does not exist"),
+			output: &types.Response{
+				Message: "group does not exist",
+				Status:  http.StatusInternalServerError,
+			},
+		},
+		{
+			name: "found",
+			input: input{
+				groupID:      "administrator",
+				permissionID: "can_edit::client:okta",
+			},
+			expected: nil,
+			output: &types.Response{
+				Status:  http.StatusOK,
+				Message: "Removed permission can_edit::client:okta for group administrator",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v0/groups/%s/entitlements/%s", test.input.groupID, test.input.permissionID), nil)
+
+			mockService.EXPECT().RemovePermissions(
+				gomock.Any(),
+				test.input.groupID,
+				Permission{
+					Relation: strings.Split(test.input.permissionID, authorization.PERMISSION_SEPARATOR)[0],
+					Object:   strings.Split(test.input.permissionID, authorization.PERMISSION_SEPARATOR)[1],
+				},
+			).Return(test.expected)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if test.expected == nil && len(rr.Data) != 0 {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+// + http PATCH :8000/api/v0/groups/administrator/entitlements 'permissions:=[{"relation":"can_delete","object":"scheme:superman"},{"relation":"can_view","object":"client:aws"}]' X-Authorization:c2hpcHBlcml6ZXI=
+// HTTP/1.1 201 Created
+// Content-Length: 95
+// Content-Type: application/json
+// Date: Tue, 20 Feb 2024 22:10:34 GMT
+
+//	{
+//	    "_meta": null,
+//	    "data": null,
+//	    "message": "Updated permissions for group administrator",
+//	    "status": 201
+//	}
+func TestHandleAssignPermissions(t *testing.T) {
+	type input struct {
+		permissions []Permission
+		groupID     string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+		output   *types.Response
+	}{
+		{
+			name:     "multiple permissions",
+			expected: nil,
+			input: input{
+				groupID: "administrator",
+				permissions: []Permission{
+					{
+						Relation: "can_view",
+						Object:   "client:github-canonical",
+					},
+					{
+						Relation: "can_delete",
+						Object:   "client:okta",
+					},
+					{
+						Relation: "can_edit",
+						Object:   "client:okta",
+					},
+				},
+			},
+			output: &types.Response{
+				Message: "Updated permissions for group administrator",
+				Status:  http.StatusCreated,
+			},
+		},
+		{
+			name:     "multiple permissions with error",
+			expected: fmt.Errorf("error"),
+			input: input{
+				groupID: "administrator",
+				permissions: []Permission{
+					{
+						Relation: "can_view",
+						Object:   "client:github-canonical",
+					},
+					{
+						Relation: "can_delete",
+						Object:   "client:okta",
+					},
+					{
+						Relation: "can_edit",
+						Object:   "client:okta",
+					},
+				},
+			},
+			output: &types.Response{
+				Message: "error",
+				Status:  http.StatusInternalServerError,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			upr := new(UpdatePermissionsRequest)
+			upr.Permissions = test.input.permissions
+			payload, _ := json.Marshal(upr)
+
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v0/groups/%s/entitlements", test.input.groupID), bytes.NewReader(payload))
+
+			mockService.EXPECT().AssignPermissions(gomock.Any(), test.input.groupID, test.input.permissions).Return(test.expected)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if test.expected == nil && len(rr.Data) != 0 {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+func TestHandleAssignPermissionsBadPermissionFormat(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		input    string
+		expected error
+		output   *types.Response
+	}{
+		{
+			name:     "no permissions",
+			expected: nil,
+			input:    "administrator",
+			output: &types.Response{
+				Message: "Error parsing JSON payload",
+				Status:  http.StatusBadRequest,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v0/groups/%s/entitlements", test.input), nil)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+// + http DELETE :8000/api/v0/groups/viewer X-Authorization:c2hpcHBlcml6ZXI=
+// HTTP/1.1 200 OK
+// Content-Length: 72
+// Content-Type: application/json
+// Date: Tue, 20 Feb 2024 22:10:36 GMT
+
+//	{
+//	    "_meta": null,
+//	    "data": null,
+//	    "message": "Deleted group viewer",
+//	    "status": 200
+//	}
+func TestHandleRemove(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected error
+		output   *types.Response
+	}{
+		{
+			name:     "unknown group",
+			input:    "unknown",
+			expected: fmt.Errorf("group does not exist"),
+			output: &types.Response{
+				Message: "group does not exist",
+				Status:  http.StatusInternalServerError,
+			},
+		},
+		{
+			name:     "found",
+			input:    "administrator",
+			expected: nil,
+			output: &types.Response{
+				Status:  http.StatusOK,
+				Message: "Deleted group administrator",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v0/groups/%s", test.input), nil)
+
+			mockService.EXPECT().DeleteGroup(
+				gomock.Any(),
+				test.input,
+			).Return(test.expected)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if test.expected == nil && len(rr.Data) != 0 {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+func TestHandleCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected error
+		output   *types.Response
+	}{
+		{
+			name:     "success",
+			expected: nil,
+			input:    "administrator",
+
+			output: &types.Response{
+				Message: "Created group administrator",
+				Status:  http.StatusCreated,
+			},
+		},
+		{
+			name:     "fail",
+			expected: fmt.Errorf("error"),
+			input:    "administrator",
+			output: &types.Response{
+				Message: "error",
+				Status:  http.StatusInternalServerError,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			upr := new(GroupRequest)
+			upr.ID = test.input
+			payload, _ := json.Marshal(upr)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v0/groups", bytes.NewReader(payload))
+
+			mockService.EXPECT().CreateGroup(gomock.Any(), "anonymous", test.input).Return(test.expected)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if test.expected == nil && len(rr.Data) != 0 {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+func TestHandleCreateBadRoleFormat(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		input    string
+		expected error
+		output   *types.Response
+	}{
+		{
+			name:     "no permissions",
+			expected: nil,
+			input:    "administrator",
+			output: &types.Response{
+				Message: "Error parsing JSON payload",
+				Status:  http.StatusBadRequest,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v0/groups", nil)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+// + http DELETE :8000/api/v0/groups/administrator/identities/joe X-Authorization:c2hpcHBlcml6ZXI=
+// HTTP/1.1 200 OK
+// Content-Length: 116
+// Content-Type: application/json
+// Date: Tue, 20 Feb 2024 22:10:33 GMT
+
+//	{
+//	    "_meta": null,
+//	    "data": null,
+//	    "message": "Removed identity joe for group administrator",
+//	    "status": 200
+//	}
+func TestHandleRemoveIdentities(t *testing.T) {
+	type input struct {
+		groupID    string
+		identityID string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+		output   *types.Response
+	}{
+		{
+			name: "unknown group",
+			input: input{
+				groupID:    "unknown",
+				identityID: "joe",
+			},
+			expected: fmt.Errorf("group does not exist"),
+			output: &types.Response{
+				Message: "group does not exist",
+				Status:  http.StatusInternalServerError,
+			},
+		},
+		{
+			name: "found",
+			input: input{
+				groupID:    "administrator",
+				identityID: "joe",
+			},
+			expected: nil,
+			output: &types.Response{
+				Status:  http.StatusOK,
+				Message: "Removed identity joe for group administrator",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v0/groups/%s/identities/%s", test.input.groupID, test.input.identityID), nil)
+
+			mockService.EXPECT().RemoveIdentities(
+				gomock.Any(),
+				test.input.groupID,
+				test.input.identityID,
+			).Return(test.expected)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if test.expected == nil && len(rr.Data) != 0 {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+// + http PATCH :8000/api/v0/groups/administrator/identities 'identities:=["joe","susan"]' X-Authorization:c2hpcHBlcml6ZXI=
+// HTTP/1.1 201 Created
+// Content-Length: 95
+// Content-Type: application/json
+// Date: Tue, 20 Feb 2024 22:10:34 GMT
+
+//	{
+//	    "_meta": null,
+//	    "data": null,
+//	    "message": "Updated identities for group administrator",
+//	    "status": 201
+//	}
+func TestHandleAssignIdentities(t *testing.T) {
+	type input struct {
+		identities []string
+		groupID    string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+		output   *types.Response
+	}{
+		{
+			name:     "multiple identities",
+			expected: nil,
+			input: input{
+				groupID: "administrator",
+				identities: []string{
+					"joe", "susan", "dummy",
+				},
+			},
+			output: &types.Response{
+				Message: "Updated identities for group administrator",
+				Status:  http.StatusCreated,
+			},
+		},
+		{
+			name:     "multiple identities with error",
+			expected: fmt.Errorf("error"),
+			input: input{
+				groupID: "administrator",
+				identities: []string{
+					"joe", "susan", "dummy",
+				},
+			},
+			output: &types.Response{
+				Message: "error",
+				Status:  http.StatusInternalServerError,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			upr := new(UpdateIdentitiesRequest)
+			upr.Identities = test.input.identities
+			payload, _ := json.Marshal(upr)
+
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v0/groups/%s/identities", test.input.groupID), bytes.NewReader(payload))
+
+			mockService.EXPECT().AssignIdentities(gomock.Any(), test.input.groupID, test.input.identities).Return(test.expected)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if test.expected == nil && len(rr.Data) != 0 {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+func TestHandleAssignIdentitiesBadPermissionFormat(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		input    string
+		expected error
+		output   *types.Response
+	}{
+		{
+			name:     "no identities",
+			expected: nil,
+			input:    "administrator",
+			output: &types.Response{
+				Message: "Error parsing JSON payload",
+				Status:  http.StatusBadRequest,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v0/groups/%s/identities", test.input), nil)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+// + http PATCH :8000/api/v0/groups/administrator/roles 'roles:=["admin","viewer"]' X-Authorization:c2hpcHBlcml6ZXI=
+// HTTP/1.1 201 Created
+// Content-Length: 95
+// Content-Type: application/json
+// Date: Tue, 20 Feb 2024 22:10:34 GMT
+
+//	{
+//	    "_meta": null,
+//	    "data": null,
+//	    "message": "Updated roles for group administrator",
+//	    "status": 201
+//	}
+func TestHandleAssignRoles(t *testing.T) {
+	type input struct {
+		roles   []string
+		groupID string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+		output   *types.Response
+	}{
+		{
+			name:     "multiple roles",
+			expected: nil,
+			input: input{
+				groupID: "administrator",
+				roles: []string{
+					"viewer", "writer",
+				},
+			},
+			output: &types.Response{
+				Message: "Updated roles for group administrator",
+				Status:  http.StatusCreated,
+			},
+		},
+		{
+			name:     "multiple roles with error",
+			expected: fmt.Errorf("error"),
+			input: input{
+				groupID: "administrator",
+				roles: []string{
+					"viewer", "writer",
+				},
+			},
+			output: &types.Response{
+				Message: "error",
+				Status:  http.StatusInternalServerError,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			upr := new(UpdateRolesRequest)
+			upr.Roles = test.input.roles
+			payload, _ := json.Marshal(upr)
+
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v0/groups/%s/roles", test.input.groupID), bytes.NewReader(payload))
+
+			mockService.EXPECT().AssignRoles(gomock.Any(), test.input.groupID, test.input.roles).Return(test.expected)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if test.expected == nil && len(rr.Data) != 0 {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+// + http DELETE :8000/api/v0/groups/administrator/roles/viewer X-Authorization:c2hpcHBlcml6ZXI=
+// HTTP/1.1 200 OK
+// Content-Length: 116
+// Content-Type: application/json
+// Date: Tue, 20 Feb 2024 22:10:33 GMT
+
+//	{
+//	    "_meta": null,
+//	    "data": null,
+//	    "message": "Removed role viewer for group administrator",
+//	    "status": 200
+//	}
+func TestHandleRemoveRole(t *testing.T) {
+	type input struct {
+		groupID string
+		roleID  string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+		output   *types.Response
+	}{
+		{
+			name: "unknown group",
+			input: input{
+				groupID: "unknown",
+				roleID:  "viewer",
+			},
+			expected: fmt.Errorf("group does not exist"),
+			output: &types.Response{
+				Message: "group does not exist",
+				Status:  http.StatusInternalServerError,
+			},
+		},
+		{
+			name: "found",
+			input: input{
+				groupID: "administrator",
+				roleID:  "viewer",
+			},
+			expected: nil,
+			output: &types.Response{
+				Status:  http.StatusOK,
+				Message: "Removed role viewer from group administrator",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v0/groups/%s/roles/%s", test.input.groupID, test.input.roleID), nil)
+
+			mockService.EXPECT().RemoveRoles(
+				gomock.Any(),
+				test.input.groupID,
+				test.input.roleID,
+			).Return(test.expected)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != test.output.Status {
+				t.Errorf("expected HTTP status code %v got %v", test.output.Status, res.StatusCode)
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if test.expected == nil && len(rr.Data) != 0 {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}
+
+// + http :8000/api/v0/groups/administrator/identities X-Authorization:c2hpcHBlcml6ZXI=
+// HTTP/1.1 200 OK
+// Content-Length: 156
+// Content-Type: application/json
+// Date: Tue, 20 Feb 2024 22:10:33 GMT
+
+// {
+//     "_meta": null,
+//     "data": [
+//        "user:joe",
+//        "user:susan",
+//        "user:dummy",
+//     ],
+//     "message": "List of entitlements",
+//     "status": 200
+// }
+
+func TestHandleListIdentitiesSuccess(t *testing.T) {
+	type expected struct {
+		identities []string
+		cToken     string
+	}
+
+	tests := []struct {
+		name     string
+		expected expected
+		output   *types.Response
+	}{
+		{
+			name:     "no identities",
+			expected: expected{identities: []string{}},
+			output: &types.Response{
+				Data:    []string{},
+				Message: "List of identities",
+				Status:  http.StatusOK,
+			},
+		},
+		{
+			name: "full identities",
+			expected: expected{
+				identities: []string{
+					"user:joe", "user:susan", "user:dummy",
+				},
+				cToken: "test",
+			},
+			output: &types.Response{
+				Data: []string{
+					"user:joe", "user:susan", "user:dummy",
+				},
+				Message: "List of identities",
+				Status:  http.StatusOK,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockService := NewMockServiceInterface(ctrl)
+
+			groupID := "administrator"
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/groups/%s/identities", groupID), nil)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "types.TokenPaginator.LoadFromRequest").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "types.TokenPaginator.PaginationHeader").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+
+			mockService.EXPECT().ListIdentities(gomock.Any(), groupID, "").Return(test.expected.identities, test.expected.cToken, nil)
+
+			w := httptest.NewRecorder()
+			mux := chi.NewMux()
+			NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
+
+			mux.ServeHTTP(w, req)
+
+			res := w.Result()
+			defer res.Body.Close()
+			data, err := io.ReadAll(res.Body)
+
+			if err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if res.StatusCode != http.StatusOK {
+				t.Errorf("expected HTTP status code 200 got %v", res.StatusCode)
+			}
+
+			tokenMap, err := base64.StdEncoding.DecodeString(res.Header.Get(types.PAGINATION_HEADER))
+
+			if test.expected.cToken != "" {
+				if err != nil {
+					t.Errorf("expected continuation token in headers")
+				}
+
+				tokens := map[string]string{}
+
+				_ = json.Unmarshal(tokenMap, &tokens)
+
+				if !reflect.DeepEqual(tokens[GROUP_TOKEN_KEY], test.expected.cToken) {
+					t.Errorf("expected continuation token to match: %v - %v", tokens[GROUP_TOKEN_KEY], test.expected.cToken)
+				}
+			}
+
+			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
+			type Response struct {
+				Data    []string          `json:"data"`
+				Message string            `json:"message"`
+				Status  int               `json:"status"`
+				Meta    *types.Pagination `json:"_meta"`
+			}
+
+			rr := new(Response)
+
+			if err := json.Unmarshal(data, rr); err != nil {
+				t.Errorf("expected error to be nil got %v", err)
+			}
+
+			if !reflect.DeepEqual(rr.Data, test.output.Data) {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
+			}
+
+			if rr.Message != test.output.Message {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Message, rr.Message)
+			}
+
+			if rr.Status != test.output.Status {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output.Status, rr.Status)
+			}
+
+		})
+	}
+}

--- a/pkg/groups/interfaces.go
+++ b/pkg/groups/interfaces.go
@@ -1,0 +1,38 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL
+
+package groups
+
+import (
+	"context"
+
+	"github.com/openfga/go-sdk/client"
+
+	ofga "github.com/canonical/identity-platform-admin-ui/internal/openfga"
+)
+
+// ServiceInterface is the interface that each business logic service needs to implement
+type ServiceInterface interface {
+	ListGroups(context.Context, string) ([]string, error) // list of groups, continuation token, error
+	GetGroup(context.Context, string, string) (string, error)
+	CreateGroup(context.Context, string, string) error
+	DeleteGroup(context.Context, string) error
+	ListRoles(context.Context, string) ([]string, error)
+	AssignRoles(context.Context, string, ...string) error
+	RemoveRoles(context.Context, string, ...string) error
+	ListPermissions(context.Context, string, map[string]string) ([]string, map[string]string, error)
+	AssignPermissions(context.Context, string, ...Permission) error
+	RemovePermissions(context.Context, string, ...Permission) error
+	ListIdentities(context.Context, string, string) ([]string, string, error)
+	AssignIdentities(context.Context, string, ...string) error
+	RemoveIdentities(context.Context, string, ...string) error
+}
+
+// OpenFGAClientInterface is the interface used to decouple the OpenFGA store implementation
+type OpenFGAClientInterface interface {
+	ListObjects(context.Context, string, string, string) ([]string, error)
+	ReadTuples(context.Context, string, string, string, string) (*client.ClientReadResponse, error)
+	WriteTuples(context.Context, ...ofga.Tuple) error
+	DeleteTuples(context.Context, ...ofga.Tuple) error
+	Check(context.Context, string, string, string) (bool, error)
+}

--- a/pkg/groups/service.go
+++ b/pkg/groups/service.go
@@ -1,0 +1,438 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL
+
+package groups
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/authorization"
+	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	ofga "github.com/canonical/identity-platform-admin-ui/internal/openfga"
+)
+
+const (
+	MEMBER_RELATION   = "member"
+	ASSIGNEE_RELATION = "assignee"
+)
+
+// Service contains the business logic to deal with groups on the Admin UI OpenFGA model
+type Service struct {
+	ofga OpenFGAClientInterface
+
+	tracer  trace.Tracer
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
+}
+
+func (s *Service) buildGroupMember(ctx context.Context, ID string) string {
+	_, span := s.tracer.Start(ctx, "groups.Service.buildGroupMember")
+	defer span.End()
+
+	return fmt.Sprintf("group:%s#%s", ID, MEMBER_RELATION)
+
+}
+
+// ListGroups returns all the groups a specific user can see (using "can_view" OpenFGA relation)
+func (s *Service) ListGroups(ctx context.Context, userID string) ([]string, error) {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.ListGroups")
+	defer span.End()
+
+	groups, err := s.ofga.ListObjects(ctx, fmt.Sprintf("user:%s", userID), "can_view", "group")
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return nil, err
+	}
+
+	return groups, nil
+}
+
+// ListRoles returns all the roles associated to a specific group
+func (s *Service) ListRoles(ctx context.Context, ID string) ([]string, error) {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.ListRoles")
+	defer span.End()
+
+	roles, err := s.ofga.ListObjects(ctx, s.buildGroupMember(ctx, ID), ASSIGNEE_RELATION, "role")
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return nil, err
+	}
+
+	return roles, nil
+}
+
+// ListPermissions returns all the permissions associated to a specific group
+func (s *Service) ListPermissions(ctx context.Context, ID string, continuationTokens map[string]string) ([]string, map[string]string, error) {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.ListPermissions")
+	defer span.End()
+
+	permissionsMap := sync.Map{}
+	tokensMap := sync.Map{}
+
+	var wg sync.WaitGroup
+
+	wg.Add(len(s.permissionTypes()))
+
+	// TODO @shipperizer use a background operator
+	for _, t := range s.permissionTypes() {
+		go func(pType string) {
+			defer wg.Done()
+			p, t, err := s.listPermissionsByType(ctx, ID, pType, continuationTokens[pType])
+
+			permissionsMap.Store(pType, p)
+			tokensMap.Store(pType, t)
+
+			// TODO @shipperizer handle errors better
+			// chain them and return at the end of the function
+			if err != nil {
+				s.logger.Error(err)
+			}
+		}(t)
+	}
+
+	wg.Wait()
+
+	permissions := make([]string, 0)
+	tokens := make(map[string]string)
+
+	permissionsMap.Range(
+		func(key any, value any) bool {
+			permissions = append(permissions, value.([]string)...)
+
+			return true
+		},
+	)
+
+	tokensMap.Range(
+		func(key any, value any) bool {
+			tokens[key.(string)] = value.(string)
+
+			return true
+		},
+	)
+
+	// TODO @shipperizer right now the function fails silently, chain errors from the goroutines
+	// and return
+	return permissions, tokens, nil
+}
+
+// GetGroup returns the specified group using the ID argument, userID is used to validate the visibility by the user
+// making the call
+func (s *Service) GetGroup(ctx context.Context, userID, ID string) (string, error) {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.GetGroup")
+	defer span.End()
+
+	exists, err := s.ofga.Check(ctx, fmt.Sprintf("user:%s", userID), "can_view", fmt.Sprintf("group:%s", ID))
+
+	if err != nil {
+
+		s.logger.Error(err.Error())
+		return "", err
+	}
+
+	if exists {
+		return ID, nil
+	}
+
+	// if we got here it means authorization check hasn't worked
+	return "", nil
+}
+
+// CreateGroup creates a group and associates it with the userID passed as argument
+// an extra tuple is created to estabilish the "privileged" relatin for admin users
+func (s *Service) CreateGroup(ctx context.Context, userID, ID string) error {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.CreateGroup")
+	defer span.End()
+
+	// TODO @shipperizer will we need also the can_view?
+	// does creating a group mean that you are the owner, therefore u get all the permissions on it?
+	// right now assumption is only admins will be able to do this
+	// potentially changing the model to say
+	// `define can_view: [user, user:*, group#assignee, group#member] or assignee or admin from privileged`
+	// might sort the problem
+
+	// TODO @shipperizer offload to privileged creator object
+	err := s.ofga.WriteTuples(
+		ctx,
+		*ofga.NewTuple(fmt.Sprintf("user:%s", userID), MEMBER_RELATION, fmt.Sprintf("group:%s", ID)),
+		*ofga.NewTuple(authorization.ADMIN_PRIVILEGE, "privileged", fmt.Sprintf("group:%s", ID)),
+	)
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// AssignRoles assigns roles to a group
+func (s *Service) AssignRoles(ctx context.Context, ID string, roles ...string) error {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.AssignRoles")
+	defer span.End()
+
+	// preemptive check to verify if all roles to be assigned are accessible by the user
+	// needs to happen separately
+
+	rs := make([]ofga.Tuple, 0)
+
+	for _, role := range roles {
+		rs = append(rs, *ofga.NewTuple(s.buildGroupMember(ctx, ID), ASSIGNEE_RELATION, fmt.Sprintf("role:%s", role)))
+	}
+
+	err := s.ofga.WriteTuples(ctx, rs...)
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// RemoveRoles drops roles from a group
+func (s *Service) RemoveRoles(ctx context.Context, ID string, roles ...string) error {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.RemoveRoles")
+	defer span.End()
+
+	// preemptive check to verify if all roles to be assigned are accessible by the user
+	// needs to happen separately
+
+	rs := make([]ofga.Tuple, 0)
+
+	for _, role := range roles {
+		rs = append(rs, *ofga.NewTuple(s.buildGroupMember(ctx, ID), ASSIGNEE_RELATION, fmt.Sprintf("role:%s", role)))
+	}
+
+	err := s.ofga.DeleteTuples(ctx, rs...)
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// AssignPermissions assigns permissions to a group
+// TODO @shipperizer see if it's worth using only one between Permission and ofga.Tuple
+func (s *Service) AssignPermissions(ctx context.Context, ID string, permissions ...Permission) error {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.AssignPermissions")
+	defer span.End()
+
+	// preemptive check to verify if all permissions to be assigned are accessible by the user
+	// needs to happen separately
+
+	ps := make([]ofga.Tuple, 0)
+
+	for _, p := range permissions {
+		ps = append(ps, *ofga.NewTuple(s.buildGroupMember(ctx, ID), p.Relation, p.Object))
+	}
+
+	err := s.ofga.WriteTuples(ctx, ps...)
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// RemovePermissions removes permissions from a group
+// TODO @shipperizer see if it's worth using only one between Permission and ofga.Tuple
+func (s *Service) RemovePermissions(ctx context.Context, ID string, permissions ...Permission) error {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.RemovePermissions")
+	defer span.End()
+
+	// preemptive check to verify if all permissions to be assigned are accessible by the user
+	// needs to happen separately
+
+	ps := make([]ofga.Tuple, 0)
+
+	for _, p := range permissions {
+		ps = append(ps, *ofga.NewTuple(s.buildGroupMember(ctx, ID), p.Relation, p.Object))
+	}
+
+	err := s.ofga.DeleteTuples(ctx, ps...)
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// DeleteGroup deletes a group and all the related tuples
+func (s *Service) DeleteGroup(ctx context.Context, ID string) error {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.DeleteGroup")
+	defer span.End()
+
+	var wg sync.WaitGroup
+
+	wg.Add(len(s.permissionTypes()))
+
+	// TODO @shipperizer use a background operator
+	for _, t := range s.permissionTypes() {
+		go func(pType string) {
+			defer wg.Done()
+			s.removePermissionsByType(ctx, ID, pType)
+		}(t)
+	}
+
+	wg.Wait()
+
+	return s.ofga.DeleteTuples(ctx, *ofga.NewTuple(authorization.ADMIN_PRIVILEGE, "privileged", fmt.Sprintf("group:%s", ID)))
+}
+
+// ListIdentities returns all the identities (users for now) assigned to a group
+func (s *Service) ListIdentities(ctx context.Context, ID, continuationToken string) ([]string, string, error) {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.ListIdentities")
+	defer span.End()
+
+	r, err := s.ofga.ReadTuples(ctx, "", MEMBER_RELATION, fmt.Sprintf("group:%s", ID), continuationToken)
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return nil, "", err
+	}
+
+	identities := make([]string, 0)
+
+	for _, t := range r.GetTuples() {
+		// TODO @shipperizer the user: bit will have to change when or if we use the identity type, this will be tricky
+		// best way right now might be to verify if a user is also an identity (no idea how though)
+		// at the moment an identity cannot be a member of a group, only a user
+		if strings.HasPrefix(t.Key.User, "user:") {
+			identities = append(identities, t.Key.User)
+		}
+	}
+
+	return identities, r.GetContinuationToken(), nil
+}
+
+// AssignIdentities assigns identities to a group, right now using the type user which is disconnected
+// form the identity type
+func (s *Service) AssignIdentities(ctx context.Context, ID string, identities ...string) error {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.AssignIdentities")
+	defer span.End()
+
+	ids := make([]ofga.Tuple, 0)
+
+	for _, identity := range identities {
+		// TODO @shipperizer swap user for identity if/when model changes
+		ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", identity), MEMBER_RELATION, s.buildGroupMember(ctx, ID)))
+	}
+
+	err := s.ofga.WriteTuples(ctx, ids...)
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// RemoveIdentities removes identities from a group
+func (s *Service) RemoveIdentities(ctx context.Context, ID string, identities ...string) error {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.RemoveIdentities")
+	defer span.End()
+
+	ids := make([]ofga.Tuple, 0)
+
+	for _, identity := range identities {
+		// TODO @shipperizer swap user for identity if/when model changes
+		ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", identity), MEMBER_RELATION, s.buildGroupMember(ctx, ID)))
+	}
+
+	err := s.ofga.DeleteTuples(ctx, ids...)
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// TODO @shipperizer make this more scalable by pushing to a channel and using goroutine pool
+// potentially create a background operator that can pipe results to an on demand channel and works off a
+// set amount of goroutines
+func (s *Service) listPermissionsByType(ctx context.Context, ID, pType, continuationToken string) ([]string, string, error) {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.listPermissionsByType")
+	defer span.End()
+
+	r, err := s.ofga.ReadTuples(ctx, s.buildGroupMember(ctx, ID), "", fmt.Sprintf("%s:", pType), continuationToken)
+
+	if err != nil {
+		s.logger.Error(err.Error())
+		return nil, "", err
+	}
+
+	permissions := make([]string, 0)
+
+	for _, t := range r.GetTuples() {
+		permissions = append(permissions, authorization.NewUrn(t.Key.Relation, t.Key.Object).ID())
+	}
+
+	return permissions, r.GetContinuationToken(), nil
+}
+
+func (s *Service) removePermissionsByType(ctx context.Context, ID, pType string) {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.removePermissionsByType")
+	defer span.End()
+
+	cToken := ""
+	memberRelation := s.buildGroupMember(ctx, ID)
+	permissions := make([]ofga.Tuple, 0)
+	for {
+		r, err := s.ofga.ReadTuples(ctx, memberRelation, "", fmt.Sprintf("%s:", pType), cToken)
+
+		if err != nil {
+			s.logger.Errorf("error when retrieving tuples for %s %s", memberRelation, pType)
+			return
+		}
+
+		for _, t := range r.Tuples {
+			permissions = append(permissions, *ofga.NewTuple(memberRelation, t.Key.Relation, t.Key.Object))
+		}
+
+		// if there are more pages, keep going with the loop
+		if cToken = r.ContinuationToken; cToken != "" {
+			continue
+		}
+
+		// TODO @shipperizer understand if better breaking at every cycle or reverting if clause
+		break
+	}
+
+	if err := s.ofga.DeleteTuples(ctx, permissions...); err != nil {
+		s.logger.Error(err.Error())
+	}
+}
+
+func (s *Service) permissionTypes() []string {
+	return []string{"group", "role", "identity", "scheme", "provider", "client"}
+}
+
+// NewService returns the implementtation of the business logic for the groups API
+func NewService(ofga OpenFGAClientInterface, tracer trace.Tracer, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *Service {
+	s := new(Service)
+
+	s.ofga = ofga
+	s.monitor = monitor
+	s.tracer = tracer
+	s.logger = logger
+
+	return s
+}

--- a/pkg/groups/service_test.go
+++ b/pkg/groups/service_test.go
@@ -1,0 +1,1150 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL
+
+package groups
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/authorization"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	ofga "github.com/canonical/identity-platform-admin-ui/internal/openfga"
+	openfga "github.com/openfga/go-sdk"
+	"github.com/openfga/go-sdk/client"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/mock/gomock"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package groups -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package groups -destination ./mock_interfaces.go -source=./interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package groups -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package groups -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+
+func TestServiceListGroups(t *testing.T) {
+	type expected struct {
+		err    error
+		groups []string
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected expected
+	}{
+		{
+			name:  "empty result",
+			input: "administrator",
+			expected: expected{
+				groups: []string{},
+				err:    nil,
+			},
+		},
+		{
+			name:  "error",
+			input: "administrator",
+			expected: expected{
+				groups: []string{},
+				err:    fmt.Errorf("error"),
+			},
+		},
+		{
+			name:  "full result",
+			input: "administrator",
+			expected: expected{
+				groups: []string{"global", "administrator", "devops"},
+				err:    nil,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockOpenFGA := NewMockOpenFGAClientInterface(ctrl)
+
+			svc := NewService(mockOpenFGA, mockTracer, mockMonitor, mockLogger)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.ListGroups").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockOpenFGA.EXPECT().ListObjects(gomock.Any(), fmt.Sprintf("user:%s", test.input), "can_view", "group").Return(test.expected.groups, test.expected.err)
+
+			if test.expected.err != nil {
+				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+			}
+
+			groups, err := svc.ListGroups(context.Background(), test.input)
+
+			if err != test.expected.err {
+				t.Errorf("expected error to be %v got %v", test.expected.err, err)
+			}
+
+			if test.expected.err == nil && !reflect.DeepEqual(groups, test.expected.groups) {
+				t.Errorf("invalid result, expected: %v, got: %v", test.expected.groups, groups)
+			}
+		})
+	}
+}
+
+func TestServiceListRoles(t *testing.T) {
+	type expected struct {
+		err   error
+		roles []string
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected expected
+	}{
+		{
+			name:  "empty result",
+			input: "administrator",
+			expected: expected{
+				roles: []string{},
+				err:   nil,
+			},
+		},
+		{
+			name:  "error",
+			input: "administrator",
+			expected: expected{
+				roles: []string{},
+				err:   fmt.Errorf("error"),
+			},
+		},
+		{
+			name:  "full result",
+			input: "administrator",
+			expected: expected{
+				roles: []string{"global", "administrator", "viewer"},
+				err:   nil,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockOpenFGA := NewMockOpenFGAClientInterface(ctrl)
+
+			svc := NewService(mockOpenFGA, mockTracer, mockMonitor, mockLogger)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.ListRoles").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockOpenFGA.EXPECT().ListObjects(gomock.Any(), fmt.Sprintf("group:%s#%s", test.input, MEMBER_RELATION), ASSIGNEE_RELATION, "role").Return(test.expected.roles, test.expected.err)
+
+			if test.expected.err != nil {
+				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+			}
+
+			roles, err := svc.ListRoles(context.Background(), test.input)
+
+			if err != test.expected.err {
+				t.Errorf("expected error to be %v got %v", test.expected.err, err)
+			}
+
+			if test.expected.err == nil && !reflect.DeepEqual(roles, test.expected.roles) {
+				t.Errorf("invalid result, expected: %v, got: %v", test.expected.roles, roles)
+			}
+		})
+	}
+}
+
+func TestServiceListIdentities(t *testing.T) {
+	type expected struct {
+		err    error
+		tuples []string
+		token  string
+	}
+
+	type input struct {
+		group string
+		token string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected expected
+		output   []string
+	}{
+		{
+			name: "empty result",
+			input: input{
+				group: "administrator",
+			},
+			expected: expected{
+				tuples: []string{},
+				token:  "",
+				err:    nil,
+			},
+			output: []string{},
+		},
+		{
+			name: "error",
+			input: input{
+				group: "administrator",
+			},
+			expected: expected{
+				tuples: []string{},
+				token:  "",
+				err:    fmt.Errorf("error"),
+			},
+		},
+		{
+			name: "full result without token",
+			input: input{
+				group: "administrator",
+			},
+			expected: expected{
+				tuples: []string{
+					"group:c-level#member",
+					"group:it-admin#member",
+					"user:joe",
+					"user:test",
+				},
+				token: "test",
+				err:   nil,
+			},
+			output: []string{
+				"user:joe",
+				"user:test",
+			},
+		},
+		{
+			name: "full result with token",
+			input: input{
+				group: "administrator",
+				token: "test",
+			},
+			expected: expected{
+				tuples: []string{
+					"group:c-level#member",
+					"group:it-admin#member",
+					"user:joe",
+					"user:test",
+				},
+				token: "",
+				err:   nil,
+			},
+			output: []string{
+				"user:joe",
+				"user:test",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockOpenFGA := NewMockOpenFGAClientInterface(ctrl)
+
+			r := new(client.ClientReadResponse)
+
+			tuples := []openfga.Tuple{}
+			for _, t := range test.expected.tuples {
+				tuples = append(
+					tuples,
+					*openfga.NewTuple(
+						*openfga.NewTupleKey(
+							t, ASSIGNEE_RELATION, fmt.Sprintf("group:%s", test.input.group),
+						),
+						time.Now(),
+					),
+				)
+			}
+
+			r.SetContinuationToken(test.expected.token)
+			r.SetTuples(tuples)
+
+			svc := NewService(mockOpenFGA, mockTracer, mockMonitor, mockLogger)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.ListIdentities").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockOpenFGA.EXPECT().ReadTuples(gomock.Any(), "", MEMBER_RELATION, fmt.Sprintf("group:%s", test.input.group), test.input.token).Return(r, test.expected.err)
+
+			if test.expected.err != nil {
+				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+			}
+
+			identities, token, err := svc.ListIdentities(context.Background(), test.input.group, test.input.token)
+
+			if err != test.expected.err {
+				t.Errorf("expected error to be %v got %v", test.expected.err, err)
+			}
+
+			if test.expected.err == nil && token != test.expected.token {
+				t.Errorf("invalid result, expected: %v, got: %v", test.expected.token, token)
+			}
+
+			if test.expected.err == nil && !reflect.DeepEqual(identities, test.output) {
+				t.Errorf("invalid result, expected: %v, got: %v", test.output, identities)
+			}
+		})
+	}
+}
+
+func TestServiceAssignRoles(t *testing.T) {
+	type input struct {
+		group string
+		roles []string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+	}{
+		{
+			name: "error",
+			input: input{
+				group: "administrator",
+				roles: []string{"viewer"},
+			},
+			expected: fmt.Errorf("error"),
+		},
+		{
+			name: "multiple roles",
+			input: input{
+				group: "administrator",
+				roles: []string{"viewer", "writer", "super"},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockOpenFGA := NewMockOpenFGAClientInterface(ctrl)
+
+			svc := NewService(mockOpenFGA, mockTracer, mockMonitor, mockLogger)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.AssignRoles").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockOpenFGA.EXPECT().WriteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+				func(ctx context.Context, tuples ...ofga.Tuple) error {
+					roles := make([]ofga.Tuple, 0)
+
+					for _, role := range test.input.roles {
+						roles = append(roles, *ofga.NewTuple(fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION), ASSIGNEE_RELATION, fmt.Sprintf("role:%s", role)))
+					}
+
+					if !reflect.DeepEqual(roles, tuples) {
+						t.Errorf("expected tuples to be %v got %v", roles, tuples)
+					}
+
+					return test.expected
+				},
+			)
+
+			if test.expected != nil {
+				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+			}
+
+			err := svc.AssignRoles(context.Background(), test.input.group, test.input.roles...)
+
+			if err != test.expected {
+				t.Errorf("expected error to be %v got %v", test.expected, err)
+			}
+		})
+	}
+}
+
+func TestServiceRemoveRoles(t *testing.T) {
+	type input struct {
+		group string
+		roles []string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+	}{
+		{
+			name: "error",
+			input: input{
+				group: "administrator",
+				roles: []string{"viewer"},
+			},
+			expected: fmt.Errorf("error"),
+		},
+		{
+			name: "multiple roles",
+			input: input{
+				group: "administrator",
+				roles: []string{"viewer", "writer", "super"},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockOpenFGA := NewMockOpenFGAClientInterface(ctrl)
+
+			svc := NewService(mockOpenFGA, mockTracer, mockMonitor, mockLogger)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.RemoveRoles").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockOpenFGA.EXPECT().DeleteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+				func(ctx context.Context, tuples ...ofga.Tuple) error {
+					roles := make([]ofga.Tuple, 0)
+
+					for _, role := range test.input.roles {
+						roles = append(roles, *ofga.NewTuple(fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION), ASSIGNEE_RELATION, fmt.Sprintf("role:%s", role)))
+					}
+
+					if !reflect.DeepEqual(roles, tuples) {
+						t.Errorf("expected tuples to be %v got %v", roles, tuples)
+					}
+
+					return test.expected
+				},
+			)
+
+			if test.expected != nil {
+				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+			}
+
+			err := svc.RemoveRoles(context.Background(), test.input.group, test.input.roles...)
+
+			if err != test.expected {
+				t.Errorf("expected error to be %v got %v", test.expected, err)
+			}
+		})
+	}
+}
+
+func TestServiceAssignIdentities(t *testing.T) {
+	type input struct {
+		group      string
+		identities []string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+	}{
+		{
+			name: "error",
+			input: input{
+				group:      "administrator",
+				identities: []string{"joe"},
+			},
+			expected: fmt.Errorf("error"),
+		},
+		{
+			name: "multiple identities",
+			input: input{
+				group:      "administrator",
+				identities: []string{"joe", "james", "ubork"},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockOpenFGA := NewMockOpenFGAClientInterface(ctrl)
+
+			svc := NewService(mockOpenFGA, mockTracer, mockMonitor, mockLogger)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.AssignIdentities").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockOpenFGA.EXPECT().WriteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+				func(ctx context.Context, tuples ...ofga.Tuple) error {
+					ids := make([]ofga.Tuple, 0)
+
+					for _, i := range test.input.identities {
+						ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", i), MEMBER_RELATION, fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION)))
+					}
+
+					if !reflect.DeepEqual(ids, tuples) {
+						t.Errorf("expected tuples to be %v got %v", ids, tuples)
+					}
+
+					return test.expected
+				},
+			)
+
+			if test.expected != nil {
+				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+			}
+
+			err := svc.AssignIdentities(context.Background(), test.input.group, test.input.identities...)
+
+			if err != test.expected {
+				t.Errorf("expected error to be %v got %v", test.expected, err)
+			}
+		})
+	}
+}
+
+func TestServiceRemoveIdentities(t *testing.T) {
+	type input struct {
+		group      string
+		identities []string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+	}{
+		{
+			name: "error",
+			input: input{
+				group:      "administrator",
+				identities: []string{"joe"},
+			},
+			expected: fmt.Errorf("error"),
+		},
+		{
+			name: "multiple identities",
+			input: input{
+				group:      "administrator",
+				identities: []string{"joe", "james", "ubork"},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockOpenFGA := NewMockOpenFGAClientInterface(ctrl)
+
+			svc := NewService(mockOpenFGA, mockTracer, mockMonitor, mockLogger)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.RemoveIdentities").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockOpenFGA.EXPECT().DeleteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+				func(ctx context.Context, tuples ...ofga.Tuple) error {
+					ids := make([]ofga.Tuple, 0)
+
+					for _, i := range test.input.identities {
+						ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", i), MEMBER_RELATION, fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION)))
+					}
+
+					if !reflect.DeepEqual(ids, tuples) {
+						t.Errorf("expected tuples to be %v got %v", ids, tuples)
+					}
+
+					return test.expected
+				},
+			)
+
+			if test.expected != nil {
+				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+			}
+
+			err := svc.RemoveIdentities(context.Background(), test.input.group, test.input.identities...)
+
+			if err != test.expected {
+				t.Errorf("expected error to be %v got %v", test.expected, err)
+			}
+		})
+	}
+}
+
+func TestServiceGetGroup(t *testing.T) {
+	type expected struct {
+		err   error
+		check bool
+	}
+
+	type input struct {
+		group string
+		user  string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected expected
+	}{
+		{
+			name: "not found",
+			input: input{
+				group: "administrator",
+				user:  "admin",
+			},
+			expected: expected{
+				check: false,
+				err:   nil,
+			},
+		},
+		{
+			name: "error",
+			input: input{
+				group: "administrator",
+				user:  "admin",
+			},
+			expected: expected{
+				check: false,
+				err:   fmt.Errorf("error"),
+			},
+		},
+		{
+			name: "found",
+			input: input{
+				group: "administrator",
+				user:  "admin",
+			},
+			expected: expected{
+				check: true,
+				err:   nil,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockOpenFGA := NewMockOpenFGAClientInterface(ctrl)
+
+			svc := NewService(mockOpenFGA, mockTracer, mockMonitor, mockLogger)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.GetGroup").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockOpenFGA.EXPECT().Check(gomock.Any(), fmt.Sprintf("user:%s", test.input.user), "can_view", fmt.Sprintf("group:%s", test.input.group)).Return(test.expected.check, test.expected.err)
+
+			if test.expected.err != nil {
+				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+			}
+
+			group, err := svc.GetGroup(context.Background(), test.input.user, test.input.group)
+
+			if err != test.expected.err {
+				t.Errorf("expected error to be %v got %v", test.expected.err, err)
+			}
+
+			if test.expected.err == nil && test.expected.check && group != test.input.group {
+				t.Errorf("invalid result, expected: %v, got: %v", test.input.group, group)
+			}
+		})
+	}
+}
+
+func TestServiceCreateGroup(t *testing.T) {
+	type input struct {
+		group string
+		user  string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+	}{
+		{
+			name: "error",
+			input: input{
+				group: "administrator",
+				user:  "admin",
+			},
+			expected: fmt.Errorf("error"),
+		},
+		{
+			name: "found",
+			input: input{
+				group: "administrator",
+				user:  "admin",
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockOpenFGA := NewMockOpenFGAClientInterface(ctrl)
+
+			svc := NewService(mockOpenFGA, mockTracer, mockMonitor, mockLogger)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.CreateGroup").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+
+			mockOpenFGA.EXPECT().WriteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+				func(ctx context.Context, tuples ...ofga.Tuple) error {
+					ps := make([]ofga.Tuple, 0)
+
+					ps = append(
+						ps,
+						*ofga.NewTuple(fmt.Sprintf("user:%s", test.input.user), MEMBER_RELATION, fmt.Sprintf("group:%s", test.input.group)),
+						*ofga.NewTuple(authorization.ADMIN_PRIVILEGE, "privileged", fmt.Sprintf("group:%s", test.input.group)),
+					)
+
+					if !reflect.DeepEqual(ps, tuples) {
+						t.Errorf("expected tuples to be %v got %v", ps, tuples)
+					}
+
+					return test.expected
+				},
+			)
+
+			if test.expected != nil {
+				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+			}
+
+			err := svc.CreateGroup(context.Background(), test.input.user, test.input.group)
+
+			if err != test.expected {
+				t.Errorf("expected error to be %v got %v", test.expected, err)
+			}
+		})
+	}
+}
+
+func TestServiceDeleteGroup(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected error
+	}{
+		{
+			name:     "error",
+			input:    "administrator",
+			expected: fmt.Errorf("error"),
+		},
+		{
+			name:     "found",
+			input:    "administrator",
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockOpenFGA := NewMockOpenFGAClientInterface(ctrl)
+
+			svc := NewService(mockOpenFGA, mockTracer, mockMonitor, mockLogger)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.DeleteGroup").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.removePermissionsByType").Times(6).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+
+			pTypes := []string{"role", "group", "identity", "scheme", "provider", "client"}
+
+			calls := []*gomock.Call{}
+
+			for _, pType := range pTypes {
+
+				calls = append(
+					calls,
+					mockOpenFGA.EXPECT().ReadTuples(gomock.Any(), fmt.Sprintf("group:%s#%s", test.input, MEMBER_RELATION), "", fmt.Sprintf("%s:", pType), "").Times(1).DoAndReturn(
+						func(ctx context.Context, user, relation, object, continuationToken string) (*client.ClientReadResponse, error) {
+							if test.expected != nil {
+								return nil, test.expected
+							}
+
+							tuples := []openfga.Tuple{
+								*openfga.NewTuple(
+									*openfga.NewTupleKey(
+										user, "can_edit", fmt.Sprintf("%s:test", pType),
+									),
+									time.Now(),
+								),
+							}
+
+							r := new(client.ClientReadResponse)
+							r.SetContinuationToken("")
+							r.SetTuples(tuples)
+
+							return r, nil
+						},
+					),
+				)
+
+			}
+
+			if test.expected == nil {
+				mockOpenFGA.EXPECT().DeleteTuples(
+					gomock.Any(),
+					gomock.Any(),
+				).Times(7).DoAndReturn(
+					func(ctx context.Context, tuples ...ofga.Tuple) error {
+						if len(tuples) != 1 {
+							t.Errorf("too many tuples")
+						}
+
+						tuple := tuples[0]
+
+						if tuple.User != fmt.Sprintf("group:%s#%s", test.input, MEMBER_RELATION) && tuple.User != authorization.ADMIN_PRIVILEGE {
+							t.Errorf("expected user to be one of %v got %v", []string{fmt.Sprintf("group:%s#%s", test.input, MEMBER_RELATION), authorization.ADMIN_PRIVILEGE}, tuple.User)
+						}
+
+						if tuple.Relation != "privileged" && tuple.Relation != "can_edit" {
+							t.Errorf("expected relation to be one of %v got %v", []string{"privileged", "can_edit"}, tuple.Relation)
+						}
+
+						if tuple.Object != fmt.Sprintf("group:%s", test.input) && !strings.HasSuffix(tuple.Object, ":test") {
+							t.Errorf("expected object to be one of %v got %v", []string{fmt.Sprintf("group:%s", test.input), "<*>:test"}, tuple.Object)
+						}
+
+						return nil
+					},
+				)
+			} else {
+				// TODO @shipperizer fix this so that we can pin it down to the error case only
+				mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				mockOpenFGA.EXPECT().DeleteTuples(
+					gomock.Any(),
+					*ofga.NewTuple(authorization.ADMIN_PRIVILEGE, "privileged", fmt.Sprintf("group:%s", test.input)),
+				).Return(test.expected)
+			}
+
+			gomock.InAnyOrder(calls)
+			err := svc.DeleteGroup(context.Background(), test.input)
+
+			if err != test.expected {
+				t.Errorf("expected error to be %v got %v", test.expected, err)
+			}
+		})
+	}
+}
+
+func TestServiceListPermissions(t *testing.T) {
+	type input struct {
+		group   string
+		cTokens map[string]string
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+	}{
+		{
+			name: "error",
+			input: input{
+				group: "administrator",
+			},
+			expected: fmt.Errorf("error"),
+		},
+		{
+			name: "found",
+			input: input{
+				group: "administrator",
+				cTokens: map[string]string{
+					"group": "test",
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockOpenFGA := NewMockOpenFGAClientInterface(ctrl)
+
+			svc := NewService(mockOpenFGA, mockTracer, mockMonitor, mockLogger)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.ListPermissions").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.listPermissionsByType").Times(6).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+
+			pTypes := []string{"role", "group", "identity", "scheme", "provider", "client"}
+			expCTokens := map[string]string{
+				"role":     "",
+				"group":    "",
+				"identity": "",
+				"scheme":   "",
+				"provider": "",
+				"client":   "",
+			}
+
+			expPermissions := []string{
+				"can_edit::role:test",
+				"can_edit::group:test",
+				"can_edit::identity:test",
+				"can_edit::scheme:test",
+				"can_edit::provider:test",
+				"can_edit::client:test",
+			}
+
+			calls := []*gomock.Call{}
+
+			for _, _ = range pTypes {
+				calls = append(
+					calls,
+					mockOpenFGA.EXPECT().ReadTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+						func(ctx context.Context, user, relation, object, continuationToken string) (*client.ClientReadResponse, error) {
+							if test.expected != nil {
+								return nil, test.expected
+							}
+
+							if user != fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION) {
+								t.Errorf("wrong user parameter expected %s got %s", fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION), user)
+							}
+
+							if object == "group:" && continuationToken != "test" {
+								t.Errorf("missing continuation token %s", test.input.cTokens["groups"])
+							}
+
+							tuples := []openfga.Tuple{
+								*openfga.NewTuple(
+									*openfga.NewTupleKey(
+										user, "can_edit", fmt.Sprintf("%stest", object),
+									),
+									time.Now(),
+								),
+							}
+
+							r := new(client.ClientReadResponse)
+							r.SetContinuationToken("")
+							r.SetTuples(tuples)
+
+							return r, nil
+						},
+					),
+				)
+			}
+
+			if test.expected != nil {
+				// TODO @shipperizer fix this so that we can pin it down to the error case only
+				mockLogger.EXPECT().Error(gomock.Any()).Times(12)
+			}
+
+			gomock.InAnyOrder(calls)
+			permissions, cTokens, err := svc.ListPermissions(context.Background(), test.input.group, test.input.cTokens)
+
+			if err != nil && test.expected != nil {
+				t.Errorf("expected error to be silenced and return nil got %v instead", err)
+			}
+
+			sort.Strings(permissions)
+			sort.Strings(expPermissions)
+
+			if err == nil && test.expected == nil && !reflect.DeepEqual(permissions, expPermissions) {
+				t.Errorf("expected permissions to be %v got %v", expPermissions, permissions)
+			}
+
+			if err == nil && test.expected == nil && !reflect.DeepEqual(cTokens, expCTokens) {
+				t.Errorf("expected continuation tokens to be %v got %v", expCTokens, cTokens)
+			}
+		})
+	}
+}
+
+func TestServiceAssignPermissions(t *testing.T) {
+	type input struct {
+		group       string
+		permissions []Permission
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+	}{
+		{
+			name: "error",
+			input: input{
+				group: "administrator",
+				permissions: []Permission{
+					{Relation: "can_delete", Object: "group:admin"},
+				},
+			},
+			expected: fmt.Errorf("error"),
+		},
+		{
+			name: "multiple permissions",
+			input: input{
+				group: "administrator",
+				permissions: []Permission{
+					{Relation: "can_view", Object: "client:okta"},
+					{Relation: "can_edit", Object: "client:okta"},
+					{Relation: "can_delete", Object: "group:admin"},
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockOpenFGA := NewMockOpenFGAClientInterface(ctrl)
+
+			svc := NewService(mockOpenFGA, mockTracer, mockMonitor, mockLogger)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.AssignPermissions").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockOpenFGA.EXPECT().WriteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+				func(ctx context.Context, tuples ...ofga.Tuple) error {
+					ps := make([]ofga.Tuple, 0)
+
+					for _, p := range test.input.permissions {
+						ps = append(ps, *ofga.NewTuple(fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION), p.Relation, p.Object))
+					}
+
+					if !reflect.DeepEqual(ps, tuples) {
+						t.Errorf("expected tuples to be %v got %v", ps, tuples)
+					}
+
+					return test.expected
+				},
+			)
+
+			if test.expected != nil {
+				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+			}
+
+			err := svc.AssignPermissions(context.Background(), test.input.group, test.input.permissions...)
+
+			if err != test.expected {
+				t.Errorf("expected error to be %v got %v", test.expected, err)
+			}
+		})
+	}
+}
+
+func TestServiceRemovePermissions(t *testing.T) {
+	type input struct {
+		group       string
+		permissions []Permission
+	}
+
+	tests := []struct {
+		name     string
+		input    input
+		expected error
+	}{
+		{
+			name: "error",
+			input: input{
+				group: "administrator",
+				permissions: []Permission{
+					{Relation: "can_delete", Object: "group:admin"},
+				},
+			},
+			expected: fmt.Errorf("error"),
+		},
+		{
+			name: "multiple permissions",
+			input: input{
+				group: "administrator",
+				permissions: []Permission{
+					{Relation: "can_view", Object: "client:okta"},
+					{Relation: "can_edit", Object: "client:okta"},
+					{Relation: "can_delete", Object: "group:admin"},
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+			mockOpenFGA := NewMockOpenFGAClientInterface(ctrl)
+
+			svc := NewService(mockOpenFGA, mockTracer, mockMonitor, mockLogger)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.RemovePermissions").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			mockOpenFGA.EXPECT().DeleteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
+				func(ctx context.Context, tuples ...ofga.Tuple) error {
+					ps := make([]ofga.Tuple, 0)
+
+					for _, p := range test.input.permissions {
+						ps = append(ps, *ofga.NewTuple(fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION), p.Relation, p.Object))
+					}
+
+					if !reflect.DeepEqual(ps, tuples) {
+						t.Errorf("expected tuples to be %v got %v", ps, tuples)
+					}
+
+					return test.expected
+				},
+			)
+
+			if test.expected != nil {
+				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
+			}
+
+			err := svc.RemovePermissions(context.Background(), test.input.group, test.input.permissions...)
+
+			if err != test.expected {
+				t.Errorf("expected error to be %v got %v", test.expected, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
IAM-366: groups API following openapi spec v0.8.0 (to a degree)

- **feat: handlers for groups API**
- **feat: create groups service**
- **feat: introduce groups API converter to deal with authorization in the middleware**
