### PR TITLE
feat: TokenPaginator enhancements + fix to properly handle empty tokens

### DIFF
--- a/internal/http/types/token.go
+++ b/internal/http/types/token.go
@@ -9,9 +9,10 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
 	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
-	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -25,6 +26,7 @@ type TokenPaginator struct {
 	logger logging.LoggerInterface
 }
 
+// LoadFromRequest populates the TokenPaginator struct with pagination tokens from the r request
 func (p *TokenPaginator) LoadFromRequest(ctx context.Context, r *http.Request) error {
 	_, span := p.tracer.Start(ctx, "types.TokenPaginator.LoadFromRequest")
 	defer span.End()
@@ -56,6 +58,8 @@ func (p *TokenPaginator) LoadFromRequest(ctx context.Context, r *http.Request) e
 	return nil
 }
 
+// SetToken sets a pagination token value for the specified type represented by key
+// if the pagination token is an empty string, SetToken will be a noop
 func (p *TokenPaginator) SetToken(ctx context.Context, key, value string) {
 	p.tokens[key] = value
 }
@@ -72,6 +76,7 @@ func (p *TokenPaginator) GetAllTokens(ctx context.Context) map[string]string {
 	return p.tokens
 }
 
+// PaginationHeader returns a composite pagination token string to use as a header
 func (p *TokenPaginator) PaginationHeader(ctx context.Context) (string, error) {
 	_, span := p.tracer.Start(ctx, "types.TokenPaginator.PaginationHeader")
 	defer span.End()

--- a/internal/http/types/token.go
+++ b/internal/http/types/token.go
@@ -53,7 +53,7 @@ func (p *TokenPaginator) LoadFromRequest(ctx context.Context, r *http.Request) e
 		return err
 	}
 
-	p.tokens = tokens
+	p.SetTokens(context.TODO(), tokens)
 
 	return nil
 }
@@ -61,9 +61,30 @@ func (p *TokenPaginator) LoadFromRequest(ctx context.Context, r *http.Request) e
 // SetToken sets a pagination token value for the specified type represented by key
 // if the pagination token is an empty string, SetToken will be a noop
 func (p *TokenPaginator) SetToken(ctx context.Context, key, value string) {
-	p.tokens[key] = value
+	if value != "" {
+		p.tokens[key] = value
+	}
 }
 
+// SetTokens sets its internal pagination tokens map to a copy of the provided map
+// if any of the pagination tokens is an empty string, it will not be set
+func (p *TokenPaginator) SetTokens(ctx context.Context, tokens map[string]string) {
+	if tokens == nil {
+		return
+	}
+
+	for key := range p.tokens {
+		delete(p.tokens, key)
+	}
+
+	for key, value := range tokens {
+		if value != "" {
+			p.tokens[key] = value
+		}
+	}
+}
+
+// GetToken returns the token value mapped to type "key", or empty string if key is not present
 func (p *TokenPaginator) GetToken(ctx context.Context, key string) string {
 	if token, ok := p.tokens[key]; ok {
 		return token

--- a/internal/http/types/token_test.go
+++ b/internal/http/types/token_test.go
@@ -1,0 +1,109 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/mock/gomock"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package types -destination ./mock_logger.go -source=../../logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package types -destination ./mock_tracer.go -source=../../tracing/interfaces.go
+
+func TestLoadFromRequestSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockLogger := NewMockLoggerInterface(ctrl)
+
+	p := TokenPaginator{
+		tokens: make(map[string]string),
+		tracer: mockTracer,
+		logger: mockLogger,
+	}
+
+	mockTracer.EXPECT().Start(gomock.Eq(context.TODO()), gomock.Any()).Return(nil, trace.SpanFromContext(context.TODO()))
+
+	mockRequest := httptest.NewRequest(http.MethodGet, "/path/to/endpoint", nil)
+	// base64("{"token-1": "continuation-token-1","token-2":"continuation-token-2","token-3":""}")
+	const mockValue = "eyJ0b2tlbi0xIjogImNvbnRpbnVhdGlvbi10b2tlbi0xIiwidG9rZW4tMiI6ImNvbnRpbnVhdGlvbi10b2tlbi0yIiwidG9rZW4tMyI6IiJ9"
+	mockRequest.Header.Set(
+		"X-Token-Pagination",
+		mockValue,
+	)
+
+	err := p.LoadFromRequest(context.TODO(), mockRequest)
+	if err != nil {
+		t.Errorf("Unexpected error while running LoadFromRequest")
+	}
+
+	expectedMap := make(map[string]string, 2)
+	expectedMap["token-1"] = "continuation-token-1"
+	expectedMap["token-2"] = "continuation-token-2"
+
+	if !reflect.DeepEqual(p.tokens, expectedMap) {
+		t.Fail()
+	}
+}
+
+func TestLoadFromRequestSuccessNoHeader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockLogger := NewMockLoggerInterface(ctrl)
+
+	p := TokenPaginator{
+		tokens: make(map[string]string),
+		tracer: mockTracer,
+		logger: mockLogger,
+	}
+
+	mockTracer.EXPECT().Start(gomock.Eq(context.TODO()), gomock.Any()).Return(nil, trace.SpanFromContext(context.TODO()))
+
+	mockRequest := httptest.NewRequest(http.MethodGet, "/path/to/endpoint", nil)
+
+	err := p.LoadFromRequest(context.TODO(), mockRequest)
+	if err != nil {
+		t.Errorf("Unexpected error while running LoadFromRequest")
+	}
+
+	if p.tokens == nil {
+		t.Fail()
+	}
+}
+
+func TestLoadFromRequestFailure_WrongHeaderValue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockLogger := NewMockLoggerInterface(ctrl)
+
+	p := TokenPaginator{
+		tokens: make(map[string]string),
+		tracer: mockTracer,
+		logger: mockLogger,
+	}
+
+	mockTracer.EXPECT().Start(gomock.Eq(context.TODO()), gomock.Any()).Return(nil, trace.SpanFromContext(context.TODO()))
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
+
+	mockRequest := httptest.NewRequest(http.MethodGet, "/path/to/endpoint", nil)
+	// base64("definitely not a json string")
+	const mockValue = "ZGVmaW5pdGVseSBub3QgYSBqc29uIHN0cmluZw=="
+	mockRequest.Header.Set(
+		"X-Token-Pagination",
+		mockValue,
+	)
+
+	err := p.LoadFromRequest(context.TODO(), mockRequest)
+	if err == nil {
+		t.Fail()
+	}
+}

--- a/pkg/groups/handlers.go
+++ b/pkg/groups/handlers.go
@@ -291,9 +291,7 @@ func (a *API) handleListPermission(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for apiType, token := range pageTokens {
-		paginator.SetToken(r.Context(), apiType, token)
-	}
+	paginator.SetTokens(r.Context(), pageTokens)
 
 	pageHeader, err := paginator.PaginationHeader(r.Context())
 
@@ -569,9 +567,7 @@ func (a *API) handleListIdentities(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if pageToken != "" {
-		paginator.SetToken(r.Context(), GROUP_TOKEN_KEY, pageToken)
-	}
+	paginator.SetToken(r.Context(), GROUP_TOKEN_KEY, pageToken)
 
 	pageHeader, err := paginator.PaginationHeader(r.Context())
 

--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -278,9 +278,7 @@ func (a *API) handleListPermission(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for apiType, token := range pageTokens {
-		paginator.SetToken(r.Context(), apiType, token)
-	}
+	paginator.SetTokens(r.Context(), pageTokens)
 
 	pageHeader, err := paginator.PaginationHeader(r.Context())
 
@@ -330,9 +328,7 @@ func (a *API) handleListRoleGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if pageToken != "" {
-		paginator.SetToken(r.Context(), ROLE_TOKEN_KEY, pageToken)
-	}
+	paginator.SetToken(r.Context(), ROLE_TOKEN_KEY, pageToken)
 
 	pageHeader, err := paginator.PaginationHeader(r.Context())
 


### PR DESCRIPTION
## Description
This PR provides a new method to set multiple tokens at a time on the `TokenPaginator` object, while also adding tests for non-trivial methods.

## Changes
- sorted imports and added godocs
- added `SetTokens` method
  - now both `SetToken` and `SetTokens` methods don't actually set empty token values, in order to have an empty TokenHeader in case no continuation tokens are available
- added tests for non-trivial methods

## Fixes
#238 