### PR TITLE
fix: address segfault when using noop client

### DIFF
--- a/internal/openfga/noop.go
+++ b/internal/openfga/noop.go
@@ -59,7 +59,7 @@ func (c *NoopClient) DeleteTuples(ctx context.Context, tuples ...Tuple) error {
 }
 
 func (c *NoopClient) ReadModel(ctx context.Context) (*openfga.AuthorizationModel, error) {
-	return nil, nil
+	return new(openfga.AuthorizationModel), nil
 }
 
 func (c *NoopClient) WriteModel(ctx context.Context, model []byte) (string, error) {
@@ -71,5 +71,5 @@ func (c *NoopClient) CompareModel(ctx context.Context, model openfga.Authorizati
 }
 
 func (c *NoopClient) ReadTuples(ctx context.Context, user, relation, object, continuationToken string) (*client.ClientReadResponse, error) {
-	return nil, nil
+	return new(client.ClientReadResponse), nil
 }


### PR DESCRIPTION
NoopClient was returning an empty response and a nil error, this triggered

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x178ca01]

goroutine 77 [running]:
github.com/canonical/identity-platform-admin-ui/pkg/roles.(*Service).removePermissionsByType(0xc0008bcf00, {0x1ebc708?, 0xc0005cd800?}, {0xc0003d07f5, 0x6}, {0x1bf2a94, 0x6})
	/root/parts/go-build/build/pkg/roles/service.go:292 +0x261
github.com/canonical/identity-platform-admin-ui/pkg/roles.(*Service).DeleteRole.func1({0x1bf2a94?, 0x0?})
	/root/parts/go-build/build/pkg/roles/service.go:245 +0x77
created by github.com/canonical/identity-platform-admin-ui/pkg/roles.(*Service).DeleteRole in goroutine 70
	/root/parts/go-build/build/pkg/roles/service.go:243 +0x24b
```

returning a response with no tuples is more realistic
