### PR TITLE
UI: add pagination and identity creation

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -40,4 +40,4 @@ Install dotrun as described in https://github.com/canonical/dotrun#installation 
 
     dotrun
 
-browse to https://localhost:8411/ to reach iam-admin-ui.
+browse to http://localhost:8411/ to reach iam-admin-ui.

--- a/ui/src/api/client.tsx
+++ b/ui/src/api/client.tsx
@@ -1,12 +1,16 @@
 import { Client } from "types/client";
-import { ApiResponse } from "types/api";
-import { handleResponse } from "util/api";
+import { ApiResponse, PaginatedResponse } from "types/api";
+import { handleResponse, PAGE_SIZE } from "util/api";
 
-export const fetchClients = (): Promise<Client[]> => {
+export const fetchClients = (
+  pageToken: string,
+): Promise<PaginatedResponse<Client[]>> => {
   return new Promise((resolve, reject) => {
-    fetch(`${import.meta.env.VITE_API_URL}/clients`)
+    fetch(
+      `${import.meta.env.VITE_API_URL}/clients?page_token=${pageToken}&size=${PAGE_SIZE}`,
+    )
       .then(handleResponse)
-      .then((result: ApiResponse<Client[]>) => resolve(result.data))
+      .then((result: PaginatedResponse<Client[]>) => resolve(result))
       .catch(reject);
   });
 };
@@ -34,7 +38,7 @@ export const createClient = (values: string): Promise<Client> => {
 
 export const updateClient = (
   clientId: string,
-  values: string
+  values: string,
 ): Promise<Client> => {
   return new Promise((resolve, reject) => {
     fetch(`${import.meta.env.VITE_API_URL}/clients/${clientId}`, {

--- a/ui/src/api/identities.tsx
+++ b/ui/src/api/identities.tsx
@@ -1,12 +1,14 @@
-import { ApiResponse } from "types/api";
-import { handleResponse } from "util/api";
+import { ApiResponse, PaginatedResponse } from "types/api";
+import { handleResponse, PAGE_SIZE } from "util/api";
 import { Identity } from "types/identity";
 
-export const fetchIdentities = (): Promise<Identity[]> => {
+export const fetchIdentities = (
+  pageToken: string,
+): Promise<PaginatedResponse<Identity[]>> => {
   return new Promise((resolve, reject) => {
-    fetch("/api/v0/identities")
+    fetch(`/api/v0/identities?page_token=${pageToken}&size=${PAGE_SIZE}`)
       .then(handleResponse)
-      .then((result: ApiResponse<Identity[]>) => resolve(result.data))
+      .then((result: PaginatedResponse<Identity[]>) => resolve(result))
       .catch(reject);
   });
 };

--- a/ui/src/api/schema.tsx
+++ b/ui/src/api/schema.tsx
@@ -1,12 +1,14 @@
-import { ApiResponse } from "types/api";
-import { handleResponse } from "util/api";
+import { ApiResponse, PaginatedResponse } from "types/api";
+import { handleResponse, PAGE_SIZE } from "util/api";
 import { Schema } from "types/schema";
 
-export const fetchSchemas = (): Promise<Schema[]> => {
+export const fetchSchemas = (
+  pageToken: string,
+): Promise<PaginatedResponse<Schema[]>> => {
   return new Promise((resolve, reject) => {
-    fetch("/api/v0/schemas")
+    fetch(`/api/v0/schemas?page_token=${pageToken}&page_size=${PAGE_SIZE}`)
       .then(handleResponse)
-      .then((result: ApiResponse<Schema[]>) => resolve(result.data))
+      .then((result: PaginatedResponse<Schema[]>) => resolve(result))
       .catch(reject);
   });
 };

--- a/ui/src/components/IconLeft.tsx
+++ b/ui/src/components/IconLeft.tsx
@@ -1,0 +1,7 @@
+import React, { FC } from "react";
+
+const IconLeft: FC = () => {
+  return <i className="p-icon--chevron-down" style={{ rotate: "90deg" }} />;
+};
+
+export default IconLeft;

--- a/ui/src/components/IconRight.tsx
+++ b/ui/src/components/IconRight.tsx
@@ -1,0 +1,7 @@
+import React, { FC } from "react";
+
+const IconRight: FC = () => {
+  return <i className="p-icon--chevron-down" style={{ rotate: "270deg" }} />;
+};
+
+export default IconRight;

--- a/ui/src/components/Pagination.tsx
+++ b/ui/src/components/Pagination.tsx
@@ -1,0 +1,47 @@
+import React, { FC } from "react";
+import { PaginatedResponse } from "types/api";
+import { Button } from "@canonical/react-components";
+import { usePagination } from "util/usePagination";
+import IconLeft from "components/IconLeft";
+import IconRight from "components/IconRight";
+
+interface Props {
+  response?: PaginatedResponse<unknown[]>;
+}
+
+const Pagination: FC<Props> = ({ response }) => {
+  const { pageToken, setPageToken } = usePagination();
+  const showFirstLink = pageToken !== "";
+  const isMissingNext = !response || !response._meta.next;
+  const isEmptyPage = response?.data.length === 0;
+
+  if (!showFirstLink && (isMissingNext || isEmptyPage)) {
+    return null;
+  }
+
+  const next = response?._meta.next ?? "";
+  const prev = response?._meta.prev ?? "";
+
+  return (
+    <>
+      {showFirstLink && (
+        <Button onClick={() => setPageToken("")} title="First page">
+          <IconLeft />
+          <IconLeft />
+        </Button>
+      )}
+      {prev && (
+        <Button onClick={() => setPageToken(prev)} title="Previous page">
+          <IconLeft />
+        </Button>
+      )}
+      {next && (
+        <Button onClick={() => setPageToken(next)} title="Next page">
+          <IconRight />
+        </Button>
+      )}
+    </>
+  );
+};
+
+export default Pagination;

--- a/ui/src/components/Panels.tsx
+++ b/ui/src/components/Panels.tsx
@@ -3,6 +3,7 @@ import usePanelParams, { panels } from "util/usePanelParams";
 import ProviderEdit from "pages/providers/ProviderEdit";
 import ClientCreate from "pages/clients/ClientCreate";
 import ClientEdit from "pages/clients/ClientEdit";
+import IdentityCreate from "pages/identities/IdentityCreate";
 
 const Panels = () => {
   const panelParams = usePanelParams();
@@ -17,6 +18,8 @@ const Panels = () => {
         return <ClientCreate />;
       case panels.clientEdit:
         return <ClientEdit />;
+      case panels.identityCreate:
+        return <IdentityCreate />;
       default:
         return null;
     }

--- a/ui/src/pages/clients/ClientList.tsx
+++ b/ui/src/pages/clients/ClientList.tsx
@@ -8,13 +8,17 @@ import { isoTimeToString } from "util/date";
 import usePanelParams from "util/usePanelParams";
 import EditClientBtn from "pages/clients/EditClientBtn";
 import DeleteClientBtn from "pages/clients/DeleteClientBtn";
+import Loader from "components/Loader";
+import Pagination from "components/Pagination";
+import { usePagination } from "util/usePagination";
 
 const ClientList: FC = () => {
   const panelParams = usePanelParams();
+  const { pageToken } = usePagination();
 
-  const { data: clients = [] } = useQuery({
-    queryKey: [queryKeys.clients],
-    queryFn: fetchClients,
+  const { data: response, isLoading } = useQuery({
+    queryKey: [queryKeys.clients, pageToken],
+    queryFn: () => fetchClients(pageToken),
   });
 
   return (
@@ -35,16 +39,14 @@ const ClientList: FC = () => {
             <NotificationConsumer />
             <MainTable
               className="u-table-layout--auto"
-              sortable
               responsive
-              paginate={30}
               headers={[
-                { content: "Id", sortKey: "id" },
-                { content: "Name", sortKey: "name" },
+                { content: "Id" },
+                { content: "Name" },
                 { content: "Date" },
                 { content: "Actions" },
               ]}
-              rows={clients.map((client) => {
+              rows={response?.data.map((client) => {
                 return {
                   columns: [
                     {
@@ -82,13 +84,17 @@ const ClientList: FC = () => {
                       "aria-label": "Actions",
                     },
                   ],
-                  sortData: {
-                    id: client.client_id,
-                    name: client.client_name.toLowerCase(),
-                  },
                 };
               })}
+              emptyStateMsg={
+                isLoading ? (
+                  <Loader text="Loading clients..." />
+                ) : (
+                  "No data to display"
+                )
+              }
             />
+            <Pagination response={response} />
           </Col>
         </Row>
       </div>

--- a/ui/src/pages/identities/DeleteIdentityBtn.tsx
+++ b/ui/src/pages/identities/DeleteIdentityBtn.tsx
@@ -1,0 +1,62 @@
+import { FC, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { queryKeys } from "util/queryKeys";
+import { useQueryClient } from "@tanstack/react-query";
+import { ConfirmationButton, useNotify } from "@canonical/react-components";
+import { Identity } from "types/identity";
+import { deleteIdentity } from "api/identities";
+
+interface Props {
+  identity: Identity;
+}
+
+const DeleteIdentityBtn: FC<Props> = ({ identity }) => {
+  const notify = useNotify();
+  const queryClient = useQueryClient();
+  const [isLoading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleDelete = () => {
+    setLoading(true);
+    deleteIdentity(identity.id)
+      .then(() => {
+        navigate(
+          "/identity",
+          notify.queue(
+            notify.success(`Identity ${identity.traits?.email} deleted.`),
+          ),
+        );
+      })
+      .catch((e) => {
+        notify.failure("Identity deletion failed", e);
+      })
+      .finally(() => {
+        setLoading(false);
+        void queryClient.invalidateQueries({
+          queryKey: [queryKeys.identities],
+        });
+      });
+  };
+
+  return (
+    <ConfirmationButton
+      className="u-no-margin--bottom"
+      loading={isLoading}
+      confirmationModalProps={{
+        title: "Confirm delete",
+        children: (
+          <p>
+            This will permanently delete identity <b>{identity.traits?.email}</b>.
+          </p>
+        ),
+        confirmButtonLabel: "Delete identity",
+        onConfirm: handleDelete,
+      }}
+      title="Confirm delete"
+    >
+      Delete
+    </ConfirmationButton>
+  );
+};
+
+export default DeleteIdentityBtn;

--- a/ui/src/pages/identities/IdentityCreate.tsx
+++ b/ui/src/pages/identities/IdentityCreate.tsx
@@ -1,0 +1,95 @@
+import React, { FC } from "react";
+import {
+  ActionButton,
+  Button,
+  Col,
+  Row,
+  useNotify,
+} from "@canonical/react-components";
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import { queryKeys } from "util/queryKeys";
+import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import IdentityForm, { IdentityFormTypes } from "pages/identities/IdentityForm";
+import { createIdentity } from "api/identities";
+import SidePanel from "components/SidePanel";
+import ScrollableContainer from "components/ScrollableContainer";
+
+const IdentityCreate: FC = () => {
+  const navigate = useNavigate();
+  const notify = useNotify();
+  const queryClient = useQueryClient();
+
+  const IdentityCreateSchema = Yup.object().shape({
+    email: Yup.string().required("This field is required"),
+    schemaId: Yup.string().required("This field is required"),
+  });
+
+  const formik = useFormik<IdentityFormTypes>({
+    initialValues: {
+      email: "",
+      schemaId: "",
+    },
+    validationSchema: IdentityCreateSchema,
+    validateOnMount: true,
+    onSubmit: (values) => {
+      const identity = {
+        schema_id: values.schemaId,
+        traits: { email: values.email },
+      };
+      createIdentity(JSON.stringify(identity))
+        .then(() => {
+          void queryClient.invalidateQueries({
+            queryKey: [queryKeys.identities],
+          });
+          const msg = `Identity created.`;
+          navigate("/identity", notify.queue(notify.success(msg)));
+        })
+        .catch((e) => {
+          formik.setSubmitting(false);
+          notify.failure("Identity creation failed", e);
+        });
+    },
+  });
+
+  const submitForm = () => {
+    void formik.submitForm();
+  };
+
+  return (
+    <SidePanel hasError={false} loading={false} className="p-panel">
+      <ScrollableContainer dependencies={[]} belowId="panel-footer">
+        <SidePanel.Header>
+          <SidePanel.HeaderTitle>Add identity</SidePanel.HeaderTitle>
+        </SidePanel.Header>
+        <SidePanel.Content>
+          <Row>
+            <IdentityForm formik={formik} />
+          </Row>
+        </SidePanel.Content>
+      </ScrollableContainer>
+      <div id="panel-footer">
+        <SidePanel.Footer>
+          <Row className="u-align-text--right">
+            <Col size={12}>
+              <Button appearance="base" onClick={() => navigate("/identity")}>
+                Cancel
+              </Button>
+              <ActionButton
+                appearance="positive"
+                loading={formik.isSubmitting}
+                disabled={!formik.isValid}
+                onClick={submitForm}
+              >
+                Save
+              </ActionButton>
+            </Col>
+          </Row>
+        </SidePanel.Footer>
+      </div>
+    </SidePanel>
+  );
+};
+
+export default IdentityCreate;

--- a/ui/src/pages/identities/IdentityForm.tsx
+++ b/ui/src/pages/identities/IdentityForm.tsx
@@ -1,0 +1,54 @@
+import React, { FC } from "react";
+import { Form, Input, Select } from "@canonical/react-components";
+import { FormikProps } from "formik";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { fetchSchemas } from "api/schema";
+
+export interface IdentityFormTypes {
+  schemaId: string;
+  email: string;
+}
+
+interface Props {
+  formik: FormikProps<IdentityFormTypes>;
+}
+
+const IdentityForm: FC<Props> = ({ formik }) => {
+  const { data } = useQuery({
+    queryKey: [queryKeys.schemas],
+    queryFn: () => fetchSchemas(""),
+  });
+
+  const schemaOptions =
+    data?.data.map((schema) => ({
+      label: schema.id,
+      value: schema.id,
+    })) ?? [];
+
+  return (
+    <Form onSubmit={formik.handleSubmit} stacked>
+      <Input
+        {...formik.getFieldProps("email")}
+        type="text"
+        label="Email"
+        error={formik.touched.email ? formik.errors.email : null}
+      />
+      <Select
+        {...formik.getFieldProps("schemaId")}
+        options={[
+          {
+            label: "Select option",
+            value: "",
+            disabled: true,
+          },
+          ...schemaOptions,
+        ]}
+        label="Schema"
+        error={formik.touched.schemaId ? formik.errors.schemaId : null}
+      />
+    </Form>
+  );
+};
+
+export default IdentityForm;

--- a/ui/src/pages/providers/ProviderList.tsx
+++ b/ui/src/pages/providers/ProviderList.tsx
@@ -41,7 +41,6 @@ const ProviderList: FC = () => {
               className="u-table-layout--auto"
               sortable
               responsive
-              paginate={30}
               headers={[
                 { content: "Name", sortKey: "id" },
                 { content: "Provider", sortKey: "provider" },

--- a/ui/src/pages/schemas/SchemaList.tsx
+++ b/ui/src/pages/schemas/SchemaList.tsx
@@ -4,11 +4,16 @@ import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { NotificationConsumer } from "@canonical/react-components/dist/components/NotificationProvider/NotificationProvider";
 import { fetchSchemas } from "api/schema";
+import Loader from "components/Loader";
+import Pagination from "components/Pagination";
+import { usePagination } from "util/usePagination";
 
 const SchemaList: FC = () => {
-  const { data: schemas = [] } = useQuery({
-    queryKey: [queryKeys.schemas],
-    queryFn: fetchSchemas,
+  const { pageToken } = usePagination();
+
+  const { data: response, isLoading } = useQuery({
+    queryKey: [queryKeys.schemas, pageToken],
+    queryFn: () => fetchSchemas(pageToken),
   });
 
   return (
@@ -24,14 +29,9 @@ const SchemaList: FC = () => {
             <NotificationConsumer />
             <MainTable
               className="u-table-layout--auto"
-              sortable
               responsive
-              paginate={30}
-              headers={[
-                { content: "Id", sortKey: "id" },
-                { content: "Schema" },
-              ]}
-              rows={schemas.map((schema) => {
+              headers={[{ content: "Id" }, { content: "Schema" }]}
+              rows={response?.data.map((schema) => {
                 return {
                   columns: [
                     {
@@ -45,12 +45,17 @@ const SchemaList: FC = () => {
                       "aria-label": "Name",
                     },
                   ],
-                  sortData: {
-                    id: schema.id,
-                  },
                 };
               })}
+              emptyStateMsg={
+                isLoading ? (
+                  <Loader text="Loading schemas..." />
+                ) : (
+                  "No data to display"
+                )
+              }
             />
+            <Pagination response={response} />
           </Col>
         </Row>
       </div>

--- a/ui/src/types/api.d.ts
+++ b/ui/src/types/api.d.ts
@@ -4,6 +4,13 @@ export interface ApiResponse<T> {
   status: number;
 }
 
+export type PaginatedResponse<T> = {
+  _meta: {
+    next?: string;
+    prev?: string;
+  };
+} & ApiResponse<T>;
+
 export interface ErrorResponse {
   error?: string;
   message?: string;

--- a/ui/src/util/api.tsx
+++ b/ui/src/util/api.tsx
@@ -1,5 +1,7 @@
 import { ErrorResponse } from "types/api";
 
+export const PAGE_SIZE = 50;
+
 export const handleResponse = async (response: Response) => {
   if (!response.ok) {
     const result = (await response.json()) as ErrorResponse;

--- a/ui/src/util/usePagination.tsx
+++ b/ui/src/util/usePagination.tsx
@@ -1,0 +1,11 @@
+import { useSearchParams } from "react-router-dom";
+
+export const usePagination = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const pageToken = searchParams.get("page_token") ?? "";
+  const setPageToken = (newPage: string) => {
+    setSearchParams({ ...searchParams, page_token: newPage });
+  };
+
+  return { pageToken, setPageToken };
+};

--- a/ui/src/util/usePanelParams.tsx
+++ b/ui/src/util/usePanelParams.tsx
@@ -9,6 +9,7 @@ export interface PanelHelper {
   openProviderEdit: (id: string) => void;
   openClientCreate: () => void;
   openClientEdit: (id: string) => void;
+  openIdentityCreate: () => void;
   updatePanelParams: (key: string, value: string) => void;
 }
 
@@ -17,6 +18,7 @@ export const panels = {
   providerEdit: "provider-edit",
   clientCreate: "client-create",
   clientEdit: "client-edit",
+  identityCreate: "identity-create",
 };
 
 type ParamMap = Record<string, string>;
@@ -67,6 +69,10 @@ const usePanelParams = (): PanelHelper => {
 
     openClientEdit: (id: string) => {
       setPanelParams(panels.clientEdit, { id });
+    },
+
+    openIdentityCreate: () => {
+      setPanelParams(panels.identityCreate);
     },
 
     updatePanelParams: (key: string, value: string) => {


### PR DESCRIPTION
# Done
- Add pagination to clients, schemas and identity lists in ui.
- Add identity creation form
- Add identity deletion

fixes WD-10253

![Screenshot from 2024-04-17 19-49-51](https://github.com/canonical/identity-platform-admin-ui/assets/3263345/6873a6b2-ae14-409a-9361-b08936627275)
![Screenshot from 2024-04-17 19-49-45](https://github.com/canonical/identity-platform-admin-ui/assets/3263345/2f43296a-1c91-49c1-a41f-4322e0efcb85)
