### PR TITLE
validation/disable

### DIFF
--- a/pkg/clients/handlers.go
+++ b/pkg/clients/handlers.go
@@ -35,7 +35,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator(a.apiKey, a.payloadValidator)
 	if err != nil {
-		a.logger.Fatal("unexpected validatingFunc already registered for clients")
+		a.logger.Fatalf("unexpected validatingFunc already registered for clients, %s", err)
 	}
 }
 

--- a/pkg/groups/handlers.go
+++ b/pkg/groups/handlers.go
@@ -79,7 +79,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator(a.apiKey, a.payloadValidator)
 	if err != nil {
-		a.logger.Fatal("unexpected validatingFunc already registered for groups")
+		a.logger.Fatalf("unexpected validatingFunc already registered for groups, %s", err)
 	}
 }
 

--- a/pkg/groups/handlers_test.go
+++ b/pkg/groups/handlers_test.go
@@ -2008,7 +2008,7 @@ func TestRegisterValidation(t *testing.T) {
 	// first registration of `apiKey` is successful
 	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)
 
-	mockLogger.EXPECT().Fatal(gomock.Any()).Times(1)
+	mockLogger.EXPECT().Fatalf(gomock.Any(), gomock.Any()).Times(1)
 
 	// second registration of `apiKey` causes logger.Fatal invocation
 	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)

--- a/pkg/identities/handlers.go
+++ b/pkg/identities/handlers.go
@@ -49,7 +49,7 @@ func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator(a.apiKey, a.payloadValidator)
 
 	if err != nil {
-		a.logger.Fatal("unexpected PayloadValidator already registered for identities")
+		a.logger.Fatalf("unexpected validatingFunc already registered for identities, %s", err)
 	}
 }
 

--- a/pkg/identities/handlers_test.go
+++ b/pkg/identities/handlers_test.go
@@ -738,7 +738,7 @@ func TestRegisterValidation(t *testing.T) {
 	// first registration of `apiKey` is successful
 	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)
 
-	mockLogger.EXPECT().Fatal(gomock.Any()).Times(1)
+	mockLogger.EXPECT().Fatalf(gomock.Any(), gomock.Any()).Times(1)
 
 	// second registration of `apiKey` causes logger.Fatal invocation
 	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)

--- a/pkg/idp/handlers.go
+++ b/pkg/idp/handlers.go
@@ -36,7 +36,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator(a.apiKey, a.payloadValidator)
 	if err != nil {
-		a.logger.Fatal("unexpected validatingFunc already registered for idps")
+		a.logger.Fatalf("unexpected validatingFunc already registered for idps, %s", err)
 	}
 }
 

--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -64,7 +64,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator("roles", a.payloadValidator)
 	if err != nil {
-		a.logger.Fatal("unexpected PayloadValidator already registered for roles")
+		a.logger.Fatalf("unexpected validatingFunc already registered for roles, %s", err)
 	}
 }
 

--- a/pkg/rules/handlers.go
+++ b/pkg/rules/handlers.go
@@ -36,7 +36,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator(a.apiKey, a.payloadValidator)
 	if err != nil {
-		a.logger.Fatal("unexpected PayloadValidator already registered for rules")
+		a.logger.Fatalf("unexpected validatingFunc already registered for rules, %s", err)
 	}
 }
 

--- a/pkg/schemas/handlers.go
+++ b/pkg/schemas/handlers.go
@@ -37,7 +37,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator(a.apiKey, a.payloadValidator)
 	if err != nil {
-		a.logger.Fatal("unexpected validatingFunc already registered for schemas")
+		a.logger.Fatalf("unexpected validatingFunc already registered for schemas, %s", err)
 	}
 }
 

--- a/pkg/schemas/handlers_test.go
+++ b/pkg/schemas/handlers_test.go
@@ -1219,7 +1219,7 @@ func TestRegisterValidation(t *testing.T) {
 	// first registration of `apiKey` is successful
 	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)
 
-	mockLogger.EXPECT().Fatal(gomock.Any()).Times(1)
+	mockLogger.EXPECT().Fatalf(gomock.Any(), gomock.Any()).Times(1)
 
 	// second registration of `apiKey` causes logger.Fatal invocation
 	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -69,35 +69,35 @@ func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, rulesConfig
 		logger,
 	)
 	identitiesAPI.RegisterEndpoints(router)
-	identitiesAPI.RegisterValidation(vldtr)
+	// identitiesAPI.RegisterValidation(vldtr)
 
 	clientsAPI := clients.NewAPI(
 		clients.NewService(externalConfig.HydraAdmin(), tracer, monitor, logger),
 		logger,
 	)
 	clientsAPI.RegisterEndpoints(router)
-	clientsAPI.RegisterValidation(vldtr)
+	// clientsAPI.RegisterValidation(vldtr)
 
 	idpAPI := idp.NewAPI(
 		idp.NewService(idpConfig, tracer, monitor, logger),
 		logger,
 	)
 	idpAPI.RegisterEndpoints(router)
-	idpAPI.RegisterValidation(vldtr)
+	// idpAPI.RegisterValidation(vldtr)
 
 	schemasAPI := schemas.NewAPI(
 		schemas.NewService(schemasConfig, tracer, monitor, logger),
 		logger,
 	)
 	schemasAPI.RegisterEndpoints(router)
-	schemasAPI.RegisterValidation(vldtr)
+	// schemasAPI.RegisterValidation(vldtr)
 
 	rulesAPI := rules.NewAPI(
 		rules.NewService(rulesConfig, tracer, monitor, logger),
 		logger,
 	)
 	rulesAPI.RegisterEndpoints(router)
-	rulesAPI.RegisterValidation(vldtr)
+	// rulesAPI.RegisterValidation(vldtr)
 
 	rolesAPI := roles.NewAPI(
 		roles.NewService(externalConfig.OpenFGA(), wpool, tracer, monitor, logger),
@@ -106,7 +106,7 @@ func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, rulesConfig
 		logger,
 	)
 	rolesAPI.RegisterEndpoints(router)
-	rolesAPI.RegisterValidation(vldtr)
+	// rolesAPI.RegisterValidation(vldtr)
 
 	groupsAPI := groups.NewAPI(
 		groups.NewService(externalConfig.OpenFGA(), wpool, tracer, monitor, logger),
@@ -115,7 +115,7 @@ func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, rulesConfig
 		logger,
 	)
 	groupsAPI.RegisterEndpoints(router)
-	groupsAPI.RegisterValidation(vldtr)
+	// groupsAPI.RegisterValidation(vldtr)
 
 	return tracing.NewMiddleware(monitor, logger).OpenTelemetry(router)
 }


### PR DESCRIPTION
- **fix: disable validation due to missing implementation of api validators**
- **fix: enhance registerValidation log message with error**

this addresses a temporary issue with the validators being nil and causing issues

```
shipperizer in ~/shipperizer/identity-platform-admin-ui on ui-pagination ● ● λ k logs identity-platform-admin-ui-fd898bb9b-ns9zm
{"severity":"fatal","@timestamp":"2024-04-17T17:04:29.581530398Z","message":"unexpected validatingFunc already registered for clients, payloadValidator can't be null"}

```


will be superseded as soon as newer changes go in 

