### PR TITLE
fix: skip validation config on createFGAmodel cmd

### DIFF
--- a/cmd/createFgaModel.go
+++ b/cmd/createFgaModel.go
@@ -63,9 +63,21 @@ func createModel(apiUrl, apiToken, storeId, kubeconfig, k8sConfigMap string) {
 		panic(err)
 	}
 
-	cfg := openfga.NewConfig(scheme, host, storeId, apiToken, "", false, tracer, monitor, logger)
+	// skip validation for openfga object
+	cfg := openfga.Config{
 
-	fgaClient := openfga.NewClient(cfg)
+		ApiScheme:   scheme,
+		ApiHost:     host,
+		StoreID:     storeId,
+		ApiToken:    apiToken,
+		AuthModelID: "",
+		Debug:       false,
+		Tracer:      tracer,
+		Monitor:     monitor,
+		Logger:      logger,
+	}
+
+	fgaClient := openfga.NewClient(&cfg)
 
 	if storeId == "" {
 		storeId, err = fgaClient.CreateStore(ctx, "identity-admin-ui")

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -30,6 +30,9 @@ manifests:
     - "deployments/kubectl/*"
 
 deploy:
+  statusCheck: true
+  statusCheckDeadlineSeconds:	180
+  tolerateFailuresUntilDeadline: true
   kubectl: {}
   helm:
     releases:


### PR DESCRIPTION
IAM-749: drop validation of openfga config in `create-model` command


also:
- allow grace period on deployment to let k8s job to its course and change the configmap

```
shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-749 ● λ make dev
after job admin-ui-openfga-setup has run, restart the identity-platform-admin-ui deployment
to make sure the changes in the configmap are picked up
Generating tags...
 - identity-platform-admin-ui -> localhost:32000/identity-platform-admin-ui:v1.5.0-104-gffd6563-dirty
Starting build...
Building [identity-platform-admin-ui]...
Target platforms: [linux/amd64]
Starting rockcraft, version 1.2.3
Logging execution to '/home/shipperizer/.local/state/rockcraft/log/rockcraft-20240403-081206.459244.log'
Launching managed ubuntu 22.04 instance...
Starting instance
Starting rockcraft, version 1.2.3
Logging execution to '/tmp/rockcraft.log'
Extracting bare:latest
Extracted bare:latest
Initialising lifecycle
Installing build-packages
Installing build-snaps
Skipping pull for certificates (already ran)
Updating sources for go-build (source changed)
Skipping pull for pebble (already ran)
Reapplying certificates (previous layer changed)
Reapplying go-build (previous layer changed)
Reapplying pebble (previous layer changed)
Skipping build for certificates (already ran)
Updating build for go-build ('PULL' step changed)
:: + make npm-build build
.
.
.
NOTES:
1. Get the application URL by running these commands:
  export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=openfga,app.kubernetes.io/instance=openfga" -o jsonpath="{.items[0].metadata.name}")
  export CONTAINER_PORT=$(kubectl get pod --namespace default $POD_NAME -o jsonpath="{.spec.containers[0].ports[1].containerPort}")
  echo "Visit http://127.0.0.1:8080 to use your application"
  kubectl --namespace default port-forward $POD_NAME 8080:$CONTAINER_PORT
WARN[0107] image [localhost:32000/identity-platform-admin-ui:v1.5.0-104-gffd6563-dirty@sha256:d316301b489e4730e325230368c64752d4d7359bb5c19befaaa830e841cd8a48] is not used.  subtask=-1 task=DevLoop
WARN[0107] See helm documentation on how to replace image names with their actual tags: https://skaffold.dev/docs/pipeline-stages/deployers/helm/#image-configuration  subtask=-1 task=DevLoop
Waiting for deployments to stabilize...
 - statefulset/kratos-courier is ready. [5/6 deployment(s) still pending]
 - deployment/kratos is ready. [4/6 deployment(s) still pending]
 - statefulset/postgresql is ready. [3/6 deployment(s) still pending]
 - deployment/hydra is ready. [2/6 deployment(s) still pending]
 - deployment/oathkeeper: waiting for rollout to finish: 0 of 1 updated replicas are available...
 - deployment/openfga: waiting for rollout to finish: 0 of 1 updated replicas are available...
 - deployment/oathkeeper is ready. [1/6 deployment(s) still pending]
 - deployment/openfga is ready.
Deployments stabilized in 8.069 seconds
 - configmap/identity-platform-admin-ui created
 - configmap/idps created
 - configmap/identity-schemas created
 - deployment.apps/identity-platform-admin-ui created
 - job.batch/admin-ui-openfga-setup created
 - service/identity-platform-admin-ui created
Waiting for deployments to stabilize...
 - deployment/identity-platform-admin-ui: container identity-platform-admin-ui terminated with exit code 2
    - pod/identity-platform-admin-ui-6bd5f98ff4-t8jxj: container identity-platform-admin-ui terminated with exit code 2
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] panic: issues setting up OpenFGA client Configuration.StoreId is not a valid ulid
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] goroutine 1 [running]:
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/canonical/identity-platform-admin-ui/internal/openfga.NewClient(0xc000866990)
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/internal/openfga/client.go:376 +0x2dd
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/canonical/identity-platform-admin-ui/cmd.serve()
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/cmd/serve.go:66 +0x2f7
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/canonical/identity-platform-admin-ui/cmd.glob..func4(0xc00081b200?, {0x1c7dd19?, 0x4?, 0x1c7dd1d?})
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/cmd/serve.go:41 +0xf
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/spf13/cobra.(*Command).execute(0x2e84740, {0x2ed04e0, 0x0, 0x0})
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/vendor/github.com/spf13/cobra/command.go:987 +0xaa3
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/spf13/cobra.(*Command).ExecuteC(0x2e84460)
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/vendor/github.com/spf13/cobra/command.go:1115 +0x3ff
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/spf13/cobra.(*Command).Execute(...)
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/vendor/github.com/spf13/cobra/command.go:1039
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/canonical/identity-platform-admin-ui/cmd.Execute()
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/cmd/root.go:22 +0x1a
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] main.main()
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/main.go:9 +0xf
 - deployment/identity-platform-admin-ui: container identity-platform-admin-ui terminated with exit code 2
    - pod/identity-platform-admin-ui-6bd5f98ff4-t8jxj: container identity-platform-admin-ui terminated with exit code 2
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] panic: issues setting up OpenFGA client Configuration.StoreId is not a valid ulid
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] goroutine 1 [running]:
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/canonical/identity-platform-admin-ui/internal/openfga.NewClient(0xc000866990)
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/internal/openfga/client.go:376 +0x2dd
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/canonical/identity-platform-admin-ui/cmd.serve()
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/cmd/serve.go:66 +0x2f7
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/canonical/identity-platform-admin-ui/cmd.glob..func4(0xc00081b200?, {0x1c7dd19?, 0x4?, 0x1c7dd1d?})
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/cmd/serve.go:41 +0xf
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/spf13/cobra.(*Command).execute(0x2e84740, {0x2ed04e0, 0x0, 0x0})
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/vendor/github.com/spf13/cobra/command.go:987 +0xaa3
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/spf13/cobra.(*Command).ExecuteC(0x2e84460)
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/vendor/github.com/spf13/cobra/command.go:1115 +0x3ff
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/spf13/cobra.(*Command).Execute(...)
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/vendor/github.com/spf13/cobra/command.go:1039
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] github.com/canonical/identity-platform-admin-ui/cmd.Execute()
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/cmd/root.go:22 +0x1a
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] main.main()
      > [identity-platform-admin-ui-6bd5f98ff4-t8jxj identity-platform-admin-ui] 	/root/parts/go-build/build/main.go:9 +0xf
 - deployment/identity-platform-admin-ui is ready.
Deployments stabilized in 14.192 seconds
Port forwarding service/oathkeeper-api in namespace default, remote port 4456 -> http://127.0.0.1:14456
Port forwarding service/openfga in namespace default, remote port 8080 -> http://127.0.0.1:14457
Port forwarding service/hydra-admin in namespace default, remote port 4445 -> http://127.0.0.1:14445
Port forwarding service/hydra-public in namespace default, remote port 4444 -> http://127.0.0.1:14444
Port forwarding service/kratos-public in namespace default, remote port 80 -> http://127.0.0.1:14433
Port forwarding service/identity-platform-admin-ui in namespace default, remote port 80 -> http://127.0.0.1:8000
Port forwarding service/kratos-admin in namespace default, remote port 80 -> http://127.0.0.1:14434
WARN[0131] could not map pods to service default/kratos-courier/80: no pods match service kratos-courier/80  subtask=service/kratos-courier task=PortForward
Port forwarding service/kratos-courier in namespace default, remote port 80 -> http://127.0.0.1:4503
Port forwarding service/openfga in namespace default, remote port 8081 -> http://127.0.0.1:8081
Port forwarding service/postgresql-hl in namespace default, remote port 5432 -> http://127.0.0.1:5432
Port forwarding service/openfga in namespace default, remote port 3000 -> http://127.0.0.1:3000
Port forwarding service/openfga in namespace default, remote port 2112 -> http://127.0.0.1:2112
Port forwarding service/postgresql in namespace default, remote port 5432 -> http://127.0.0.1:5433
Press Ctrl+C to exit


```
