### PR TITLE
IAM-773: drop non can_ relations from group entitlements

### DIFF
--- a/pkg/groups/service.go
+++ b/pkg/groups/service.go
@@ -382,6 +382,11 @@ func (s *Service) listPermissionsByType(ctx context.Context, ID, pType, continua
 	permissions := make([]string, 0)
 
 	for _, t := range r.GetTuples() {
+		// if relation doesn't start with can_ it means it's not a permission (see #assignee)
+		if !strings.HasPrefix(t.Key.Relation, "can_") {
+			continue
+		}
+
 		permissions = append(permissions, authorization.NewUrn(t.Key.Relation, t.Key.Object).ID())
 	}
 

--- a/pkg/groups/service_test.go
+++ b/pkg/groups/service_test.go
@@ -957,6 +957,16 @@ func TestServiceListPermissions(t *testing.T) {
 								),
 							}
 
+							if object == "role:role" {
+								tuples = append(tuples,
+									*openfga.NewTuple(
+										*openfga.NewTupleKey(
+											fmt.Sprintf("group:%s#%s", user, MEMBER_RELATION), "assignee", fmt.Sprintf("%stest", object),
+										),
+										time.Now(),
+									),
+								)
+							}
 							r := new(client.ClientReadResponse)
 							r.SetContinuationToken("")
 							r.SetTuples(tuples)


### PR DESCRIPTION
IAM-773: addressing group entitlements issue, closes #243
