### PR TITLE
ci: add cleanup of job after 60s

### DIFF
--- a/deployments/kubectl/job.yaml
+++ b/deployments/kubectl/job.yaml
@@ -4,6 +4,7 @@ kind: Job
 metadata:
   name: admin-ui-openfga-setup
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       securityContext:


### PR DESCRIPTION
this will mean that at each `make dev` run a new store and model will be created 
assumption is that make dev is a one off command for bootstrapping the setup, not an iterative command to run