### PR TITLE
fix: export `GetRequestBodyFromContext` function

### DIFF
--- a/rebac-admin-backend/v1/groups.go
+++ b/rebac-admin-backend/v1/groups.go
@@ -35,7 +35,7 @@ func (h handler) GetGroups(w http.ResponseWriter, req *http.Request, params reso
 func (h handler) PostGroups(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
@@ -89,7 +89,7 @@ func (h handler) GetGroupsItem(w http.ResponseWriter, req *http.Request, id stri
 func (h handler) PutGroupsItem(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
@@ -136,7 +136,7 @@ func (h handler) GetGroupsItemEntitlements(w http.ResponseWriter, req *http.Requ
 func (h handler) PatchGroupsItemEntitlements(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
@@ -183,7 +183,7 @@ func (h handler) GetGroupsItemIdentities(w http.ResponseWriter, req *http.Reques
 func (h handler) PatchGroupsItemIdentities(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
@@ -230,7 +230,7 @@ func (h handler) GetGroupsItemRoles(w http.ResponseWriter, req *http.Request, id
 func (h handler) PatchGroupsItemRoles(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return

--- a/rebac-admin-backend/v1/identities.go
+++ b/rebac-admin-backend/v1/identities.go
@@ -35,7 +35,7 @@ func (h handler) GetIdentities(w http.ResponseWriter, req *http.Request, params 
 func (h handler) PostIdentities(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
@@ -89,7 +89,7 @@ func (h handler) GetIdentitiesItem(w http.ResponseWriter, req *http.Request, id 
 func (h handler) PutIdentitiesItem(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
@@ -136,7 +136,7 @@ func (h handler) GetIdentitiesItemEntitlements(w http.ResponseWriter, req *http.
 func (h handler) PatchIdentitiesItemEntitlements(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
@@ -183,7 +183,7 @@ func (h handler) GetIdentitiesItemGroups(w http.ResponseWriter, req *http.Reques
 func (h handler) PatchIdentitiesItemGroups(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
@@ -230,7 +230,7 @@ func (h handler) GetIdentitiesItemRoles(w http.ResponseWriter, req *http.Request
 func (h handler) PatchIdentitiesItemRoles(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return

--- a/rebac-admin-backend/v1/identity_providers.go
+++ b/rebac-admin-backend/v1/identity_providers.go
@@ -58,7 +58,7 @@ func (h handler) GetIdentityProviders(w http.ResponseWriter, req *http.Request, 
 func (h handler) PostIdentityProviders(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
@@ -112,7 +112,7 @@ func (h handler) GetIdentityProvidersItem(w http.ResponseWriter, req *http.Reque
 func (h handler) PutIdentityProvidersItem(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return

--- a/rebac-admin-backend/v1/roles.go
+++ b/rebac-admin-backend/v1/roles.go
@@ -35,7 +35,7 @@ func (h handler) GetRoles(w http.ResponseWriter, req *http.Request, params resou
 func (h handler) PostRoles(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
@@ -89,7 +89,7 @@ func (h handler) GetRolesItem(w http.ResponseWriter, req *http.Request, id strin
 func (h handler) PutRolesItem(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return
@@ -136,7 +136,7 @@ func (h handler) GetRolesItemEntitlements(w http.ResponseWriter, req *http.Reque
 func (h handler) PatchRolesItemEntitlements(w http.ResponseWriter, req *http.Request, id string) {
 	ctx := req.Context()
 
-	body, err := getRequestBodyFromContext(req.Context())
+	body, err := GetRequestBodyFromContext(req.Context())
 	if err != nil {
 		writeErrorResponse(w, err)
 		return

--- a/rebac-admin-backend/v1/validation.go
+++ b/rebac-admin-backend/v1/validation.go
@@ -34,9 +34,9 @@ func newHandlerWithValidation(handler resources.ServerInterface) *handlerWithVal
 // requestBodyContextKey is the context key to retrieve the parsed request body struct instance.
 type requestBodyContextKey struct{}
 
-// getRequestBodyFromContext fetches request body from given context. If the value
+// GetRequestBodyFromContext fetches request body from given context. If the value
 // was not found in the given context, this will return an error.
-func getRequestBodyFromContext(ctx context.Context) (any, error) {
+func GetRequestBodyFromContext(ctx context.Context) (any, error) {
 	body := ctx.Value(requestBodyContextKey{})
 	if body == nil {
 		return nil, NewMissingRequestBodyError("request body is not available")


### PR DESCRIPTION
This is to export the `GetRequestBodyFromContext` function.

Fixes CSS-7621