### PR TITLE
IAM-749: set openfga model and store env vars to dummy values for correct validation of admin-ui

### DIFF
--- a/deployments/kubectl/configMap.yaml
+++ b/deployments/kubectl/configMap.yaml
@@ -22,7 +22,8 @@ data:
   OPENFGA_API_HOST: openfga.default.svc.cluster.local:8080
   OPENFGA_API_TOKEN: "42"
   AUTHORIZATION_ENABLED: "false"
-
+  OPENFGA_STORE_ID: "-----to-be-replaced----"
+  OPENFGA_AUTHORIZATION_MODEL_ID: "-----to-be-replaced----"
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
IAM-749: openfga client config validation needs store and model ids set, the k8s job will
substitute those with valid values in the dev setup
