### PR TITLE
IAM 782

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -100,7 +100,7 @@ func serve() {
 
 	schemasConfig := &schemas.Config{
 		K8s:       k8sCoreV1,
-		Kratos:    extCfg.KratosPublic().IdentityApi(),
+		Kratos:    extCfg.KratosPublic().IdentityAPI(),
 		Name:      specs.SchemasConfigMapName,
 		Namespace: specs.SchemasConfigMapNamespace,
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,11 +13,12 @@ require (
 	github.com/openfga/go-sdk v0.3.4
 	github.com/openfga/language/pkg/go v0.0.0-20240122114256-aaa86ab89379
 	github.com/ory/hydra-client-go/v2 v2.1.1
-	github.com/ory/kratos-client-go v1.0.0
+	github.com/ory/kratos-client-go v1.1.0
 	github.com/ory/oathkeeper-client-go v0.40.6
 	github.com/prometheus/client_golang v1.17.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
+	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0
 	go.opentelemetry.io/contrib/propagators/jaeger v1.20.0
 	go.opentelemetry.io/otel v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/openfga/language/pkg/go v0.0.0-20240122114256-aaa86ab89379 h1:j42rKsj
 github.com/openfga/language/pkg/go v0.0.0-20240122114256-aaa86ab89379/go.mod h1:dHJaJ7H5tViBCPidTsfl3IOd152FhYxWFQmZXOhZ2pw=
 github.com/ory/hydra-client-go/v2 v2.1.1 h1:3JatU9uFbw5XhF3lgPCas1l1Kok2v5Mq1p26zZwGHNg=
 github.com/ory/hydra-client-go/v2 v2.1.1/go.mod h1:IiIwChp/9wRvPoyFQblqPvg78uVishCCrV9+/M7Pl34=
-github.com/ory/kratos-client-go v1.0.0 h1:mm32FMJrt4pBv2KEuhuNtiewJApc8c1Kmz0+WFHhOMA=
-github.com/ory/kratos-client-go v1.0.0/go.mod h1:a2Tl4cgQAxsjR59w3EfnH5hengabjXUHiEVDzdqiZI0=
+github.com/ory/kratos-client-go v1.1.0 h1:mCk5wxNTxjYq/sbZfoEY/JcxuBtuixStHD14Y0sU1E8=
+github.com/ory/kratos-client-go v1.1.0/go.mod h1:ultwfjWsBxshnZgopqQ3DrKOe/t6SXsM+KKOd21PaTQ=
 github.com/ory/oathkeeper-client-go v0.40.6 h1:Qm/odusPn6DTJ8mXXElNzfXYpcD5wqmb/k3dOYKUfTg=
 github.com/ory/oathkeeper-client-go v0.40.6/go.mod h1:9JUPR04XPH3e53TYbfu+KveCnTIYtlSTJiQ23rEQLJI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -147,6 +147,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/http/types/generic.go
+++ b/internal/http/types/generic.go
@@ -4,8 +4,12 @@
 package types
 
 import (
+	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/tomnomnom/linkheader"
 )
 
 type Response struct {
@@ -15,15 +19,29 @@ type Response struct {
 	Meta    *Pagination `json:"_meta"`
 }
 
+// NavigationTokens are parameters used to navigate `list` result endpoints
+type NavigationTokens struct {
+	// deserialization only
+	Next string `json:"next,omitempty"`
+	Prev string `json:"prev,omitempty"`
+}
+
+// Pagination object is used to serialize and deserialize pagination parameters
+// it will populate the `meta` part for the `Response` struct
 type Pagination struct {
-	Page int64 `json:"page"`
-	Size int64 `json:"size"`
+	PageToken string `json:"page_token"` // serialization only
+	Size      int64  `json:"size"`
+	Page      int64  `json:"page"` // to be deprecated
+
+	// deserialization only
+	NavigationTokens
 }
 
 func NewPaginationWithDefaults() *Pagination {
 	p := new(Pagination)
 
 	p.Page = 1
+	p.PageToken = ""
 	p.Size = 100
 
 	return p
@@ -37,9 +55,49 @@ func ParsePagination(q url.Values) *Pagination {
 		p.Page = page
 	}
 
+	// TODO @shipperizer introduce go-playground/validator
 	if size, err := strconv.ParseInt(q.Get("size"), 10, 64); err == nil && size > 0 {
 		p.Size = size
 	}
 
+	if token := q.Get("page_token"); token != "" {
+		p.PageToken = token
+	}
+
 	return p
+}
+
+// ParseLinkTokens accepts a request/response headers and will parse the Link
+// headers, it returns quickly in case of error with a default NavigationTokens object
+func ParseLinkTokens(headers http.Header) (NavigationTokens, error) {
+	links := linkheader.Parse(headers.Get("Link"))
+
+	pagination := NavigationTokens{}
+
+	for _, link := range links {
+		token, err := parseLinkToken(link.URL)
+
+		if err != nil {
+			return NavigationTokens{}, err
+		}
+
+		switch link.Rel {
+		case "next":
+			pagination.Next = token
+		case "prev":
+			pagination.Prev = token
+		}
+	}
+
+	return pagination, nil
+}
+
+func parseLinkToken(linkURL string) (string, error) {
+	u, err := url.Parse(linkURL)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to parse link header successfully: %s", err)
+	}
+
+	return u.Query().Get("page_token"), nil
 }

--- a/internal/http/types/token.go
+++ b/internal/http/types/token.go
@@ -19,6 +19,9 @@ const (
 	PAGINATION_HEADER = "X-Token-Pagination"
 )
 
+// TODO @shipperizer move this under openfga package or at least change name to reflect this is used for openfga
+// related endpoints
+
 type TokenPaginator struct {
 	tokens map[string]string
 

--- a/internal/kratos/client.go
+++ b/internal/kratos/client.go
@@ -14,8 +14,8 @@ type Client struct {
 	c *client.APIClient
 }
 
-func (c *Client) IdentityApi() client.IdentityApi {
-	return c.c.IdentityApi
+func (c *Client) IdentityAPI() client.IdentityAPI {
+	return c.c.IdentityAPI
 }
 
 func NewClient(url string, debug bool) *Client {

--- a/pkg/identities/handlers.go
+++ b/pkg/identities/handlers.go
@@ -29,7 +29,6 @@ type UpdateIdentityRequest struct {
 
 type API struct {
 	service   ServiceInterface
-	baseURL   string
 	validator *validator.Validate
 
 	logger logging.LoggerInterface
@@ -64,7 +63,7 @@ func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
 
 	credID := r.URL.Query().Get("credID")
 
-	ids, err := a.service.ListIdentities(r.Context(), pagination.Page, pagination.Size, credID)
+	ids, err := a.service.ListIdentities(r.Context(), pagination.Size, pagination.PageToken, credID)
 
 	if err != nil {
 		rr := a.error(ids.Error)
@@ -74,6 +73,10 @@ func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
+
+	// TODO @shipperizer improve on this, see if better to stick with link headers
+	pagination.Next = ids.Tokens.Next
+	pagination.Prev = ids.Tokens.Prev
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(

--- a/pkg/identities/interfaces.go
+++ b/pkg/identities/interfaces.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ServiceInterface interface {
-	ListIdentities(context.Context, int64, int64, string) (*IdentityData, error)
+	ListIdentities(context.Context, int64, string, string) (*IdentityData, error)
 	GetIdentity(context.Context, string) (*IdentityData, error)
 	CreateIdentity(context.Context, *kClient.CreateIdentityBody) (*IdentityData, error)
 	UpdateIdentity(context.Context, string, *kClient.UpdateIdentityBody) (*IdentityData, error)

--- a/pkg/identities/service.go
+++ b/pkg/identities/service.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	kClient "github.com/ory/kratos-client-go"
+	"github.com/tomnomnom/linkheader"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
@@ -18,15 +20,23 @@ import (
 )
 
 type Service struct {
-	kratos kClient.IdentityApi
+	kratos kClient.IdentityAPI
 
 	tracer  trace.Tracer
 	monitor monitoring.MonitorInterface
 	logger  logging.LoggerInterface
 }
 
+// TODO @shipperizer worth offloading to a different place as it's going to be reused
+type PaginationTokens struct {
+	First string
+	Prev  string
+	Next  string
+}
+
 type IdentityData struct {
 	Identities []kClient.Identity
+	Tokens     PaginationTokens
 	Error      *kClient.GenericError
 }
 
@@ -35,14 +45,44 @@ type KratosError struct {
 	Error *kClient.GenericError `json:"error,omitempty"`
 }
 
-func (s *Service) buildListRequest(ctx context.Context, page, size int64, credID string) kClient.IdentityApiListIdentitiesRequest {
-	r := s.kratos.ListIdentities(ctx).Page(page).PerPage(size)
+func (s *Service) buildListRequest(ctx context.Context, size int64, token, credID string) kClient.IdentityAPIListIdentitiesRequest {
+	r := s.kratos.ListIdentities(ctx).PageToken(token).PageSize(size)
 
 	if credID != "" {
 		r = r.CredentialsIdentifier(credID)
 	}
 
 	return r
+}
+
+func (s *Service) parseLinkURL(linkURL string) string {
+	u, err := url.Parse(linkURL)
+
+	if err != nil {
+		s.logger.Errorf("failed to parse link header successfully: %s", err)
+		return ""
+	}
+
+	return u.Query().Get("page_token")
+}
+
+func (s *Service) parsePagination(r *http.Response) PaginationTokens {
+	links := linkheader.Parse(r.Header.Get("Link"))
+
+	pagination := PaginationTokens{}
+
+	for _, link := range links {
+		switch link.Rel {
+		case "first":
+			pagination.First = s.parseLinkURL(link.URL)
+		case "next":
+			pagination.Next = s.parseLinkURL(link.URL)
+		case "prev":
+			pagination.Prev = s.parseLinkURL(link.URL)
+		}
+	}
+
+	return pagination
 }
 
 func (s *Service) parseError(r *http.Response) *kClient.GenericError {
@@ -59,13 +99,12 @@ func (s *Service) parseError(r *http.Response) *kClient.GenericError {
 	return gerr.Error
 }
 
-// TODO @shipperizer fix pagination
-func (s *Service) ListIdentities(ctx context.Context, page, size int64, credID string) (*IdentityData, error) {
-	ctx, span := s.tracer.Start(ctx, "kratos.IdentityApi.ListIdentities")
+func (s *Service) ListIdentities(ctx context.Context, size int64, token, credID string) (*IdentityData, error) {
+	ctx, span := s.tracer.Start(ctx, "kratos.IdentityAPI.ListIdentities")
 	defer span.End()
 
 	identities, rr, err := s.kratos.ListIdentitiesExecute(
-		s.buildListRequest(ctx, page, size, credID),
+		s.buildListRequest(ctx, size, token, credID),
 	)
 
 	data := new(IdentityData)
@@ -75,6 +114,7 @@ func (s *Service) ListIdentities(ctx context.Context, page, size int64, credID s
 		data.Error = s.parseError(rr)
 	}
 
+	data.Tokens = s.parsePagination(rr)
 	data.Identities = identities
 
 	// TODO @shipperizer check if identities is defaulting to empty slice inside kratos-client
@@ -86,7 +126,7 @@ func (s *Service) ListIdentities(ctx context.Context, page, size int64, credID s
 }
 
 func (s *Service) GetIdentity(ctx context.Context, ID string) (*IdentityData, error) {
-	ctx, span := s.tracer.Start(ctx, "kratos.IdentityApi.GetIdentity")
+	ctx, span := s.tracer.Start(ctx, "kratos.IdentityAPI.GetIdentity")
 	defer span.End()
 
 	identity, rr, err := s.kratos.GetIdentityExecute(
@@ -110,7 +150,7 @@ func (s *Service) GetIdentity(ctx context.Context, ID string) (*IdentityData, er
 }
 
 func (s *Service) CreateIdentity(ctx context.Context, bodyID *kClient.CreateIdentityBody) (*IdentityData, error) {
-	ctx, span := s.tracer.Start(ctx, "kratos.IdentityApi.CreateIdentity")
+	ctx, span := s.tracer.Start(ctx, "kratos.IdentityAPI.CreateIdentity")
 	defer span.End()
 
 	if bodyID == nil {
@@ -147,7 +187,7 @@ func (s *Service) CreateIdentity(ctx context.Context, bodyID *kClient.CreateIden
 }
 
 func (s *Service) UpdateIdentity(ctx context.Context, ID string, bodyID *kClient.UpdateIdentityBody) (*IdentityData, error) {
-	ctx, span := s.tracer.Start(ctx, "kratos.IdentityApi.UpdateIdentity")
+	ctx, span := s.tracer.Start(ctx, "kratos.IdentityAPI.UpdateIdentity")
 	defer span.End()
 	if ID == "" {
 		err := fmt.Errorf("no identity ID passed")
@@ -196,7 +236,7 @@ func (s *Service) UpdateIdentity(ctx context.Context, ID string, bodyID *kClient
 }
 
 func (s *Service) DeleteIdentity(ctx context.Context, ID string) (*IdentityData, error) {
-	ctx, span := s.tracer.Start(ctx, "kratos.IdentityApi.DeleteIdentity")
+	ctx, span := s.tracer.Start(ctx, "kratos.IdentityAPI.DeleteIdentity")
 	defer span.End()
 
 	rr, err := s.kratos.DeleteIdentityExecute(
@@ -215,7 +255,7 @@ func (s *Service) DeleteIdentity(ctx context.Context, ID string) (*IdentityData,
 	return data, err
 }
 
-func NewService(kratos kClient.IdentityApi, tracer trace.Tracer, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *Service {
+func NewService(kratos kClient.IdentityAPI, tracer trace.Tracer, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *Service {
 	s := new(Service)
 
 	s.kratos = kratos

--- a/pkg/identities/service_test.go
+++ b/pkg/identities/service_test.go
@@ -77,8 +77,8 @@ func TestListIdentitiesSuccess(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(
-		[]string{ids.Tokens.First, ids.Tokens.Next, ids.Tokens.Prev},
-		[]string{"eyJvZmZzZXQiOiIwIiwidiI6Mn0", "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ", "eyJvZmZzZXQiOiItMjUwIiwidiI6Mn0"},
+		[]string{ids.Tokens.Next, ids.Tokens.Prev},
+		[]string{"eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ", "eyJvZmZzZXQiOiItMjUwIiwidiI6Mn0"},
 	) {
 		t.Fatalf("expected tokens to be set, not %v", ids.Tokens)
 	}

--- a/pkg/identities/service_test.go
+++ b/pkg/identities/service_test.go
@@ -21,7 +21,7 @@ import (
 //go:generate mockgen -build_flags=--mod=mod -package identities -destination ./mock_interfaces.go -source=./interfaces.go
 //go:generate mockgen -build_flags=--mod=mod -package identities -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
 //go:generate mockgen -build_flags=--mod=mod -package identities -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
-//go:generate mockgen -build_flags=--mod=mod -package identities -destination ./mock_kratos.go github.com/ory/kratos-client-go IdentityApi
+//go:generate mockgen -build_flags=--mod=mod -package identities -destination ./mock_kratos.go github.com/ory/kratos-client-go IdentityAPI
 
 func TestListIdentitiesSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -30,12 +30,12 @@ func TestListIdentitiesSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
-	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
 
-	identityRequest := kClient.IdentityApiListIdentitiesRequest{
-		ApiService: mockKratosIdentityApi,
+	identityRequest := kClient.IdentityAPIListIdentitiesRequest{
+		ApiService: mockKratosIdentityAPI,
 	}
 
 	identities := make([]kClient.Identity, 0)
@@ -44,17 +44,17 @@ func TestListIdentitiesSuccess(t *testing.T) {
 		identities = append(identities, *kClient.NewIdentity(fmt.Sprintf("test-%v", i), "test.json", "https://test.com/test.json", map[string]string{"name": "name"}))
 	}
 
-	mockTracer.EXPECT().Start(ctx, "kratos.IdentityApi.ListIdentities").Times(1).Return(ctx, trace.SpanFromContext(ctx))
-	mockKratosIdentityApi.EXPECT().ListIdentities(ctx).Times(1).Return(identityRequest)
-	mockKratosIdentityApi.EXPECT().ListIdentitiesExecute(gomock.Any()).Times(1).DoAndReturn(
-		func(r kClient.IdentityApiListIdentitiesRequest) ([]kClient.Identity, *http.Response, error) {
+	mockTracer.EXPECT().Start(ctx, "kratos.IdentityAPI.ListIdentities").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityAPI.EXPECT().ListIdentities(ctx).Times(1).Return(identityRequest)
+	mockKratosIdentityAPI.EXPECT().ListIdentitiesExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.IdentityAPIListIdentitiesRequest) ([]kClient.Identity, *http.Response, error) {
 
 			// use reflect as attributes are private, also are pointers so need to cast it multiple times
-			if page := (*int64)(reflect.ValueOf(r).FieldByName("page").UnsafePointer()); *page != 2 {
-				t.Fatalf("expected page as 2, got %v", *page)
+			if pageToken := (*string)(reflect.ValueOf(r).FieldByName("pageToken").UnsafePointer()); *pageToken != "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ" {
+				t.Fatalf("expected pageToken as eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ, got %v", *pageToken)
 			}
 
-			if pageSize := (*int64)(reflect.ValueOf(r).FieldByName("perPage").UnsafePointer()); *pageSize != 10 {
+			if pageSize := (*int64)(reflect.ValueOf(r).FieldByName("pageSize").UnsafePointer()); *pageSize != 10 {
 				t.Fatalf("expected page size as 10, got %v", *pageSize)
 			}
 
@@ -62,15 +62,27 @@ func TestListIdentitiesSuccess(t *testing.T) {
 				t.Fatalf("expected credential id to be empty, got %v", *credID)
 			}
 
-			return identities, new(http.Response), nil
+			rr := new(http.Response)
+			rr.Header = make(http.Header)
+			rr.Header.Set("Link", `<http://kratos-admin.default.svc.cluster.local/identities?page=0&page_size=250&page_token=eyJvZmZzZXQiOiIwIiwidiI6Mn0&per_page=250>; rel="first",<http://kratos-admin.default.svc.cluster.local/identities?page=1&page_size=250&page_token=eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ&per_page=250>; rel="next",<http://kratos-admin.default.svc.cluster.local/identities?page=-1&page_size=250&page_token=eyJvZmZzZXQiOiItMjUwIiwidiI6Mn0&per_page=250>; rel="prev`)
+
+			return identities, rr, nil
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityApi, mockTracer, mockMonitor, mockLogger).ListIdentities(ctx, 2, 10, "")
+	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).ListIdentities(ctx, 10, "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ", "")
 
 	if !reflect.DeepEqual(ids.Identities, identities) {
 		t.Fatalf("expected identities to be %v not  %v", identities, ids.Identities)
 	}
+
+	if !reflect.DeepEqual(
+		[]string{ids.Tokens.First, ids.Tokens.Next, ids.Tokens.Prev},
+		[]string{"eyJvZmZzZXQiOiIwIiwidiI6Mn0", "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ", "eyJvZmZzZXQiOiItMjUwIiwidiI6Mn0"},
+	) {
+		t.Fatalf("expected tokens to be set, not %v", ids.Tokens)
+	}
+
 	if err != nil {
 		t.Fatalf("expected error to be nil not  %v", err)
 	}
@@ -83,28 +95,28 @@ func TestListIdentitiesFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
-	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
 
-	identityRequest := kClient.IdentityApiListIdentitiesRequest{
-		ApiService: mockKratosIdentityApi,
+	identityRequest := kClient.IdentityAPIListIdentitiesRequest{
+		ApiService: mockKratosIdentityAPI,
 	}
 
 	identities := make([]kClient.Identity, 0)
 
 	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
-	mockTracer.EXPECT().Start(ctx, "kratos.IdentityApi.ListIdentities").Times(1).Return(ctx, trace.SpanFromContext(ctx))
-	mockKratosIdentityApi.EXPECT().ListIdentities(ctx).Times(1).Return(identityRequest)
-	mockKratosIdentityApi.EXPECT().ListIdentitiesExecute(gomock.Any()).Times(1).DoAndReturn(
-		func(r kClient.IdentityApiListIdentitiesRequest) ([]kClient.Identity, *http.Response, error) {
+	mockTracer.EXPECT().Start(ctx, "kratos.IdentityAPI.ListIdentities").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityAPI.EXPECT().ListIdentities(ctx).Times(1).Return(identityRequest)
+	mockKratosIdentityAPI.EXPECT().ListIdentitiesExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.IdentityAPIListIdentitiesRequest) ([]kClient.Identity, *http.Response, error) {
 
 			// use reflect as attributes are private, also are pointers so need to cast it multiple times
-			if page := (*int64)(reflect.ValueOf(r).FieldByName("page").UnsafePointer()); *page != 2 {
-				t.Fatalf("expected page as 2, got %v", *page)
+			if pageToken := (*string)(reflect.ValueOf(r).FieldByName("pageToken").UnsafePointer()); *pageToken != "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ" {
+				t.Fatalf("expected pageToken as eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ, got %v", *pageToken)
 			}
 
-			if pageSize := (*int64)(reflect.ValueOf(r).FieldByName("perPage").UnsafePointer()); *pageSize != 10 {
+			if pageSize := (*int64)(reflect.ValueOf(r).FieldByName("pageSize").UnsafePointer()); *pageSize != 10 {
 				t.Fatalf("expected page size as 10, got %v", *pageSize)
 			}
 
@@ -135,7 +147,7 @@ func TestListIdentitiesFails(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityApi, mockTracer, mockMonitor, mockLogger).ListIdentities(ctx, 2, 10, "test")
+	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).ListIdentities(ctx, 10, "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ", "test")
 
 	if !reflect.DeepEqual(ids.Identities, identities) {
 		t.Fatalf("expected identities to be empty not  %v", ids.Identities)
@@ -161,22 +173,22 @@ func TestGetIdentitySuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
-	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
 	credID := "test-1"
 
-	identityRequest := kClient.IdentityApiGetIdentityRequest{
-		ApiService: mockKratosIdentityApi,
+	identityRequest := kClient.IdentityAPIGetIdentityRequest{
+		ApiService: mockKratosIdentityAPI,
 	}
 
 	identity := kClient.NewIdentity(credID, "test.json", "https://test.com/test.json", map[string]string{"name": "name"})
 
-	mockTracer.EXPECT().Start(ctx, "kratos.IdentityApi.GetIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
-	mockKratosIdentityApi.EXPECT().GetIdentity(ctx, credID).Times(1).Return(identityRequest)
-	mockKratosIdentityApi.EXPECT().GetIdentityExecute(gomock.Any()).Times(1).Return(identity, new(http.Response), nil)
+	mockTracer.EXPECT().Start(ctx, "kratos.IdentityAPI.GetIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityAPI.EXPECT().GetIdentity(ctx, credID).Times(1).Return(identityRequest)
+	mockKratosIdentityAPI.EXPECT().GetIdentityExecute(gomock.Any()).Times(1).Return(identity, new(http.Response), nil)
 
-	ids, err := NewService(mockKratosIdentityApi, mockTracer, mockMonitor, mockLogger).GetIdentity(ctx, credID)
+	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).GetIdentity(ctx, credID)
 
 	if !reflect.DeepEqual(ids.Identities, []kClient.Identity{*identity}) {
 		t.Fatalf("expected identities to be %v not  %v", *identity, ids.Identities)
@@ -193,20 +205,20 @@ func TestGetIdentityFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
-	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
 	credID := "test"
 
-	identityRequest := kClient.IdentityApiGetIdentityRequest{
-		ApiService: mockKratosIdentityApi,
+	identityRequest := kClient.IdentityAPIGetIdentityRequest{
+		ApiService: mockKratosIdentityAPI,
 	}
 
 	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
-	mockTracer.EXPECT().Start(ctx, "kratos.IdentityApi.GetIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
-	mockKratosIdentityApi.EXPECT().GetIdentity(ctx, credID).Times(1).Return(identityRequest)
-	mockKratosIdentityApi.EXPECT().GetIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
-		func(r kClient.IdentityApiGetIdentityRequest) (*kClient.Identity, *http.Response, error) {
+	mockTracer.EXPECT().Start(ctx, "kratos.IdentityAPI.GetIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityAPI.EXPECT().GetIdentity(ctx, credID).Times(1).Return(identityRequest)
+	mockKratosIdentityAPI.EXPECT().GetIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.IdentityAPIGetIdentityRequest) (*kClient.Identity, *http.Response, error) {
 			rr := httptest.NewRecorder()
 			rr.Header().Set("Content-Type", "application/json")
 			rr.WriteHeader(http.StatusNotFound)
@@ -230,7 +242,7 @@ func TestGetIdentityFails(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityApi, mockTracer, mockMonitor, mockLogger).GetIdentity(ctx, credID)
+	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).GetIdentity(ctx, credID)
 
 	if !reflect.DeepEqual(ids.Identities, make([]kClient.Identity, 0)) {
 		t.Fatalf("expected identities to be empty not  %v", ids.Identities)
@@ -256,12 +268,12 @@ func TestCreateIdentitySuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
-	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
 
-	identityRequest := kClient.IdentityApiCreateIdentityRequest{
-		ApiService: mockKratosIdentityApi,
+	identityRequest := kClient.IdentityAPICreateIdentityRequest{
+		ApiService: mockKratosIdentityAPI,
 	}
 
 	identity := kClient.NewIdentity("test", "test.json", "https://test.com/test.json", map[string]string{"name": "name"})
@@ -269,10 +281,10 @@ func TestCreateIdentitySuccess(t *testing.T) {
 	identityBody := kClient.NewCreateIdentityBody("test.json", map[string]interface{}{"name": "name"})
 	identityBody.SetCredentials(*credentials)
 
-	mockTracer.EXPECT().Start(ctx, "kratos.IdentityApi.CreateIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
-	mockKratosIdentityApi.EXPECT().CreateIdentity(ctx).Times(1).Return(identityRequest)
-	mockKratosIdentityApi.EXPECT().CreateIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
-		func(r kClient.IdentityApiCreateIdentityRequest) (*kClient.Identity, *http.Response, error) {
+	mockTracer.EXPECT().Start(ctx, "kratos.IdentityAPI.CreateIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityAPI.EXPECT().CreateIdentity(ctx).Times(1).Return(identityRequest)
+	mockKratosIdentityAPI.EXPECT().CreateIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.IdentityAPICreateIdentityRequest) (*kClient.Identity, *http.Response, error) {
 
 			// use reflect as attributes are private, also are pointers so need to cast it multiple times
 			if IDBody := (*kClient.CreateIdentityBody)(reflect.ValueOf(r).FieldByName("createIdentityBody").UnsafePointer()); !reflect.DeepEqual(*IDBody, *identityBody) {
@@ -283,7 +295,7 @@ func TestCreateIdentitySuccess(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityApi, mockTracer, mockMonitor, mockLogger).CreateIdentity(ctx, identityBody)
+	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).CreateIdentity(ctx, identityBody)
 
 	if !reflect.DeepEqual(ids.Identities, []kClient.Identity{*identity}) {
 		t.Fatalf("expected identities to be %v not  %v", *identity, ids.Identities)
@@ -301,12 +313,12 @@ func TestCreateIdentityFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
-	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
 
-	identityRequest := kClient.IdentityApiCreateIdentityRequest{
-		ApiService: mockKratosIdentityApi,
+	identityRequest := kClient.IdentityAPICreateIdentityRequest{
+		ApiService: mockKratosIdentityAPI,
 	}
 
 	credentials := kClient.NewIdentityWithCredentialsWithDefaults()
@@ -314,10 +326,10 @@ func TestCreateIdentityFails(t *testing.T) {
 	identityBody.SetCredentials(*credentials)
 
 	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
-	mockTracer.EXPECT().Start(ctx, "kratos.IdentityApi.CreateIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
-	mockKratosIdentityApi.EXPECT().CreateIdentity(ctx).Times(1).Return(identityRequest)
-	mockKratosIdentityApi.EXPECT().CreateIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
-		func(r kClient.IdentityApiCreateIdentityRequest) (*kClient.Identity, *http.Response, error) {
+	mockTracer.EXPECT().Start(ctx, "kratos.IdentityAPI.CreateIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityAPI.EXPECT().CreateIdentity(ctx).Times(1).Return(identityRequest)
+	mockKratosIdentityAPI.EXPECT().CreateIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.IdentityAPICreateIdentityRequest) (*kClient.Identity, *http.Response, error) {
 			rr := httptest.NewRecorder()
 			rr.Header().Set("Content-Type", "application/json")
 			rr.WriteHeader(http.StatusInternalServerError)
@@ -341,7 +353,7 @@ func TestCreateIdentityFails(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityApi, mockTracer, mockMonitor, mockLogger).CreateIdentity(ctx, identityBody)
+	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).CreateIdentity(ctx, identityBody)
 
 	if !reflect.DeepEqual(ids.Identities, make([]kClient.Identity, 0)) {
 		t.Fatalf("expected identities to be empty not  %v", ids.Identities)
@@ -367,12 +379,12 @@ func TestUpdateIdentitySuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
-	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
 
-	identityRequest := kClient.IdentityApiUpdateIdentityRequest{
-		ApiService: mockKratosIdentityApi,
+	identityRequest := kClient.IdentityAPIUpdateIdentityRequest{
+		ApiService: mockKratosIdentityAPI,
 	}
 
 	identity := kClient.NewIdentity("test", "test.json", "https://test.com/test.json", map[string]string{"name": "name"})
@@ -381,10 +393,10 @@ func TestUpdateIdentitySuccess(t *testing.T) {
 	identityBody.SetTraits(map[string]interface{}{"name": "name"})
 	identityBody.SetCredentials(*credentials)
 
-	mockTracer.EXPECT().Start(ctx, "kratos.IdentityApi.UpdateIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
-	mockKratosIdentityApi.EXPECT().UpdateIdentity(ctx, identity.Id).Times(1).Return(identityRequest)
-	mockKratosIdentityApi.EXPECT().UpdateIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
-		func(r kClient.IdentityApiUpdateIdentityRequest) (*kClient.Identity, *http.Response, error) {
+	mockTracer.EXPECT().Start(ctx, "kratos.IdentityAPI.UpdateIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityAPI.EXPECT().UpdateIdentity(ctx, identity.Id).Times(1).Return(identityRequest)
+	mockKratosIdentityAPI.EXPECT().UpdateIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.IdentityAPIUpdateIdentityRequest) (*kClient.Identity, *http.Response, error) {
 
 			// use reflect as attributes are private, also are pointers so need to cast it multiple times
 			if IDBody := (*kClient.UpdateIdentityBody)(reflect.ValueOf(r).FieldByName("updateIdentityBody").UnsafePointer()); !reflect.DeepEqual(*IDBody, *identityBody) {
@@ -395,7 +407,7 @@ func TestUpdateIdentitySuccess(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityApi, mockTracer, mockMonitor, mockLogger).UpdateIdentity(ctx, identity.Id, identityBody)
+	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).UpdateIdentity(ctx, identity.Id, identityBody)
 
 	if !reflect.DeepEqual(ids.Identities, []kClient.Identity{*identity}) {
 		t.Fatalf("expected identities to be %v not  %v", *identity, ids.Identities)
@@ -413,14 +425,14 @@ func TestUpdateIdentityFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
-	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
 
 	credID := "test"
 
-	identityRequest := kClient.IdentityApiUpdateIdentityRequest{
-		ApiService: mockKratosIdentityApi,
+	identityRequest := kClient.IdentityAPIUpdateIdentityRequest{
+		ApiService: mockKratosIdentityAPI,
 	}
 
 	credentials := kClient.NewIdentityWithCredentialsWithDefaults()
@@ -429,10 +441,10 @@ func TestUpdateIdentityFails(t *testing.T) {
 	identityBody.SetCredentials(*credentials)
 
 	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
-	mockTracer.EXPECT().Start(ctx, "kratos.IdentityApi.UpdateIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
-	mockKratosIdentityApi.EXPECT().UpdateIdentity(ctx, credID).Times(1).Return(identityRequest)
-	mockKratosIdentityApi.EXPECT().UpdateIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
-		func(r kClient.IdentityApiUpdateIdentityRequest) (*kClient.Identity, *http.Response, error) {
+	mockTracer.EXPECT().Start(ctx, "kratos.IdentityAPI.UpdateIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityAPI.EXPECT().UpdateIdentity(ctx, credID).Times(1).Return(identityRequest)
+	mockKratosIdentityAPI.EXPECT().UpdateIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.IdentityAPIUpdateIdentityRequest) (*kClient.Identity, *http.Response, error) {
 			rr := httptest.NewRecorder()
 			rr.Header().Set("Content-Type", "application/json")
 			rr.WriteHeader(http.StatusConflict)
@@ -456,7 +468,7 @@ func TestUpdateIdentityFails(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityApi, mockTracer, mockMonitor, mockLogger).UpdateIdentity(ctx, credID, identityBody)
+	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).UpdateIdentity(ctx, credID, identityBody)
 
 	if !reflect.DeepEqual(ids.Identities, make([]kClient.Identity, 0)) {
 		t.Fatalf("expected identities to be empty not  %v", ids.Identities)
@@ -482,20 +494,20 @@ func TestDeleteIdentitySuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
-	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
 	credID := "test-1"
 
-	identityRequest := kClient.IdentityApiDeleteIdentityRequest{
-		ApiService: mockKratosIdentityApi,
+	identityRequest := kClient.IdentityAPIDeleteIdentityRequest{
+		ApiService: mockKratosIdentityAPI,
 	}
 
-	mockTracer.EXPECT().Start(ctx, "kratos.IdentityApi.DeleteIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
-	mockKratosIdentityApi.EXPECT().DeleteIdentity(ctx, credID).Times(1).Return(identityRequest)
-	mockKratosIdentityApi.EXPECT().DeleteIdentityExecute(gomock.Any()).Times(1).Return(new(http.Response), nil)
+	mockTracer.EXPECT().Start(ctx, "kratos.IdentityAPI.DeleteIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityAPI.EXPECT().DeleteIdentity(ctx, credID).Times(1).Return(identityRequest)
+	mockKratosIdentityAPI.EXPECT().DeleteIdentityExecute(gomock.Any()).Times(1).Return(new(http.Response), nil)
 
-	ids, err := NewService(mockKratosIdentityApi, mockTracer, mockMonitor, mockLogger).DeleteIdentity(ctx, credID)
+	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).DeleteIdentity(ctx, credID)
 
 	if len(ids.Identities) > 0 {
 		t.Fatalf("invalid result, expected no identities, got %v", ids.Identities)
@@ -513,20 +525,20 @@ func TestDeleteIdentityFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
-	mockKratosIdentityApi := NewMockIdentityApi(ctrl)
+	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
 	credID := "test-1"
 
-	identityRequest := kClient.IdentityApiDeleteIdentityRequest{
-		ApiService: mockKratosIdentityApi,
+	identityRequest := kClient.IdentityAPIDeleteIdentityRequest{
+		ApiService: mockKratosIdentityAPI,
 	}
 
 	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
-	mockTracer.EXPECT().Start(ctx, "kratos.IdentityApi.DeleteIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
-	mockKratosIdentityApi.EXPECT().DeleteIdentity(ctx, credID).Times(1).Return(identityRequest)
-	mockKratosIdentityApi.EXPECT().DeleteIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
-		func(r kClient.IdentityApiDeleteIdentityRequest) (*http.Response, error) {
+	mockTracer.EXPECT().Start(ctx, "kratos.IdentityAPI.DeleteIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockKratosIdentityAPI.EXPECT().DeleteIdentity(ctx, credID).Times(1).Return(identityRequest)
+	mockKratosIdentityAPI.EXPECT().DeleteIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
+		func(r kClient.IdentityAPIDeleteIdentityRequest) (*http.Response, error) {
 			rr := httptest.NewRecorder()
 			rr.Header().Set("Content-Type", "application/json")
 			rr.WriteHeader(http.StatusNotFound)
@@ -550,7 +562,7 @@ func TestDeleteIdentityFails(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityApi, mockTracer, mockMonitor, mockLogger).DeleteIdentity(ctx, credID)
+	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).DeleteIdentity(ctx, credID)
 
 	if !reflect.DeepEqual(ids.Identities, make([]kClient.Identity, 0)) {
 		t.Fatalf("expected identities to be empty not  %v", ids.Identities)

--- a/pkg/rules/handlers.go
+++ b/pkg/rules/handlers.go
@@ -50,6 +50,10 @@ func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
 
 	pagination := types.ParsePagination(r.URL.Query())
 
+	if pagination.Page < 1 {
+		pagination.Page = 1
+	}
+
 	rules, err := a.service.ListRules(r.Context(), pagination.Page, pagination.Size)
 
 	if err != nil {

--- a/pkg/schemas/handlers.go
+++ b/pkg/schemas/handlers.go
@@ -52,7 +52,7 @@ func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
 
 	pagination := types.ParsePagination(r.URL.Query())
 
-	schemas, err := a.service.ListSchemas(r.Context(), pagination.Page, pagination.Size)
+	schemas, err := a.service.ListSchemas(r.Context(), pagination.Size, pagination.PageToken)
 
 	if err != nil {
 		rr := a.error(schemas.Error)
@@ -62,6 +62,10 @@ func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
+
+	// TODO @shipperizer improve on this, see if better to stick with link headers
+	pagination.Next = schemas.Tokens.Next
+	pagination.Prev = schemas.Tokens.Prev
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(

--- a/pkg/schemas/handlers_test.go
+++ b/pkg/schemas/handlers_test.go
@@ -28,7 +28,7 @@ import (
 //go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
 //go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
 //go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_corev1.go k8s.io/client-go/kubernetes/typed/core/v1 CoreV1Interface,ConfigMapInterface
-//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_kratos.go github.com/ory/kratos-client-go IdentityApi
+//go:generate mockgen -build_flags=--mod=mod -package schemas -destination ./mock_kratos.go github.com/ory/kratos-client-go IdentityAPI
 
 func TestHandleListSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -102,11 +102,15 @@ func TestHandleListSuccess(t *testing.T) {
 				Schema: v1Schema,
 			},
 		},
+		Tokens: types.NavigationTokens{
+			Next: "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ",
+			Prev: "eyJvZmZzZXQiOiItMjUwIiwidiI6Mn0",
+		},
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v0/schemas", nil)
 
-	mockService.EXPECT().ListSchemas(gomock.Any(), int64(1), int64(100)).Return(&schemas, nil)
+	mockService.EXPECT().ListSchemas(gomock.Any(), int64(100), "").Return(&schemas, nil)
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
@@ -161,7 +165,7 @@ func TestHandleListFails(t *testing.T) {
 	gerr.SetMessage("teapot error")
 	gerr.SetReason("teapot is broken")
 
-	mockService.EXPECT().ListSchemas(gomock.Any(), int64(1), int64(100)).Return(&IdentitySchemaData{IdentitySchemas: make([]kClient.IdentitySchemaContainer, 0), Error: gerr}, fmt.Errorf("error"))
+	mockService.EXPECT().ListSchemas(gomock.Any(), int64(100), "").Return(&IdentitySchemaData{IdentitySchemas: make([]kClient.IdentitySchemaContainer, 0), Error: gerr}, fmt.Errorf("error"))
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()

--- a/pkg/schemas/interfaces.go
+++ b/pkg/schemas/interfaces.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ServiceInterface interface {
-	ListSchemas(context.Context, int64, int64) (*IdentitySchemaData, error)
+	ListSchemas(context.Context, int64, string) (*IdentitySchemaData, error)
 	GetSchema(context.Context, string) (*IdentitySchemaData, error)
 	EditSchema(context.Context, string, *kClient.IdentitySchemaContainer) (*IdentitySchemaData, error)
 	CreateSchema(context.Context, *kClient.IdentitySchemaContainer) (*IdentitySchemaData, error)

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -65,7 +65,7 @@ func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, rulesConfig
 	metrics.NewAPI(logger).RegisterEndpoints(router)
 
 	identitiesAPI := identities.NewAPI(
-		identities.NewService(externalConfig.KratosAdmin().IdentityApi(), tracer, monitor, logger),
+		identities.NewService(externalConfig.KratosAdmin().IdentityAPI(), tracer, monitor, logger),
 		logger,
 	)
 	identitiesAPI.RegisterEndpoints(router)


### PR DESCRIPTION
IAM-782 + IAM-784: pagination for Kratos

- **fix: add page tokens to the response**
- **feat: parse and expose link header from hydra**
- **feat: adjust identity api to accept page token**
- **feat: adjust pagination for schemas endpoints**


```
shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-782 ● ● λ http :8000/api/v0/identities size==3                                                 
HTTP/1.1 200 OK
Content-Type: application/json
Date: Fri, 05 Apr 2024 16:53:26 GMT
Transfer-Encoding: chunked

{
    "_meta": {
        "first": "00000000-0000-0000-0000-000000000000",
        "page": 0,
        "page_token": "",
        "size": 3
    },
    "data": [
        {
            "created_at": "2024-04-05T16:28:24.406322Z",
            "id": "60a09add-4957-4ef6-9549-68ad38c5606a",
            "organization_id": null,
            "recovery_addresses": [
                {
                    "created_at": "2024-04-05T16:28:24.407827Z",
                    "id": "d79292dd-48b8-47c8-844e-39e5d7f594c7",
                    "updated_at": "2024-04-05T16:28:24.407827Z",
                    "value": "test-1@gmail.com",
                    "via": "email"
                }
            ],
            "schema_id": "default",
            "schema_url": "http://kratos-7cbb94c499-jhklw:4433/schemas/ZGVmYXVsdA",
            "state": "active",
            "state_changed_at": "2024-04-05T16:28:24.401155Z",
            "traits": {
                "email": "test-1@gmail.com"
            },
            "updated_at": "2024-04-05T16:28:24.406322Z",
            "verifiable_addresses": [
                {
                    "created_at": "2024-04-05T16:28:24.407279Z",
                    "id": "289c8bed-ae80-4d6c-84bd-9a584ea1784e",
                    "status": "pending",
                    "updated_at": "2024-04-05T16:28:24.407279Z",
                    "value": "test-1@gmail.com",
                    "verified": false,
                    "via": "email"
                }
            ]
        },
        {
            "created_at": "2024-04-05T16:32:11.415531Z",
            "id": "a37a64ec-4cac-48d9-8639-937cbc2981bc",
            "organization_id": null,
            "recovery_addresses": [
                {
                    "created_at": "2024-04-05T16:32:11.417057Z",
                    "id": "c12fc956-30a4-46a3-b2dd-b8ed4a5e2b3f",
                    "updated_at": "2024-04-05T16:32:11.417057Z",
                    "value": "kk@gmail.com",
                    "via": "email"
                }
            ],
            "schema_id": "default",
            "schema_url": "http://kratos-7cbb94c499-jhklw:4433/schemas/ZGVmYXVsdA",
            "state": "active",
            "state_changed_at": "2024-04-05T16:32:11.414872Z",
            "traits": {
                "email": "kk@gmail.com"
            },
            "updated_at": "2024-04-05T16:32:11.415531Z",
            "verifiable_addresses": [
                {
                    "created_at": "2024-04-05T16:32:11.416602Z",
                    "id": "f66b2a90-7de7-4fa1-8151-d720d0e9bb55",
                    "status": "pending",
                    "updated_at": "2024-04-05T16:32:11.416602Z",
                    "value": "kk@gmail.com",
                    "verified": false,
                    "via": "email"
                }
            ]
        },
        {
            "created_at": "2024-04-05T16:31:49.896801Z",
            "id": "a574aed1-4dbe-4dbe-8290-0c9a161f6d4d",
            "organization_id": null,
            "recovery_addresses": [
                {
                    "created_at": "2024-04-05T16:31:49.898386Z",
                    "id": "258a3d92-6e01-4d7b-a611-ad8a5a4ed75a",
                    "updated_at": "2024-04-05T16:31:49.898386Z",
                    "value": "jj@gmail.com",
                    "via": "email"
                }
            ],
            "schema_id": "default",
            "schema_url": "http://kratos-7cbb94c499-jhklw:4433/schemas/ZGVmYXVsdA",
            "state": "active",
            "state_changed_at": "2024-04-05T16:31:49.896059Z",
            "traits": {
                "email": "jj@gmail.com"
            },
            "updated_at": "2024-04-05T16:31:49.896801Z",
            "verifiable_addresses": [
                {
                    "created_at": "2024-04-05T16:31:49.89793Z",
                    "id": "237df955-f256-4ee1-991e-d19bf2320dfe",
                    "status": "pending",
                    "updated_at": "2024-04-05T16:31:49.89793Z",
                    "value": "jj@gmail.com",
                    "verified": false,
                    "via": "email"
                }
            ]
        }
    ],
    "message": "List of identities",
    "status": 200
}


shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-782 ● ● λ http :8000/api/v0/identities size==2 
HTTP/1.1 200 OK
Content-Length: 1742
Content-Type: application/json
Date: Fri, 05 Apr 2024 16:53:34 GMT

{
    "_meta": {
        "first": "00000000-0000-0000-0000-000000000000",
        "next": "a37a64ec-4cac-48d9-8639-937cbc2981bc",
        "page": 0,
        "page_token": "",
        "size": 2
    },
    "data": [
        {
            "created_at": "2024-04-05T16:28:24.406322Z",
            "id": "60a09add-4957-4ef6-9549-68ad38c5606a",
            "organization_id": null,
            "recovery_addresses": [
                {
                    "created_at": "2024-04-05T16:28:24.407827Z",
                    "id": "d79292dd-48b8-47c8-844e-39e5d7f594c7",
                    "updated_at": "2024-04-05T16:28:24.407827Z",
                    "value": "test-1@gmail.com",
                    "via": "email"
                }
            ],
            "schema_id": "default",
            "schema_url": "http://kratos-7cbb94c499-jhklw:4433/schemas/ZGVmYXVsdA",
            "state": "active",
            "state_changed_at": "2024-04-05T16:28:24.401155Z",
            "traits": {
                "email": "test-1@gmail.com"
            },
            "updated_at": "2024-04-05T16:28:24.406322Z",
            "verifiable_addresses": [
                {
                    "created_at": "2024-04-05T16:28:24.407279Z",
                    "id": "289c8bed-ae80-4d6c-84bd-9a584ea1784e",
                    "status": "pending",
                    "updated_at": "2024-04-05T16:28:24.407279Z",
                    "value": "test-1@gmail.com",
                    "verified": false,
                    "via": "email"
                }
            ]
        },
        {
            "created_at": "2024-04-05T16:32:11.415531Z",
            "id": "a37a64ec-4cac-48d9-8639-937cbc2981bc",
            "organization_id": null,
            "recovery_addresses": [
                {
                    "created_at": "2024-04-05T16:32:11.417057Z",
                    "id": "c12fc956-30a4-46a3-b2dd-b8ed4a5e2b3f",
                    "updated_at": "2024-04-05T16:32:11.417057Z",
                    "value": "kk@gmail.com",
                    "via": "email"
                }
            ],
            "schema_id": "default",
            "schema_url": "http://kratos-7cbb94c499-jhklw:4433/schemas/ZGVmYXVsdA",
            "state": "active",
            "state_changed_at": "2024-04-05T16:32:11.414872Z",
            "traits": {
                "email": "kk@gmail.com"
            },
            "updated_at": "2024-04-05T16:32:11.415531Z",
            "verifiable_addresses": [
                {
                    "created_at": "2024-04-05T16:32:11.416602Z",
                    "id": "f66b2a90-7de7-4fa1-8151-d720d0e9bb55",
                    "status": "pending",
                    "updated_at": "2024-04-05T16:32:11.416602Z",
                    "value": "kk@gmail.com",
                    "verified": false,
                    "via": "email"
                }
            ]
        }
    ],
    "message": "List of identities",
    "status": 200
}


shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-782 ● ● λ  
shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-782 ● ● λ http :8000/api/v0/identities size==2  page_token==a37a64ec-4cac-48d9-8639-937cbc2981bc
HTTP/1.1 200 OK
Content-Length: 949
Content-Type: application/json
Date: Fri, 05 Apr 2024 16:53:45 GMT

{
    "_meta": {
        "first": "00000000-0000-0000-0000-000000000000",
        "page": 0,
        "page_token": "a37a64ec-4cac-48d9-8639-937cbc2981bc",
        "size": 2
    },
    "data": [
        {
            "created_at": "2024-04-05T16:31:49.896801Z",
            "id": "a574aed1-4dbe-4dbe-8290-0c9a161f6d4d",
            "organization_id": null,
            "recovery_addresses": [
                {
                    "created_at": "2024-04-05T16:31:49.898386Z",
                    "id": "258a3d92-6e01-4d7b-a611-ad8a5a4ed75a",
                    "updated_at": "2024-04-05T16:31:49.898386Z",
                    "value": "jj@gmail.com",
                    "via": "email"
                }
            ],
            "schema_id": "default",
            "schema_url": "http://kratos-7cbb94c499-jhklw:4433/schemas/ZGVmYXVsdA",
            "state": "active",
            "state_changed_at": "2024-04-05T16:31:49.896059Z",
            "traits": {
                "email": "jj@gmail.com"
            },
            "updated_at": "2024-04-05T16:31:49.896801Z",
            "verifiable_addresses": [
                {
                    "created_at": "2024-04-05T16:31:49.89793Z",
                    "id": "237df955-f256-4ee1-991e-d19bf2320dfe",
                    "status": "pending",
                    "updated_at": "2024-04-05T16:31:49.89793Z",
                    "value": "jj@gmail.com",
                    "verified": false,
                    "via": "email"
                }
            ]
        }
    ],
    "message": "List of identities",
    "status": 200
}

```


**to notice**

- identities API has UUID tokens that match the next resource
- schemas API  uses base64 encoded tokens with an offset key
- rules API will follow the base64 offset pattern as current implementation in Oathkeeper is relying on page and size, no page token https://github.com/canonical/identity-platform-admin-ui/issues/268

this is by Ory design


### TODO 

- [ ] rebase