### PR TITLE
UI: Add schemas and identities read only screens WD-10036

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <title>Canonical IAM</title>
+    <title>Identity platform</title>
     <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" type="image/x-icon" />
 
     <script>const global = globalThis;</script>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,6 +4,8 @@ import Loader from "components/Loader";
 import ClientList from "pages/clients/ClientList";
 import NoMatch from "components/NoMatch";
 import ProviderList from "pages/providers/ProviderList";
+import IdentityList from "pages/identities/IdentityList";
+import SchemaList from "pages/schemas/SchemaList";
 
 const App: FC = () => {
   return (
@@ -12,6 +14,8 @@ const App: FC = () => {
         <Route path="/" element={<Navigate to="/provider" replace={true} />} />
         <Route path="/provider" element={<ProviderList />} />
         <Route path="/client" element={<ClientList />} />
+        <Route path="/identity" element={<IdentityList />} />
+        <Route path="/schema" element={<SchemaList />} />
         <Route path="*" element={<NoMatch />} />
       </Routes>
     </Suspense>

--- a/ui/src/api/identities.tsx
+++ b/ui/src/api/identities.tsx
@@ -1,0 +1,58 @@
+import { ApiResponse } from "types/api";
+import { handleResponse } from "util/api";
+import { Identity } from "types/identity";
+
+export const fetchIdentities = (): Promise<Identity[]> => {
+  return new Promise((resolve, reject) => {
+    fetch("/api/v0/identities")
+      .then(handleResponse)
+      .then((result: ApiResponse<Identity[]>) => resolve(result.data))
+      .catch(reject);
+  });
+};
+
+export const fetchIdentity = (identityId: string): Promise<Identity> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/api/v0/identities/${identityId}`)
+      .then(handleResponse)
+      .then((result: ApiResponse<Identity[]>) => resolve(result.data[0]))
+      .catch(reject);
+  });
+};
+
+export const createIdentity = (body: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    fetch("/api/v0/identities", {
+      method: "POST",
+      body: body,
+    })
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
+export const updateIdentity = (
+  identityId: string,
+  values: string,
+): Promise<Identity> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/api/v0/identities/${identityId}`, {
+      method: "PATCH",
+      body: values,
+    })
+      .then(handleResponse)
+      .then((result: ApiResponse<Identity>) => resolve(result.data))
+      .catch(reject);
+  });
+};
+
+export const deleteIdentity = (identityId: string) => {
+  return new Promise((resolve, reject) => {
+    fetch(`/api/v0/identities/${identityId}`, {
+      method: "DELETE",
+    })
+      .then(resolve)
+      .catch(reject);
+  });
+};

--- a/ui/src/api/schema.tsx
+++ b/ui/src/api/schema.tsx
@@ -1,0 +1,58 @@
+import { ApiResponse } from "types/api";
+import { handleResponse } from "util/api";
+import { Schema } from "types/schema";
+
+export const fetchSchemas = (): Promise<Schema[]> => {
+  return new Promise((resolve, reject) => {
+    fetch("/api/v0/schemas")
+      .then(handleResponse)
+      .then((result: ApiResponse<Schema[]>) => resolve(result.data))
+      .catch(reject);
+  });
+};
+
+export const fetchSchema = (schemaId: string): Promise<Schema> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/api/v0/schemas/${schemaId}`)
+      .then(handleResponse)
+      .then((result: ApiResponse<Schema[]>) => resolve(result.data[0]))
+      .catch(reject);
+  });
+};
+
+export const createSchema = (body: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    fetch("/api/v0/schemas", {
+      method: "POST",
+      body: body,
+    })
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
+export const updateSchema = (
+  schemaId: string,
+  values: string,
+): Promise<Schema> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/api/v0/schemas/${schemaId}`, {
+      method: "PATCH",
+      body: values,
+    })
+      .then(handleResponse)
+      .then((result: ApiResponse<Schema>) => resolve(result.data))
+      .catch(reject);
+  });
+};
+
+export const deleteSchema = (schemaId: string) => {
+  return new Promise((resolve, reject) => {
+    fetch(`/api/v0/schemas/${schemaId}`, {
+      method: "DELETE",
+    })
+      .then(resolve)
+      .catch(reject);
+  });
+};

--- a/ui/src/components/Logo.tsx
+++ b/ui/src/components/Logo.tsx
@@ -11,7 +11,7 @@ const Logo: FC = () => {
           alt="Circle of friends"
         />
       </div>
-      <div className="logo-text p-heading--4">Canonical IAM</div>
+      <div className="logo-text p-heading--4">Identity platform</div>
     </NavLink>
   );
 };

--- a/ui/src/components/Navigation.tsx
+++ b/ui/src/components/Navigation.tsx
@@ -54,6 +54,32 @@ const Navigation: FC = () => {
                       Clients
                     </NavLink>
                   </li>
+                  <li className="p-side-navigation__item secondary">
+                    <NavLink
+                      className="p-side-navigation__link"
+                      to={`/identity`}
+                      title={`Identity list`}
+                    >
+                      <Icon
+                        className="is-light p-side-navigation__icon"
+                        name="user"
+                      />{" "}
+                      Identities
+                    </NavLink>
+                  </li>
+                  <li className="p-side-navigation__item secondary">
+                    <NavLink
+                      className="p-side-navigation__link"
+                      to={`/schema`}
+                      title={`Schema list`}
+                    >
+                      <Icon
+                        className="is-light p-side-navigation__icon"
+                        name="profile"
+                      />{" "}
+                      Schemas
+                    </NavLink>
+                  </li>
                 </ul>
               </div>
             </div>

--- a/ui/src/pages/identities/IdentityList.tsx
+++ b/ui/src/pages/identities/IdentityList.tsx
@@ -1,0 +1,72 @@
+import React, { FC } from "react";
+import { Col, MainTable, Row } from "@canonical/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { NotificationConsumer } from "@canonical/react-components/dist/components/NotificationProvider/NotificationProvider";
+import { fetchIdentities } from "api/identities";
+import { isoTimeToString } from "util/date";
+
+const IdentityList: FC = () => {
+  const { data: identities = [] } = useQuery({
+    queryKey: [queryKeys.identities],
+    queryFn: fetchIdentities,
+  });
+
+  return (
+    <div className="p-panel">
+      <div className="p-panel__header ">
+        <div className="p-panel__title">
+          <h1 className="p-heading--4 u-no-margin--bottom">Identities</h1>
+        </div>
+      </div>
+      <div className="p-panel__content">
+        <Row>
+          <Col size={12}>
+            <NotificationConsumer />
+            <MainTable
+              className="u-table-layout--auto"
+              sortable
+              responsive
+              paginate={30}
+              headers={[
+                { content: "Id", sortKey: "id" },
+                { content: "Schema", sortKey: "schema" },
+                { content: "Created at", sortKey: "createdAt" },
+              ]}
+              rows={identities.map((identity) => {
+                return {
+                  columns: [
+                    {
+                      content: identity.traits?.email ?? identity.id,
+                      role: "rowheader",
+                      "aria-label": "Id",
+                    },
+                    {
+                      content: identity.schema_id,
+                      role: "rowheader",
+                      "aria-label": "Schema",
+                    },
+                    {
+                      content: identity.created_at
+                        ? isoTimeToString(identity.created_at)
+                        : "",
+                      role: "rowheader",
+                      "aria-label": "Created at",
+                    },
+                  ],
+                  sortData: {
+                    id: identity.id,
+                    schema: identity.schema_id,
+                    createdAt: identity.created_at,
+                  },
+                };
+              })}
+            />
+          </Col>
+        </Row>
+      </div>
+    </div>
+  );
+};
+
+export default IdentityList;

--- a/ui/src/pages/schemas/SchemaList.tsx
+++ b/ui/src/pages/schemas/SchemaList.tsx
@@ -1,0 +1,61 @@
+import React, { FC } from "react";
+import { Col, MainTable, Row } from "@canonical/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { NotificationConsumer } from "@canonical/react-components/dist/components/NotificationProvider/NotificationProvider";
+import { fetchSchemas } from "api/schema";
+
+const SchemaList: FC = () => {
+  const { data: schemas = [] } = useQuery({
+    queryKey: [queryKeys.schemas],
+    queryFn: fetchSchemas,
+  });
+
+  return (
+    <div className="p-panel">
+      <div className="p-panel__header ">
+        <div className="p-panel__title">
+          <h1 className="p-heading--4 u-no-margin--bottom">Schemas</h1>
+        </div>
+      </div>
+      <div className="p-panel__content">
+        <Row>
+          <Col size={12}>
+            <NotificationConsumer />
+            <MainTable
+              className="u-table-layout--auto"
+              sortable
+              responsive
+              paginate={30}
+              headers={[
+                { content: "Id", sortKey: "id" },
+                { content: "Schema" },
+              ]}
+              rows={schemas.map((schema) => {
+                return {
+                  columns: [
+                    {
+                      content: schema.id,
+                      role: "rowheader",
+                      "aria-label": "Id",
+                    },
+                    {
+                      content: JSON.stringify(schema.schema),
+                      role: "rowheader",
+                      "aria-label": "Name",
+                    },
+                  ],
+                  sortData: {
+                    id: schema.id,
+                  },
+                };
+              })}
+            />
+          </Col>
+        </Row>
+      </div>
+    </div>
+  );
+};
+
+export default SchemaList;

--- a/ui/src/types/identity.d.ts
+++ b/ui/src/types/identity.d.ts
@@ -1,0 +1,16 @@
+export interface Identity {
+  id: string;
+  schema_id: string;
+  schema_url: string;
+  state: string;
+  state_changed_at: string;
+  traits?: {
+    email?: string;
+    username?: string;
+  };
+  metadata_public?: string;
+  metadata_admin?: string;
+  created_at?: string;
+  updated_at?: string;
+  organization_id?: string;
+}

--- a/ui/src/types/schema.d.ts
+++ b/ui/src/types/schema.d.ts
@@ -1,0 +1,4 @@
+export interface Schema {
+  id: string;
+  schema: object;
+}


### PR DESCRIPTION
# Done
- change logo copy and page title to "Identity Platform"
- added read only screen for schemas
- added read only screen for identities
- added navigation entries for schemas and identities
- added typescript crud bindings for schemas and identities

# Screenshots
![Screenshot from 2024-03-28 18-10-41](https://github.com/canonical/identity-platform-admin-ui/assets/1155472/2dba747c-a08a-43ef-9696-ad10b7504b3b)
![Screenshot from 2024-03-28 18-10-45](https://github.com/canonical/identity-platform-admin-ui/assets/1155472/69769e8c-e3af-454f-9f2e-6fa08430ceea)
