### PR TITLE
Improve identity provider forms in UI

### DIFF
--- a/pkg/idp/third_party.go
+++ b/pkg/idp/third_party.go
@@ -63,7 +63,7 @@ type Configuration struct {
 
 	// SubjectSource is a flag which controls from which endpoint the subject identifier is taken by microsoft provider.
 	// Can be either `userinfo` or `me`.
-	// If the value is `uerinfo` then the subject identifier is taken from sub field of uderifo standard endpoint response.
+	// If the value is `userinfo` then the subject identifier is taken from sub field of userinfo standard endpoint response.
 	// If the value is `me` then the `id` field of https://graph.microsoft.com/v1.0/me response is taken as subject.
 	// The default is `userinfo`.
 	SubjectSource string `json:"subject_source" yaml:"subject_source"`

--- a/ui/.eslintrc.cjs
+++ b/ui/.eslintrc.cjs
@@ -35,5 +35,6 @@ module.exports = {
     semi: ["error", "always"],
     "object-curly-spacing": ["error", "always"],
     "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    "react/react-in-jsx-scope": "off",
   },
 };

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@canonical/react-components": "0.51.0",
     "@tanstack/react-query": "^5.28.6",
+    "@use-it/event-listener": "0.1.7",
     "formik": "2.4.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Suspense } from "react";
+import { FC, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import Loader from "components/Loader";
 import ClientList from "pages/clients/ClientList";

--- a/ui/src/components/CheckboxList.tsx
+++ b/ui/src/components/CheckboxList.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { CheckboxInput, Col, Row } from "@canonical/react-components";
 
 interface Props {

--- a/ui/src/components/Loader.tsx
+++ b/ui/src/components/Loader.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { Spinner } from "@canonical/react-components";
 
 interface Props {

--- a/ui/src/components/Logo.tsx
+++ b/ui/src/components/Logo.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { NavLink } from "react-router-dom";
 
 const Logo: FC = () => {

--- a/ui/src/components/Navigation.tsx
+++ b/ui/src/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { NavLink } from "react-router-dom";
 import { Button, Icon } from "@canonical/react-components";
 import classnames from "classnames";

--- a/ui/src/components/NoMatch.tsx
+++ b/ui/src/components/NoMatch.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { Row, Col } from "@canonical/react-components";
 
 const NoMatch: FC = () => {

--- a/ui/src/components/Panels.tsx
+++ b/ui/src/components/Panels.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ProviderCreate from "pages/providers/ProviderCreate";
 import usePanelParams, { panels } from "util/usePanelParams";
 import ProviderEdit from "pages/providers/ProviderEdit";

--- a/ui/src/components/ScrollableContainer.tsx
+++ b/ui/src/components/ScrollableContainer.tsx
@@ -1,0 +1,41 @@
+import { DependencyList, FC, ReactNode, useEffect, useRef } from "react";
+import useEventListener from "@use-it/event-listener";
+import { getAbsoluteHeightBelow, getParentsBottomSpacing } from "util/helpers";
+
+interface Props {
+  children: ReactNode;
+  dependencies: DependencyList;
+  belowId?: string;
+}
+
+const ScrollableContainer: FC<Props> = ({
+  dependencies,
+  children,
+  belowId = "",
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const updateChildContainerHeight = () => {
+    const childContainer = ref.current?.children[0];
+    if (!childContainer) {
+      return;
+    }
+    const above = childContainer.getBoundingClientRect().top + 1;
+    const below = getAbsoluteHeightBelow(belowId);
+    const parentsBottomSpacing = getParentsBottomSpacing(childContainer);
+    const offset = Math.ceil(above + below + parentsBottomSpacing);
+    const style = `height: calc(100vh - ${offset}px); min-height: calc(100vh - ${offset}px)`;
+    childContainer.setAttribute("style", style);
+  };
+
+  useEventListener("resize", updateChildContainerHeight);
+  useEffect(updateChildContainerHeight, [...dependencies, ref]);
+
+  return (
+    <div ref={ref} className="scrollable-container">
+      <div className="content-details">{children}</div>
+    </div>
+  );
+};
+
+export default ScrollableContainer;

--- a/ui/src/components/SidePanel.tsx
+++ b/ui/src/components/SidePanel.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, ReactNode } from "react";
+import { FC, PropsWithChildren, ReactNode } from "react";
 import Loader from "components/Loader";
 import classnames from "classnames";
 import { Spinner } from "@canonical/react-components";

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter as Router } from "react-router-dom";
 import Navigation from "components/Navigation";

--- a/ui/src/pages/clients/ClientCreate.tsx
+++ b/ui/src/pages/clients/ClientCreate.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from "react-router-dom";
 import ClientForm, { ClientFormTypes } from "pages/clients/ClientForm";
 import { createClient } from "api/client";
 import SidePanel from "components/SidePanel";
+import ScrollableContainer from "components/ScrollableContainer";
 
 const ClientCreate: FC = () => {
   const navigate = useNavigate();
@@ -57,31 +58,35 @@ const ClientCreate: FC = () => {
 
   return (
     <SidePanel hasError={false} loading={false} className="p-panel">
-      <SidePanel.Header>
-        <SidePanel.HeaderTitle>Add client</SidePanel.HeaderTitle>
-      </SidePanel.Header>
-      <SidePanel.Content>
-        <Row>
-          <ClientForm formik={formik} />
-        </Row>
-      </SidePanel.Content>
-      <SidePanel.Footer>
-        <Row className="u-align-text--right">
-          <Col size={12}>
-            <Button appearance="base" onClick={() => navigate("/client")}>
-              Cancel
-            </Button>
-            <ActionButton
-              appearance="positive"
-              loading={formik.isSubmitting}
-              disabled={!formik.isValid}
-              onClick={submitForm}
-            >
-              Save
-            </ActionButton>
-          </Col>
-        </Row>
-      </SidePanel.Footer>
+      <ScrollableContainer dependencies={[]} belowId="panel-footer">
+        <SidePanel.Header>
+          <SidePanel.HeaderTitle>Add client</SidePanel.HeaderTitle>
+        </SidePanel.Header>
+        <SidePanel.Content>
+          <Row>
+            <ClientForm formik={formik} />
+          </Row>
+        </SidePanel.Content>
+      </ScrollableContainer>
+      <div id="panel-footer">
+        <SidePanel.Footer>
+          <Row className="u-align-text--right">
+            <Col size={12}>
+              <Button appearance="base" onClick={() => navigate("/client")}>
+                Cancel
+              </Button>
+              <ActionButton
+                appearance="positive"
+                loading={formik.isSubmitting}
+                disabled={!formik.isValid}
+                onClick={submitForm}
+              >
+                Save
+              </ActionButton>
+            </Col>
+          </Row>
+        </SidePanel.Footer>
+      </div>
     </SidePanel>
   );
 };

--- a/ui/src/pages/clients/ClientCreate.tsx
+++ b/ui/src/pages/clients/ClientCreate.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import {
   ActionButton,
   Button,

--- a/ui/src/pages/clients/ClientEdit.tsx
+++ b/ui/src/pages/clients/ClientEdit.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import {
   ActionButton,
   Button,

--- a/ui/src/pages/clients/ClientEdit.tsx
+++ b/ui/src/pages/clients/ClientEdit.tsx
@@ -15,6 +15,7 @@ import ClientForm, { ClientFormTypes } from "pages/clients/ClientForm";
 import { fetchClient, updateClient } from "api/client";
 import usePanelParams from "util/usePanelParams";
 import SidePanel from "components/SidePanel";
+import ScrollableContainer from "components/ScrollableContainer";
 
 const ClientEdit: FC = () => {
   const navigate = useNavigate();
@@ -69,36 +70,40 @@ const ClientEdit: FC = () => {
 
   return (
     <SidePanel hasError={false} loading={false} className="p-panel">
-      <SidePanel.Header>
-        <SidePanel.HeaderTitle>Edit client</SidePanel.HeaderTitle>
-      </SidePanel.Header>
-      <SidePanel.Content className="u-no-padding">
-        <Row>
-          <ClientForm formik={formik} />
-        </Row>
-      </SidePanel.Content>
-      <SidePanel.Footer className="u-align--right">
-        <Row>
-          <Col size={12}>
-            <Button
-              appearance="base"
-              className="u-no-margin--bottom u-sv2"
-              onClick={() => navigate(`/client`)}
-            >
-              Cancel
-            </Button>
-            <ActionButton
-              appearance="positive"
-              className="u-no-margin--bottom"
-              loading={formik.isSubmitting}
-              disabled={!formik.isValid}
-              onClick={submitForm}
-            >
-              Update
-            </ActionButton>
-          </Col>
-        </Row>
-      </SidePanel.Footer>
+      <ScrollableContainer dependencies={[]} belowId="panel-footer">
+        <SidePanel.Header>
+          <SidePanel.HeaderTitle>Edit client</SidePanel.HeaderTitle>
+        </SidePanel.Header>
+        <SidePanel.Content className="u-no-padding">
+          <Row>
+            <ClientForm formik={formik} />
+          </Row>
+        </SidePanel.Content>
+      </ScrollableContainer>
+      <div id="panel-footer">
+        <SidePanel.Footer className="u-align--right">
+          <Row>
+            <Col size={12}>
+              <Button
+                appearance="base"
+                className="u-no-margin--bottom u-sv2"
+                onClick={() => navigate(`/client`)}
+              >
+                Cancel
+              </Button>
+              <ActionButton
+                appearance="positive"
+                className="u-no-margin--bottom"
+                loading={formik.isSubmitting}
+                disabled={!formik.isValid}
+                onClick={submitForm}
+              >
+                Update
+              </ActionButton>
+            </Col>
+          </Row>
+        </SidePanel.Footer>
+      </div>
     </SidePanel>
   );
 };

--- a/ui/src/pages/clients/ClientForm.tsx
+++ b/ui/src/pages/clients/ClientForm.tsx
@@ -40,17 +40,6 @@ const ClientForm: FC<Props> = ({ formik }) => {
         required
       />
       <Input
-        id="client_uri"
-        name="client_uri"
-        type="text"
-        label="Client uri"
-        onBlur={formik.handleBlur}
-        onChange={formik.handleChange}
-        value={formik.values.client_uri}
-        error={formik.touched.client_uri ? formik.errors.client_uri : null}
-        required
-      />
-      <Input
         id="scope"
         name="scope"
         type="text"
@@ -59,21 +48,6 @@ const ClientForm: FC<Props> = ({ formik }) => {
         onChange={formik.handleChange}
         value={formik.values.scope}
         error={formik.touched.scope ? formik.errors.scope : null}
-        required
-      />
-      <Input
-        id="request_object_signing_alg"
-        name="request_object_signing_alg"
-        type="text"
-        label="Signing algorithm"
-        onBlur={formik.handleBlur}
-        onChange={formik.handleChange}
-        value={formik.values.request_object_signing_alg}
-        error={
-          formik.touched.request_object_signing_alg
-            ? formik.errors.request_object_signing_alg
-            : null
-        }
         required
       />
       <Input
@@ -88,6 +62,32 @@ const ClientForm: FC<Props> = ({ formik }) => {
         value={formik.values.redirect_uris}
         error={
           formik.touched.redirect_uris ? formik.errors.redirect_uris : null
+        }
+        required
+      />
+      <Input
+        id="client_uri"
+        name="client_uri"
+        type="text"
+        label="Client uri"
+        onBlur={formik.handleBlur}
+        onChange={formik.handleChange}
+        value={formik.values.client_uri}
+        error={formik.touched.client_uri ? formik.errors.client_uri : null}
+        required
+      />
+      <Input
+        id="request_object_signing_alg"
+        name="request_object_signing_alg"
+        type="text"
+        label="Signing algorithm"
+        onBlur={formik.handleBlur}
+        onChange={formik.handleChange}
+        value={formik.values.request_object_signing_alg}
+        error={
+          formik.touched.request_object_signing_alg
+            ? formik.errors.request_object_signing_alg
+            : null
         }
         required
       />

--- a/ui/src/pages/clients/ClientForm.tsx
+++ b/ui/src/pages/clients/ClientForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { Form, Input } from "@canonical/react-components";
 import { FormikProps } from "formik";
 import CheckboxList from "components/CheckboxList";

--- a/ui/src/pages/clients/ClientList.tsx
+++ b/ui/src/pages/clients/ClientList.tsx
@@ -1,8 +1,7 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { Button, Col, MainTable, Row } from "@canonical/react-components";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
-import { Link } from "react-router-dom";
 import { NotificationConsumer } from "@canonical/react-components/dist/components/NotificationProvider/NotificationProvider";
 import { fetchClients } from "api/client";
 import { isoTimeToString } from "util/date";

--- a/ui/src/pages/clients/DeleteClientBtn.tsx
+++ b/ui/src/pages/clients/DeleteClientBtn.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import { FC, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";

--- a/ui/src/pages/clients/EditClientBtn.tsx
+++ b/ui/src/pages/clients/EditClientBtn.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
 import usePanelParams from "util/usePanelParams";
 

--- a/ui/src/pages/providers/DeleteProviderBtn.tsx
+++ b/ui/src/pages/providers/DeleteProviderBtn.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import { FC, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";

--- a/ui/src/pages/providers/EditProviderBtn.tsx
+++ b/ui/src/pages/providers/EditProviderBtn.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
 import usePanelParams from "util/usePanelParams";
 

--- a/ui/src/pages/providers/ProviderCreate.tsx
+++ b/ui/src/pages/providers/ProviderCreate.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from "react-router-dom";
 import ProviderForm, { ProviderFormTypes } from "pages/providers/ProviderForm";
 import { createProvider } from "api/provider";
 import SidePanel from "components/SidePanel";
+import ScrollableContainer from "components/ScrollableContainer";
 
 const ProviderCreate: FC = () => {
   const navigate = useNavigate();
@@ -32,6 +33,7 @@ const ProviderCreate: FC = () => {
       client_secret: "",
       mapper_url: "file:///etc/config/kratos/okta_schema.jsonnet",
       scope: "email",
+      subject_source: "userinfo",
     },
     validationSchema: ProviderCreateSchema,
     onSubmit: (values) => {
@@ -58,31 +60,35 @@ const ProviderCreate: FC = () => {
 
   return (
     <SidePanel hasError={false} loading={false} className="p-panel">
-      <SidePanel.Header>
-        <SidePanel.HeaderTitle>Add ID provider</SidePanel.HeaderTitle>
-      </SidePanel.Header>
-      <SidePanel.Content>
-        <Row>
-          <ProviderForm formik={formik} />
-        </Row>
-      </SidePanel.Content>
-      <SidePanel.Footer>
-        <Row className="u-align-text--right">
-          <Col size={12}>
-            <Button appearance="base" onClick={() => navigate("/provider")}>
-              Cancel
-            </Button>
-            <ActionButton
-              appearance="positive"
-              loading={formik.isSubmitting}
-              disabled={!formik.isValid}
-              onClick={submitForm}
-            >
-              Save
-            </ActionButton>
-          </Col>
-        </Row>
-      </SidePanel.Footer>
+      <ScrollableContainer dependencies={[]} belowId="panel-footer">
+        <SidePanel.Header>
+          <SidePanel.HeaderTitle>Add ID provider</SidePanel.HeaderTitle>
+        </SidePanel.Header>
+        <SidePanel.Content>
+          <Row>
+            <ProviderForm formik={formik} />
+          </Row>
+        </SidePanel.Content>
+      </ScrollableContainer>
+      <div id="panel-footer">
+        <SidePanel.Footer>
+          <Row className="u-align-text--right">
+            <Col size={12}>
+              <Button appearance="base" onClick={() => navigate("/provider")}>
+                Cancel
+              </Button>
+              <ActionButton
+                appearance="positive"
+                loading={formik.isSubmitting}
+                disabled={!formik.isValid}
+                onClick={submitForm}
+              >
+                Save
+              </ActionButton>
+            </Col>
+          </Row>
+        </SidePanel.Footer>
+      </div>
     </SidePanel>
   );
 };

--- a/ui/src/pages/providers/ProviderCreate.tsx
+++ b/ui/src/pages/providers/ProviderCreate.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import {
   ActionButton,
   Button,

--- a/ui/src/pages/providers/ProviderEdit.tsx
+++ b/ui/src/pages/providers/ProviderEdit.tsx
@@ -14,6 +14,7 @@ import ProviderForm, { ProviderFormTypes } from "pages/providers/ProviderForm";
 import { fetchProvider, updateProvider } from "api/provider";
 import SidePanel from "components/SidePanel";
 import usePanelParams from "util/usePanelParams";
+import ScrollableContainer from "components/ScrollableContainer";
 
 const ProviderEdit: FC = () => {
   const notify = useNotify();
@@ -75,36 +76,40 @@ const ProviderEdit: FC = () => {
 
   return (
     <SidePanel hasError={false} loading={false} className="p-panel">
-      <SidePanel.Header>
-        <SidePanel.HeaderTitle>Edit provider</SidePanel.HeaderTitle>
-      </SidePanel.Header>
-      <SidePanel.Content className="u-no-padding">
-        <Row>
-          <ProviderForm formik={formik} isEdit={true} />
-        </Row>
-      </SidePanel.Content>
-      <SidePanel.Footer className="u-align--right">
-        <Row>
-          <Col size={12}>
-            <Button
-              appearance="base"
-              className="u-no-margin--bottom u-sv2"
-              onClick={panelParams.clear}
-            >
-              Cancel
-            </Button>
-            <ActionButton
-              appearance="positive"
-              className="u-no-margin--bottom"
-              loading={formik.isSubmitting}
-              disabled={!formik.isValid}
-              onClick={() => void formik.submitForm()}
-            >
-              Update
-            </ActionButton>
-          </Col>
-        </Row>
-      </SidePanel.Footer>
+      <ScrollableContainer dependencies={[]} belowId="panel-footer">
+        <SidePanel.Header>
+          <SidePanel.HeaderTitle>Edit provider</SidePanel.HeaderTitle>
+        </SidePanel.Header>
+        <SidePanel.Content className="u-no-padding">
+          <Row>
+            <ProviderForm formik={formik} isEdit={true} />
+          </Row>
+        </SidePanel.Content>
+      </ScrollableContainer>
+      <div id="panel-footer">
+        <SidePanel.Footer className="u-align--right">
+          <Row>
+            <Col size={12}>
+              <Button
+                appearance="base"
+                className="u-no-margin--bottom u-sv2"
+                onClick={panelParams.clear}
+              >
+                Cancel
+              </Button>
+              <ActionButton
+                appearance="positive"
+                className="u-no-margin--bottom"
+                loading={formik.isSubmitting}
+                disabled={!formik.isValid}
+                onClick={() => void formik.submitForm()}
+              >
+                Update
+              </ActionButton>
+            </Col>
+          </Row>
+        </SidePanel.Footer>
+      </div>
     </SidePanel>
   );
 };

--- a/ui/src/pages/providers/ProviderEdit.tsx
+++ b/ui/src/pages/providers/ProviderEdit.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import {
   ActionButton,
   Button,

--- a/ui/src/pages/providers/ProviderForm.tsx
+++ b/ui/src/pages/providers/ProviderForm.tsx
@@ -1,10 +1,5 @@
-import React, { FC } from "react";
-import {
-  Form,
-  Input,
-  Select,
-  Textarea,
-} from "@canonical/react-components";
+import { FC, useState } from "react";
+import { Form, Input, Select, Textarea } from "@canonical/react-components";
 import { FormikProps } from "formik";
 
 const providerOptions = [
@@ -114,7 +109,7 @@ interface Props {
 }
 
 const ProviderForm: FC<Props> = ({ formik, isEdit = false }) => {
-  const [hasAutoDiscovery, setAutoDiscovery] = React.useState(
+  const [hasAutoDiscovery, setAutoDiscovery] = useState(
     !(formik.values.auth_url || formik.values.token_url),
   );
 

--- a/ui/src/pages/providers/ProviderList.tsx
+++ b/ui/src/pages/providers/ProviderList.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { Button, Col, MainTable, Row } from "@canonical/react-components";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";

--- a/ui/src/sass/_forms.scss
+++ b/ui/src/sass/_forms.scss
@@ -1,0 +1,6 @@
+// a section of form elements indented between radio button options with a left border connecting the radio buttons
+.radio-section {
+  margin-left: $spv--small;
+  padding-left: $spv--medium;
+  border-left: $border;
+}

--- a/ui/src/sass/_scrollable_container.scss
+++ b/ui/src/sass/_scrollable_container.scss
@@ -1,0 +1,7 @@
+.scrollable-container {
+  .content-details {
+    display: block;
+    overflow: auto;
+    scrollbar-gutter: stable;
+  }
+}

--- a/ui/src/sass/styles.scss
+++ b/ui/src/sass/styles.scss
@@ -11,4 +11,6 @@
 @include vf-p-icon-user;
 @include vf-p-icon-user-group;
 
+@import "forms";
 @import "logo";
+@import "scrollable_container";

--- a/ui/src/types/provider.d.ts
+++ b/ui/src/types/provider.d.ts
@@ -13,6 +13,6 @@ export interface IdentityProvider {
   provider?: string;
   requested_claims?: string;
   scope?: string[];
-  subject_source?: string;
+  subject_source?: "userinfo" | "me";
   token_url?: string;
 }

--- a/ui/src/util/helpers.tsx
+++ b/ui/src/util/helpers.tsx
@@ -1,0 +1,23 @@
+export const getParentsBottomSpacing = (element: Element): number => {
+  let sum = 0;
+  while (element.parentElement) {
+    element = element.parentElement;
+    const style = window.getComputedStyle(element);
+    const margin = parseInt(style.marginBottom);
+    const padding = parseInt(style.paddingBottom);
+    sum += margin + padding;
+  }
+  return sum;
+};
+
+export const getAbsoluteHeightBelow = (belowId: string): number => {
+  const element = belowId ? document.getElementById(belowId) : undefined;
+  if (!element) {
+    return 0;
+  }
+  const style = window.getComputedStyle(element);
+  const margin = parseFloat(style.marginTop) + parseFloat(style.marginBottom);
+  const padding =
+    parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+  return element.offsetHeight + margin + padding + 1;
+};

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1894,6 +1894,11 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
+"@use-it/event-listener@0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@use-it/event-listener/-/event-listener-0.1.7.tgz#443a9b6df87f2f2961b74d42997ce723a7078623"
+  integrity sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==
+
 "@vitejs/plugin-react@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-4.2.1.tgz#744d8e4fcb120fc3dbaa471dadd3483f5a304bb9"


### PR DESCRIPTION
# Done
* improve identity provider forms: 
  * add subheadings
  * add help texts
  * improve layout
  * improve visual structure
  * add nice visual for selecting auto discovery / manual urls
* make buttons in side panels sticky on the bottom
* avoid react imports

# Screenshots

![Screenshot from 2024-03-26 16-13-58](https://github.com/canonical/identity-platform-admin-ui/assets/1155472/aaf1812d-72c6-45f1-9a0d-613313b6e53f)
![Screenshot from 2024-03-26 16-14-11](https://github.com/canonical/identity-platform-admin-ui/assets/1155472/43ccbe16-1d22-4451-898a-ae016454aba4)
![Screenshot from 2024-03-26 16-14-18](https://github.com/canonical/identity-platform-admin-ui/assets/1155472/8688803e-82fe-4aff-9ced-601bb7821986)
