### PR TITLE
feat: setup validation for APIs

### DIFF
--- a/internal/validation/registry.go
+++ b/internal/validation/registry.go
@@ -1,0 +1,93 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package validation
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
+)
+
+const apiVersion = "v0"
+
+type ValidationRegistryInterface interface {
+	ValidationMiddleware(next http.Handler) http.Handler
+	RegisterValidatingFunc(key string, vf ValidatingFunc) error
+}
+
+type ValidatingFunc func(r *http.Request) validator.ValidationErrors
+
+type ValidationRegistry struct {
+	validatingFuncs map[string]ValidatingFunc
+
+	tracer  tracing.TracingInterface
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
+}
+
+func (v *ValidationRegistry) ValidationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, span := v.tracer.Start(r.Context(), "validator.ValidationRegistry.ValidationMiddleware")
+		defer span.End()
+
+		r = r.WithContext(ctx)
+		key := v.apiKey(r.URL.Path)
+
+		vf, ok := v.validatingFuncs[key]
+		if !ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if validationErr := vf(r); validationErr != nil {
+			e := NewValidationError(validationErr)
+
+			w.WriteHeader(e.Status)
+			_ = json.NewEncoder(w).Encode(e)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (v *ValidationRegistry) RegisterValidatingFunc(key string, vf ValidatingFunc) error {
+	if vf == nil {
+		return fmt.Errorf("validatingFunc can't be null")
+	}
+
+	if _, ok := v.validatingFuncs[key]; ok {
+		return fmt.Errorf("key is already registered")
+	}
+
+	v.validatingFuncs[key] = vf
+
+	return nil
+}
+
+func (v *ValidationRegistry) apiKey(endpoint string) string {
+	after, found := strings.CutPrefix(endpoint, fmt.Sprintf("/api/%s/", apiVersion))
+	if !found {
+		return ""
+	}
+	return strings.SplitN(after, "/", 1)[0]
+}
+
+func NewRegistry(tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *ValidationRegistry {
+	v := new(ValidationRegistry)
+	v.validatingFuncs = make(map[string]ValidatingFunc)
+
+	v.tracer = tracer
+	v.monitor = monitor
+	v.logger = logger
+
+	return v
+}

--- a/internal/validation/registry_test.go
+++ b/internal/validation/registry_test.go
@@ -1,0 +1,188 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package validation
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/mock/gomock"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package validation -destination ./mock_logger.go -source=../logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package validation -destination ./mock_monitor.go -source=../monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package validation -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+
+func TestValidator_Middleware(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	tracer := NewMockTracer(ctrl)
+	monitor := NewMockMonitorInterface(ctrl)
+	logger := NewMockLoggerInterface(ctrl)
+
+	tracer.EXPECT().
+		Start(gomock.Any(), gomock.Eq("validator.ValidationRegistry.ValidationMiddleware")).
+		Times(2).
+		Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+
+	mainHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("main handler\n"))
+	})
+
+	vld := NewRegistry(tracer, monitor, logger)
+	vld.validatingFuncs["mock-key"] = func(r *http.Request) validator.ValidationErrors {
+		type InvalidStruct struct {
+			FirstName string `validate:"required"`
+		}
+
+		e := validator.New(validator.WithRequiredStructEnabled()).Struct(InvalidStruct{})
+		if e == nil {
+			return nil
+		}
+		return e.(validator.ValidationErrors)
+	}
+
+	for _, tt := range []struct {
+		name            string
+		expctedResponse string
+		expectedCode    int
+		mockRequest     *http.Request
+	}{
+		{
+			name:         "MatchingPrefix",
+			expectedCode: http.StatusBadRequest,
+			mockRequest:  httptest.NewRequest(http.MethodGet, "/api/v0/mock-key", nil),
+		},
+		{
+			name:            "NoMatchingPrefix",
+			expctedResponse: "main handler\n",
+			expectedCode:    http.StatusOK,
+			mockRequest:     httptest.NewRequest(http.MethodGet, "/api/v0/different-mock-key", nil),
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mockResponse := httptest.NewRecorder()
+
+			decoratedHandler := vld.ValidationMiddleware(mainHandler)
+			decoratedHandler.ServeHTTP(mockResponse, tt.mockRequest)
+
+			responseValue := mockResponse.Body.String()
+
+			if mockResponse.Code != tt.expectedCode {
+				t.Fatalf("actual response code differes from expected")
+			}
+
+			if tt.expctedResponse == "" {
+				return
+			}
+
+			if responseValue != tt.expctedResponse {
+				t.Fatalf("actual response body differes from expected")
+			}
+		})
+	}
+}
+
+func TestValidator_RegisterValidator(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	tracer := NewMockTracer(ctrl)
+	monitor := NewMockMonitorInterface(ctrl)
+	logger := NewMockLoggerInterface(ctrl)
+
+	emptyValidator := &ValidationRegistry{
+		validatingFuncs: make(map[string]ValidatingFunc),
+		tracer:          tracer,
+		monitor:         monitor,
+		logger:          logger,
+	}
+
+	noopVf := ValidatingFunc(func(r *http.Request) validator.ValidationErrors {
+		return nil
+	})
+	validatingFuncs := make(map[string]ValidatingFunc)
+	validatingFuncs["mock-key-1"] = noopVf
+
+	nonEmptyValidator := &ValidationRegistry{
+		validatingFuncs: validatingFuncs,
+		tracer:          tracer,
+		monitor:         monitor,
+		logger:          logger,
+	}
+
+	for _, tt := range []struct {
+		name      string
+		validator *ValidationRegistry
+		prefix    string
+		vf        ValidatingFunc
+		expected  string
+	}{
+		{
+			name:      "Nil middleware",
+			validator: emptyValidator,
+			prefix:    "",
+			vf:        nil,
+			expected:  "validatingFunc can't be null",
+		},
+		{
+			name:      "Existing key",
+			validator: nonEmptyValidator,
+			prefix:    "mock-key-1",
+			vf:        noopVf,
+			expected:  "key is already registered",
+		},
+		{
+			name:      "Success",
+			validator: emptyValidator,
+			prefix:    "mock-key",
+			vf:        noopVf,
+			expected:  "",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.validator.RegisterValidatingFunc(tt.prefix, tt.vf)
+
+			if tt.expected == "" && nil == result {
+				return
+			}
+
+			if result.Error() != tt.expected {
+				t.Fatalf("returned error doesn't match expected error")
+			}
+		})
+	}
+}
+
+func TestNewValidator(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	tracer := NewMockTracer(ctrl)
+	monitor := NewMockMonitorInterface(ctrl)
+	logger := NewMockLoggerInterface(ctrl)
+
+	v := NewRegistry(tracer, monitor, logger)
+
+	if v.tracer != tracer {
+		t.FailNow()
+	}
+
+	if v.monitor != monitor {
+		t.FailNow()
+	}
+
+	if v.logger != logger {
+		t.FailNow()
+	}
+
+	if v.validatingFuncs == nil {
+		t.Fatalf("validatingFuncs map expected not empty")
+	}
+
+	if len(v.validatingFuncs) != 0 {
+		t.Fatalf("validatingFuncs map expected not populated")
+	}
+}

--- a/internal/validation/types.go
+++ b/internal/validation/types.go
@@ -1,0 +1,24 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package validation
+
+import (
+	"net/http"
+
+	"github.com/go-playground/validator/v10"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
+)
+
+func NewValidationError(errors validator.ValidationErrors) *types.Response {
+	return &types.Response{
+		Status:  http.StatusBadRequest,
+		Message: "validation errors",
+		Data:    buildErrorData(errors),
+	}
+}
+
+func buildErrorData(err validator.ValidationErrors) []any {
+	return nil
+}

--- a/pkg/clients/handlers.go
+++ b/pkg/clients/handlers.go
@@ -1,5 +1,5 @@
-// Copyright 2024 Canonical Ltd
-// SPDX-License-Identifier: AGPL
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package clients
 

--- a/pkg/groups/handlers.go
+++ b/pkg/groups/handlers.go
@@ -1,5 +1,5 @@
 // Copyright 2024 Canonical Ltd.
-// SPDX-License-Identifier: AGPL
+// SPDX-License-Identifier: AGPL-3.0
 
 package groups
 

--- a/pkg/identities/handlers.go
+++ b/pkg/identities/handlers.go
@@ -1,5 +1,5 @@
-// Copyright 2024 Canonical Ltd
-// SPDX-License-Identifier: AGPL
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package identities
 

--- a/pkg/idp/handlers.go
+++ b/pkg/idp/handlers.go
@@ -1,5 +1,5 @@
-// Copyright 2024 Canonical Ltd
-// SPDX-License-Identifier: AGPL
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package idp
 

--- a/pkg/idp/handlers.go
+++ b/pkg/idp/handlers.go
@@ -9,15 +9,18 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-playground/validator/v10"
 
 	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 )
 
 const okValue = "ok"
 
 type API struct {
-	service ServiceInterface
+	service   ServiceInterface
+	validator *validator.Validate
 
 	logger logging.LoggerInterface
 }
@@ -28,6 +31,17 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 	mux.Post("/api/v0/idps", a.handleCreate)
 	mux.Patch("/api/v0/idps/{id:.+}", a.handlePartialUpdate)
 	mux.Delete("/api/v0/idps/{id:.+}", a.handleRemove)
+}
+
+func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
+	err := v.RegisterValidatingFunc("idps", a.validatingFunc)
+	if err != nil {
+		a.logger.Fatal("unexpected validatingFunc already registered for idps")
+	}
+}
+
+func (a *API) validatingFunc(r *http.Request) validator.ValidationErrors {
+	return nil
 }
 
 func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
@@ -246,7 +260,7 @@ func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
 	a := new(API)
 
 	a.service = service
-
+	a.validator = validator.New(validator.WithRequiredStructEnabled())
 	a.logger = logger
 
 	return a

--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -1,5 +1,5 @@
 // Copyright 2024 Canonical Ltd.
-// SPDX-License-Identifier: AGPL
+// SPDX-License-Identifier: AGPL-3.0
 
 package roles
 

--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -10,11 +10,14 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/go-playground/validator/v10"
+
 	"github.com/canonical/identity-platform-admin-ui/internal/authorization"
 	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
 	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
 	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
+	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -39,7 +42,8 @@ type RoleRequest struct {
 // API is the core HTTP object that implements all the HTTP and business logic for the roles
 // HTTP API functionality
 type API struct {
-	service ServiceInterface
+	service   ServiceInterface
+	validator *validator.Validate
 
 	logger  logging.LoggerInterface
 	tracer  tracing.TracingInterface
@@ -57,7 +61,16 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 	mux.Patch("/api/v0/roles/{id}/entitlements", a.handleAssignPermission) // this can only work for assignment unless payload includes add and remove
 	mux.Delete("/api/v0/roles/{id}/entitlements/{e_id}", a.handleRemovePermission)
 	mux.Get("/api/v0/roles/{id}/groups", a.handleListRoleGroup)
+}
+func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
+	err := v.RegisterValidatingFunc("roles", a.validatingFunc)
+	if err != nil {
+		a.logger.Fatal("unexpected validatingFunc already registered for roles")
+	}
+}
 
+func (a *API) validatingFunc(r *http.Request) validator.ValidationErrors {
+	return nil
 }
 
 func (a *API) userFromContext(ctx context.Context) *authorization.User {
@@ -459,7 +472,7 @@ func NewAPI(service ServiceInterface, tracer tracing.TracingInterface, monitor m
 	a := new(API)
 
 	a.service = service
-
+	a.validator = validator.New(validator.WithRequiredStructEnabled())
 	a.logger = logger
 	a.tracer = tracer
 	a.monitor = monitor

--- a/pkg/rules/handlers.go
+++ b/pkg/rules/handlers.go
@@ -9,15 +9,19 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/go-playground/validator/v10"
+
 	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 
 	"github.com/go-chi/chi/v5"
 	oathkeeper "github.com/ory/oathkeeper-client-go"
 )
 
 type API struct {
-	service ServiceInterface
+	service   ServiceInterface
+	validator *validator.Validate
 
 	logger logging.LoggerInterface
 }
@@ -28,6 +32,17 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 	mux.Post("/api/v0/rules", a.handleCreate)
 	mux.Put("/api/v0/rules/{id}", a.handleUpdate)
 	mux.Delete("/api/v0/rules/{id}", a.handleRemove)
+}
+
+func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
+	err := v.RegisterValidatingFunc("rules", a.validatingFunc)
+	if err != nil {
+		a.logger.Fatal("unexpected validatingFunc already registered for rules")
+	}
+}
+
+func (a *API) validatingFunc(r *http.Request) validator.ValidationErrors {
+	return nil
 }
 
 func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
@@ -237,7 +252,7 @@ func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
 	a := new(API)
 
 	a.service = service
-
+	a.validator = validator.New(validator.WithRequiredStructEnabled())
 	a.logger = logger
 
 	return a

--- a/pkg/rules/handlers.go
+++ b/pkg/rules/handlers.go
@@ -1,5 +1,5 @@
-// Copyright 2024 Canonical Ltd
-// SPDX-License-Identifier: AGPL
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package rules
 

--- a/pkg/schemas/handlers.go
+++ b/pkg/schemas/handlers.go
@@ -1,5 +1,5 @@
-// Copyright 2024 Canonical Ltd
-// SPDX-License-Identifier: AGPL
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package schemas
 

--- a/pkg/schemas/handlers.go
+++ b/pkg/schemas/handlers.go
@@ -9,16 +9,19 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-playground/validator/v10"
 	kClient "github.com/ory/kratos-client-go"
 
 	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 )
 
 const okValue = "ok"
 
 type API struct {
-	service ServiceInterface
+	service   ServiceInterface
+	validator *validator.Validate
 
 	logger logging.LoggerInterface
 }
@@ -31,6 +34,17 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 	mux.Delete("/api/v0/schemas/{id:.+}", a.handleRemove)
 	mux.Get("/api/v0/schemas/default", a.handleDetailDefault)
 	mux.Put("/api/v0/schemas/default", a.handleUpdateDefault)
+}
+
+func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
+	err := v.RegisterValidatingFunc("schemas", a.validatingFunc)
+	if err != nil {
+		a.logger.Fatal("unexpected validatingFunc already registered for schemas")
+	}
+}
+
+func (a *API) validatingFunc(r *http.Request) validator.ValidationErrors {
+	return nil
 }
 
 func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
@@ -346,7 +360,7 @@ func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
 	a := new(API)
 
 	a.service = service
-
+	a.validator = validator.New(validator.WithRequiredStructEnabled())
 	a.logger = logger
 
 	return a

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -1,5 +1,5 @@
-// Copyright 2024 Canonical Ltd
-// SPDX-License-Identifier: AGPL
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package web
 

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -14,7 +14,7 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
 	"github.com/canonical/identity-platform-admin-ui/internal/pool"
 	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
-	"github.com/canonical/identity-platform-admin-ui/internal/validator"
+	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 
 	"github.com/canonical/identity-platform-admin-ui/pkg/clients"
 	"github.com/canonical/identity-platform-admin-ui/pkg/groups"
@@ -34,7 +34,7 @@ func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, rulesConfig
 	monitor := ollyConfig.Monitor()
 	tracer := ollyConfig.Tracer()
 
-	vldtr := validation.NewValidator(tracer, monitor, logger)
+	vldtr := validation.NewRegistry(tracer, monitor, logger)
 
 	middlewares := make(chi.Middlewares, 0)
 	middlewares = append(
@@ -54,46 +54,68 @@ func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, rulesConfig
 
 	router.Use(middlewares...)
 
-	// apply authorization middleware using With to overcome issue with <id> URLParams not available
+	// apply authorization and validation middlewares using With to overcome issue with <id> URLParams not available
 	router = router.With(
 		authorization.NewMiddleware(
 			authorization.NewAuthorizer(externalConfig.Authorizer(), tracer, monitor, logger), monitor, logger).Authorize(),
+		vldtr.ValidationMiddleware,
 	).(*chi.Mux)
 
 	status.NewAPI(tracer, monitor, logger).RegisterEndpoints(router)
 	metrics.NewAPI(logger).RegisterEndpoints(router)
-	identities.NewAPI(
+
+	identitiesAPI := identities.NewAPI(
 		identities.NewService(externalConfig.KratosAdmin().IdentityApi(), tracer, monitor, logger),
 		logger,
-	).RegisterEndpoints(router)
-	clients.NewAPI(
+	)
+	identitiesAPI.RegisterEndpoints(router)
+	identitiesAPI.RegisterValidation(vldtr)
+
+	clientsAPI := clients.NewAPI(
 		clients.NewService(externalConfig.HydraAdmin(), tracer, monitor, logger),
 		logger,
-	).RegisterEndpoints(router)
-	idp.NewAPI(
+	)
+	clientsAPI.RegisterEndpoints(router)
+	clientsAPI.RegisterValidation(vldtr)
+
+	idpAPI := idp.NewAPI(
 		idp.NewService(idpConfig, tracer, monitor, logger),
 		logger,
-	).RegisterEndpoints(router)
-	schemas.NewAPI(
+	)
+	idpAPI.RegisterEndpoints(router)
+	idpAPI.RegisterValidation(vldtr)
+
+	schemasAPI := schemas.NewAPI(
 		schemas.NewService(schemasConfig, tracer, monitor, logger),
 		logger,
-	).RegisterEndpoints(router)
-	rules.NewAPI(
+	)
+	schemasAPI.RegisterEndpoints(router)
+	schemasAPI.RegisterValidation(vldtr)
+
+	rulesAPI := rules.NewAPI(
 		rules.NewService(rulesConfig, tracer, monitor, logger),
 		logger,
-	).RegisterEndpoints(router)
-	roles.NewAPI(
+	)
+	rulesAPI.RegisterEndpoints(router)
+	rulesAPI.RegisterValidation(vldtr)
+
+	rolesAPI := roles.NewAPI(
 		roles.NewService(externalConfig.OpenFGA(), wpool, tracer, monitor, logger),
 		tracer,
 		monitor,
 		logger,
-	).RegisterEndpoints(router)
-	groups.NewAPI(
+	)
+	rolesAPI.RegisterEndpoints(router)
+	rolesAPI.RegisterValidation(vldtr)
+
+	groupsAPI := groups.NewAPI(
 		groups.NewService(externalConfig.OpenFGA(), wpool, tracer, monitor, logger),
 		tracer,
 		monitor,
 		logger,
-	).RegisterEndpoints(router)
+	)
+	groupsAPI.RegisterEndpoints(router)
+	groupsAPI.RegisterValidation(vldtr)
 
 	return tracing.NewMiddleware(monitor, logger).OpenTelemetry(router)
 }

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
 	"github.com/canonical/identity-platform-admin-ui/internal/pool"
 	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
+	"github.com/canonical/identity-platform-admin-ui/internal/validator"
 
 	"github.com/canonical/identity-platform-admin-ui/pkg/clients"
 	"github.com/canonical/identity-platform-admin-ui/pkg/groups"
@@ -32,6 +33,8 @@ func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, rulesConfig
 	logger := ollyConfig.Logger()
 	monitor := ollyConfig.Monitor()
 	tracer := ollyConfig.Tracer()
+
+	vldtr := validation.NewValidator(tracer, monitor, logger)
 
 	middlewares := make(chi.Middlewares, 0)
 	middlewares = append(


### PR DESCRIPTION
## Description
This PR introduces what's needed to have validation on each APIs, leveraging both custom `ValidationRegistry` struct (introduced by this PR) and 3rd party `validator` already part of the project dependencies.

## Changes
- updated license on touched files
- introduced `ValidationRegistry` object for registering validating functions for each API
- introduced 3rd party validator in each API struct to perform the actual validation
- tests on added code