### PR TITLE
IAM 776 Implement validation for all handlers

### DIFF
--- a/internal/validation/registry_test.go
+++ b/internal/validation/registry_test.go
@@ -22,7 +22,7 @@ import (
 
 type payloadValidator struct{}
 
-func (_ *payloadValidator) Validate(ctx context.Context, _, _ string, _ []byte) (context.Context, validator.ValidationErrors, error) {
+func (p *payloadValidator) Validate(ctx context.Context, _, _ string, _ []byte) (context.Context, validator.ValidationErrors, error) {
 	e := mockValidationErrors()
 	if e == nil {
 		return ctx, nil, nil
@@ -30,7 +30,7 @@ func (_ *payloadValidator) Validate(ctx context.Context, _, _ string, _ []byte) 
 	return ctx, e, nil
 }
 
-func (_ *payloadValidator) NeedsValidation(r *http.Request) bool {
+func (p *payloadValidator) NeedsValidation(r *http.Request) bool {
 	return true
 }
 

--- a/pkg/clients/handlers.go
+++ b/pkg/clients/handlers.go
@@ -202,7 +202,7 @@ func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
 	a.apiKey = "clients"
 
 	a.service = service
-	//a.payloadValidator = NewClientsPayloadValidator(a.apiKey)
+	a.payloadValidator = NewClientsPayloadValidator(a.apiKey)
 	a.logger = logger
 
 	return a

--- a/pkg/clients/handlers.go
+++ b/pkg/clients/handlers.go
@@ -35,7 +35,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator(a.apiKey, a.payloadValidator)
 	if err != nil {
-		a.logger.Fatalf("unexpected validatingFunc already registered for clients, %s", err)
+		a.logger.Fatalf("unexpected error while registering PayloadValidator for 'clients', %s", err)
 	}
 }
 

--- a/pkg/clients/handlers.go
+++ b/pkg/clients/handlers.go
@@ -35,7 +35,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator(a.apiKey, a.payloadValidator)
 	if err != nil {
-		a.logger.Fatalf("unexpected error while registering PayloadValidator for 'clients', %s", err)
+		a.logger.Fatalf("unexpected error while registering PayloadValidator for clients, %s", err)
 	}
 }
 

--- a/pkg/clients/handlers.go
+++ b/pkg/clients/handlers.go
@@ -27,9 +27,9 @@ type API struct {
 func (a *API) RegisterEndpoints(mux *chi.Mux) {
 	mux.Get("/api/v0/clients", a.ListClients)
 	mux.Post("/api/v0/clients", a.CreateClient)
-	mux.Get("/api/v0/clients/{id}", a.GetClient)
-	mux.Put("/api/v0/clients/{id}", a.UpdateClient)
-	mux.Delete("/api/v0/clients/{id}", a.DeleteClient)
+	mux.Get("/api/v0/clients/{id:.+}", a.GetClient)
+	mux.Put("/api/v0/clients/{id:.+}", a.UpdateClient)
+	mux.Delete("/api/v0/clients/{id:.+}", a.DeleteClient)
 }
 
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {

--- a/pkg/clients/handlers_test.go
+++ b/pkg/clients/handlers_test.go
@@ -594,7 +594,7 @@ func TestRegisterValidation(t *testing.T) {
 	// first registration of `apiKey` is successful
 	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)
 
-	mockLogger.EXPECT().Fatal(gomock.Any()).Times(1)
+	mockLogger.EXPECT().Fatalf(gomock.Any(), gomock.Any()).Times(1)
 
 	// second registration of `apiKey` causes logger.Fatal invocation
 	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)

--- a/pkg/clients/validation.go
+++ b/pkg/clients/validation.go
@@ -1,0 +1,84 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+	client "github.com/ory/hydra-client-go/v2"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/validation"
+)
+
+var (
+	oauth2ClientRules = map[string]string{
+		"AllowedCorsOrigins":      "omitempty,dive,required",
+		"Audience":                "omitempty,dive,required",
+		"ClientName":              "required",
+		"SubjectType":             "omitempty,oneof=pairwise public",
+		"GrantTypes":              "omitempty,dive,required",
+		"TokenEndpointAuthMethod": "omitempty,oneof=client_secret_basic client_secret_post private_key_jwt none",
+	}
+)
+
+type PayloadValidator struct {
+	apiKey    string
+	validator *validator.Validate
+}
+
+func (p *PayloadValidator) setupValidator() {
+	p.validator.RegisterStructValidationMapRules(oauth2ClientRules, client.OAuth2Client{})
+}
+
+func (p *PayloadValidator) NeedsValidation(req *http.Request) bool {
+	return req.Method == http.MethodPost || req.Method == http.MethodPut
+}
+
+func (p *PayloadValidator) Validate(ctx context.Context, method, endpoint string, body []byte) (context.Context, validator.ValidationErrors, error) {
+	validated := false
+	var err error
+
+	if p.isCreateClient(method, endpoint) || p.isUpdateClient(method, endpoint) {
+		clientRequest := new(client.OAuth2Client)
+		if err := json.Unmarshal(body, clientRequest); err != nil {
+			return ctx, nil, err
+		}
+
+		err = p.validator.Struct(clientRequest)
+		validated = true
+
+	}
+
+	if !validated {
+		return ctx, nil, validation.NoMatchError(p.apiKey)
+	}
+
+	if err == nil {
+		return ctx, nil, nil
+	}
+
+	return ctx, err.(validator.ValidationErrors), nil
+}
+
+func (p *PayloadValidator) isCreateClient(method string, endpoint string) bool {
+	return method == http.MethodPost && endpoint == ""
+}
+
+func (p *PayloadValidator) isUpdateClient(method string, endpoint string) bool {
+	return method == http.MethodPut && strings.HasPrefix(endpoint, "/")
+}
+
+func NewClientsPayloadValidator(apiKey string) *PayloadValidator {
+	p := new(PayloadValidator)
+	p.apiKey = apiKey
+	p.validator = validation.NewValidator()
+
+	p.setupValidator()
+
+	return p
+}

--- a/pkg/clients/validation.go
+++ b/pkg/clients/validation.go
@@ -17,11 +17,14 @@ import (
 
 var (
 	oauth2ClientRules = map[string]string{
-		"AllowedCorsOrigins":      "omitempty,dive,required",
-		"Audience":                "omitempty,dive,required",
-		"ClientName":              "required",
-		"SubjectType":             "omitempty,oneof=pairwise public",
-		"GrantTypes":              "omitempty,dive,required",
+		// if not empy, validate every item is not nil and not empty
+		"AllowedCorsOrigins": "omitempty,dive,required",
+		"Audience":           "omitempty,dive,required",
+		"GrantTypes":         "omitempty,dive,required",
+		"ClientName":         "required",
+		// if not empty, validate value is one of 'pairwise' and 'public'
+		"SubjectType": "omitempty,oneof=pairwise public",
+		// if not empty, validate value is one of 'client_secret_basic', 'client_secret_post', 'private_key_jwt' and 'none'
 		"TokenEndpointAuthMethod": "omitempty,oneof=client_secret_basic client_secret_post private_key_jwt none",
 	}
 )

--- a/pkg/clients/validation_test.go
+++ b/pkg/clients/validation_test.go
@@ -1,0 +1,214 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	client "github.com/ory/kratos-client-go"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/validation"
+)
+
+func TestNeedsValidation(t *testing.T) {
+	p := new(PayloadValidator)
+	p.validator = validation.NewValidator()
+	p.setupValidator()
+
+	for _, tt := range []struct {
+		name           string
+		req            *http.Request
+		expectedResult bool
+	}{
+		{
+			name:           http.MethodPost,
+			req:            httptest.NewRequest(http.MethodPost, "/", nil),
+			expectedResult: true,
+		},
+		{
+			name:           http.MethodPut,
+			req:            httptest.NewRequest(http.MethodPut, "/", nil),
+			expectedResult: true,
+		},
+		{
+			name:           http.MethodGet,
+			req:            httptest.NewRequest(http.MethodGet, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodPatch,
+			req:            httptest.NewRequest(http.MethodPatch, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodDelete,
+			req:            httptest.NewRequest(http.MethodDelete, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodConnect,
+			req:            httptest.NewRequest(http.MethodConnect, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodHead,
+			req:            httptest.NewRequest(http.MethodHead, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodTrace,
+			req:            httptest.NewRequest(http.MethodTrace, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodOptions,
+			req:            httptest.NewRequest(http.MethodOptions, "/", nil),
+			expectedResult: false,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.NeedsValidation(tt.req)
+
+			if result != tt.expectedResult {
+				t.Fatalf("Result doesn't match expected one, obtained %t instead of %t", result, tt.expectedResult)
+			}
+		})
+	}
+
+}
+
+func TestValidate(t *testing.T) {
+	p := new(PayloadValidator)
+	p.apiKey = "clients"
+	p.validator = validation.NewValidator()
+	p.setupValidator()
+
+	for _, tt := range []struct {
+		name           string
+		method         string
+		endpoint       string
+		body           func() []byte
+		expectedResult validator.ValidationErrors
+		expectedError  error
+	}{
+		{
+			name:     "CreateClientSuccess",
+			method:   http.MethodPost,
+			endpoint: "",
+			body: func() []byte {
+				clientName := "mock-name"
+				subjectType := "pairwise"
+				tokenAuthMethod := "client_secret_basic"
+				c := client.OAuth2Client{
+					AllowedCorsOrigins:      []string{"mock-origin-1", "mock-origin-2"},
+					Audience:                []string{"mock-aud-1", "mock-aud-2"},
+					ClientName:              &clientName,
+					SubjectType:             &subjectType,
+					GrantTypes:              []string{"code_grant"},
+					TokenEndpointAuthMethod: &tokenAuthMethod,
+				}
+
+				marshal, _ := json.Marshal(c)
+				return marshal
+			},
+			expectedResult: nil,
+			expectedError:  nil,
+		},
+		{
+			name:     "UpdateClientSuccess",
+			method:   http.MethodPut,
+			endpoint: "/client-id",
+			body: func() []byte {
+				clientName := "mock-name"
+				subjectType := "pairwise"
+				tokenAuthMethod := "client_secret_basic"
+				c := client.OAuth2Client{
+					AllowedCorsOrigins:      []string{"mock-origin-1", "mock-origin-2"},
+					Audience:                []string{"mock-aud-1", "mock-aud-2"},
+					ClientName:              &clientName,
+					SubjectType:             &subjectType,
+					GrantTypes:              []string{},
+					TokenEndpointAuthMethod: &tokenAuthMethod,
+				}
+
+				marshal, _ := json.Marshal(c)
+				return marshal
+			},
+			expectedResult: nil,
+			expectedError:  nil,
+		},
+		{
+			name:     "NoMatch",
+			method:   http.MethodPost,
+			endpoint: "no-match-endpoint",
+			body: func() []byte {
+				return nil
+			},
+			expectedResult: nil,
+			expectedError:  validation.NoMatchError(p.apiKey),
+		},
+		{
+			name:     "CreateClientFailure",
+			method:   http.MethodPost,
+			endpoint: "",
+			body: func() []byte {
+				subjectType := "not-one-of-allowed-values"
+				tokenAuthMethod := "not-one-of-allowed-values"
+				c := client.OAuth2Client{
+					AllowedCorsOrigins:      []string{"", "mock-origin-2"},
+					Audience:                []string{"mock-aud-1", ""},
+					SubjectType:             &subjectType,
+					GrantTypes:              []string{},
+					TokenEndpointAuthMethod: &tokenAuthMethod,
+				}
+
+				marshal, _ := json.Marshal(c)
+				return marshal
+			},
+			expectedResult: validator.ValidationErrors{},
+			expectedError:  nil,
+		},
+		{
+			name:     "UpdateClientFailure",
+			method:   http.MethodPut,
+			endpoint: "/client-id",
+			body: func() []byte {
+				subjectType := "not-one-of-allowed-values"
+				tokenAuthMethod := "not-one-of-allowed-values"
+				c := client.OAuth2Client{
+					AllowedCorsOrigins:      []string{"", "mock-origin-2"},
+					Audience:                []string{"mock-aud-1", ""},
+					SubjectType:             &subjectType,
+					GrantTypes:              []string{},
+					TokenEndpointAuthMethod: &tokenAuthMethod,
+				}
+
+				marshal, _ := json.Marshal(c)
+				return marshal
+			},
+			expectedResult: validator.ValidationErrors{},
+			expectedError:  nil,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, result, err := p.Validate(context.TODO(), tt.method, tt.endpoint, tt.body())
+
+			if err != nil && err.Error() != tt.expectedError.Error() {
+				t.Fatalf("Returned error doesn't match expected, obtained '%v' instead of '%v'", err, tt.expectedError)
+			} else if result != nil && errors.Is(result, tt.expectedResult) {
+				t.Fatalf("Returned validation errors don't match expected, obtained '%v' instead of '%v'", result, tt.expectedResult)
+			} else {
+				return
+			}
+		})
+	}
+}

--- a/pkg/clients/validation_test.go
+++ b/pkg/clients/validation_test.go
@@ -202,11 +202,27 @@ func TestValidate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, result, err := p.Validate(context.TODO(), tt.method, tt.endpoint, tt.body())
 
-			if err != nil && err.Error() != tt.expectedError.Error() {
-				t.Fatalf("Returned error doesn't match expected, obtained '%v' instead of '%v'", err, tt.expectedError)
-			} else if result != nil && errors.Is(result, tt.expectedResult) {
-				t.Fatalf("Returned validation errors don't match expected, obtained '%v' instead of '%v'", result, tt.expectedResult)
-			} else {
+			if err != nil {
+				if tt.expectedError == nil {
+					t.Fatalf("Unexpected error for '%s'", tt.name)
+				}
+
+				if err.Error() != tt.expectedError.Error() {
+					t.Fatalf("Returned error doesn't match expected, obtained '%v' instead of '%v'", err, tt.expectedError)
+				}
+
+				return
+			}
+
+			if result != nil {
+				if tt.expectedResult == nil {
+					t.Fatalf("Unexpected result for '%s'", tt.name)
+				}
+
+				if errors.Is(result, tt.expectedResult) {
+					t.Fatalf("Returned validation errors don't match expected, obtained '%v' instead of '%v'", result, tt.expectedResult)
+				}
+
 				return
 			}
 		})

--- a/pkg/groups/handlers.go
+++ b/pkg/groups/handlers.go
@@ -26,6 +26,7 @@ const (
 )
 
 type UpdateRolesRequest struct {
+	// validate slice is not nil, and each item is not nil
 	Roles []string `json:"roles" validate:"required,dive,required"`
 }
 
@@ -35,6 +36,7 @@ type Permission struct {
 }
 
 type UpdatePermissionsRequest struct {
+	// validate slice is not nil, and each item is not nil
 	Permissions []Permission `json:"permissions" validate:"required,dive,required"`
 }
 

--- a/pkg/groups/handlers.go
+++ b/pkg/groups/handlers.go
@@ -79,7 +79,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator(a.apiKey, a.payloadValidator)
 	if err != nil {
-		a.logger.Fatalf("unexpected validatingFunc already registered for groups, %s", err)
+		a.logger.Fatalf("unexpected error while registering PayloadValidator for groups, %s", err)
 	}
 }
 

--- a/pkg/groups/validation.go
+++ b/pkg/groups/validation.go
@@ -19,7 +19,7 @@ type PayloadValidator struct {
 	validator *validator.Validate
 }
 
-func (_ *PayloadValidator) NeedsValidation(r *http.Request) bool {
+func (p *PayloadValidator) NeedsValidation(r *http.Request) bool {
 	return r.Method == http.MethodPost || r.Method == http.MethodPatch
 }
 

--- a/pkg/groups/validation_test.go
+++ b/pkg/groups/validation_test.go
@@ -267,11 +267,27 @@ func TestValidate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, result, err := p.Validate(context.TODO(), tt.method, tt.endpoint, tt.body())
 
-			if err != nil && err.Error() != tt.expectedError.Error() {
-				t.Fatalf("Returned error doesn't match expected, obtained '%v' instead of '%v'", err, tt.expectedError)
-			} else if result != nil && errors.Is(result, tt.expectedResult) {
-				t.Fatalf("Returned validation errors don't match expected, obtained '%v' instead of '%v'", result, tt.expectedResult)
-			} else {
+			if err != nil {
+				if tt.expectedError == nil {
+					t.Fatalf("Unexpected error for '%s'", tt.name)
+				}
+
+				if err.Error() != tt.expectedError.Error() {
+					t.Fatalf("Returned error doesn't match expected, obtained '%v' instead of '%v'", err, tt.expectedError)
+				}
+
+				return
+			}
+
+			if result != nil {
+				if tt.expectedResult == nil {
+					t.Fatalf("Unexpected result for '%s'", tt.name)
+				}
+
+				if errors.Is(result, tt.expectedResult) {
+					t.Fatalf("Returned validation errors don't match expected, obtained '%v' instead of '%v'", result, tt.expectedResult)
+				}
+
 				return
 			}
 		})

--- a/pkg/identities/handlers.go
+++ b/pkg/identities/handlers.go
@@ -49,7 +49,7 @@ func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator(a.apiKey, a.payloadValidator)
 
 	if err != nil {
-		a.logger.Fatalf("unexpected validatingFunc already registered for identities, %s", err)
+		a.logger.Fatalf("unexpected error while registering PayloadValidator for identities, %s", err)
 	}
 }
 

--- a/pkg/identities/validation.go
+++ b/pkg/identities/validation.go
@@ -19,8 +19,8 @@ var (
 		"Credentials": "required",
 	}
 
-	// mutually exclusive fields
 	credentialsRules = map[string]string{
+		// mutually exclusive fields
 		"Oidc":     "required_without=Password,excluded_with=Password",
 		"Password": "required_without=Oidc,excluded_with=Oidc",
 	}

--- a/pkg/identities/validation.go
+++ b/pkg/identities/validation.go
@@ -39,7 +39,7 @@ func (p *PayloadValidator) setupValidator() {
 	p.validator.RegisterStructValidationMapRules(credentialsRules, UpdateIdentityRequest{}.UpdateIdentityBody.Credentials)
 }
 
-func (_ *PayloadValidator) NeedsValidation(req *http.Request) bool {
+func (p *PayloadValidator) NeedsValidation(req *http.Request) bool {
 	return req.Method == http.MethodPost || req.Method == http.MethodPut
 }
 
@@ -78,11 +78,11 @@ func (p *PayloadValidator) Validate(ctx context.Context, method, endpoint string
 	return ctx, err.(validator.ValidationErrors), nil
 }
 
-func (_ *PayloadValidator) isCreateIdentity(method, endpoint string) bool {
+func (p *PayloadValidator) isCreateIdentity(method, endpoint string) bool {
 	return endpoint == "" && method == http.MethodPost
 }
 
-func (_ *PayloadValidator) isUpdateIdentity(method, endpoint string) bool {
+func (p *PayloadValidator) isUpdateIdentity(method, endpoint string) bool {
 	return strings.HasPrefix(endpoint, "/") && method == http.MethodPut
 }
 

--- a/pkg/identities/validation_test.go
+++ b/pkg/identities/validation_test.go
@@ -206,11 +206,27 @@ func TestValidate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, result, err := p.Validate(context.TODO(), tt.method, tt.endpoint, tt.body())
 
-			if err != nil && err.Error() != tt.expectedError.Error() {
-				t.Fatalf("Returned error doesn't match expected, obtained '%v' instead of '%v'", err, tt.expectedError)
-			} else if result != nil && errors.Is(result, tt.expectedResult) {
-				t.Fatalf("Returned validation errors don't match expected, obtained '%v' instead of '%v'", result, tt.expectedResult)
-			} else {
+			if err != nil {
+				if tt.expectedError == nil {
+					t.Fatalf("Unexpected error for '%s'", tt.name)
+				}
+
+				if err.Error() != tt.expectedError.Error() {
+					t.Fatalf("Returned error doesn't match expected, obtained '%v' instead of '%v'", err, tt.expectedError)
+				}
+
+				return
+			}
+
+			if result != nil {
+				if tt.expectedResult == nil {
+					t.Fatalf("Unexpected result for '%s'", tt.name)
+				}
+
+				if errors.Is(result, tt.expectedResult) {
+					t.Fatalf("Returned validation errors don't match expected, obtained '%v' instead of '%v'", result, tt.expectedResult)
+				}
+
 				return
 			}
 		})

--- a/pkg/idp/handlers.go
+++ b/pkg/idp/handlers.go
@@ -256,7 +256,7 @@ func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
 	a := new(API)
 	a.apiKey = "idps"
 
-	//a.payloadValidator = NewIdPPayloadValidator(a.apiKey)
+	a.payloadValidator = NewIdPPayloadValidator(a.apiKey)
 	a.service = service
 	a.logger = logger
 

--- a/pkg/idp/handlers.go
+++ b/pkg/idp/handlers.go
@@ -36,7 +36,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator(a.apiKey, a.payloadValidator)
 	if err != nil {
-		a.logger.Fatalf("unexpected validatingFunc already registered for idps, %s", err)
+		a.logger.Fatalf("unexpected error while registering PayloadValidator for idps, %s", err)
 	}
 }
 

--- a/pkg/idp/third_party.go
+++ b/pkg/idp/third_party.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd
+// Copyright 2024 Canonical Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 
 package idp
@@ -31,7 +31,7 @@ type Configuration struct {
 	// - dingtalk
 	// - linkedin
 	// - patreon
-	Provider string `json:"provider" yaml:"provider"`
+	Provider string `json:"provider" yaml:"provider" validate:"required,supported_provider"`
 
 	// Label represents an optional label which can be used in the UI generation.
 	Label string `json:"label"`
@@ -44,52 +44,52 @@ type Configuration struct {
 
 	// IssuerURL is the OpenID Connect Server URL. You can leave this empty if `provider` is not set to `generic`.
 	// If set, neither `auth_url` nor `token_url` are required.
-	IssuerURL string `json:"issuer_url" yaml:"issuer_url"`
+	IssuerURL string `json:"issuer_url" yaml:"issuer_url" validate:"required_if=Provider generic"`
 
 	// AuthURL is the authorize url, typically something like: https://example.org/oauth2/auth
 	// Should only be used when the OAuth2 / OpenID Connect server is not supporting OpenID Connect Discovery and when
 	// `provider` is set to `generic`.
-	AuthURL string `json:"auth_url" yaml:"auth_url"`
+	AuthURL string `json:"auth_url" yaml:"auth_url" validate:"required_if=Provider generic"`
 
 	// TokenURL is the token url, typically something like: https://example.org/oauth2/token
 	// Should only be used when the OAuth2 / OpenID Connect server is not supporting OpenID Connect Discovery and when
 	// `provider` is set to `generic`.
-	TokenURL string `json:"token_url" yaml:"token_url"`
+	TokenURL string `json:"token_url" yaml:"token_url" validate:"required_if=Provider generic"`
 
 	// Tenant is the Azure AD Tenant to use for authentication, and must be set when `provider` is set to `microsoft`.
 	// Can be either `common`, `organizations`, `consumers` for a multitenant application or a specific tenant like
 	// `8eaef023-2b34-4da1-9baa-8bc8c9d6a490` or `contoso.onmicrosoft.com`.
-	Tenant string `json:"microsoft_tenant" yaml:"microsoft_tenant"`
+	Tenant string `json:"microsoft_tenant" yaml:"microsoft_tenant" validate:"required_if=Provider microsoft"`
 
 	// SubjectSource is a flag which controls from which endpoint the subject identifier is taken by microsoft provider.
 	// Can be either `userinfo` or `me`.
 	// If the value is `userinfo` then the subject identifier is taken from sub field of userinfo standard endpoint response.
 	// If the value is `me` then the `id` field of https://graph.microsoft.com/v1.0/me response is taken as subject.
 	// The default is `userinfo`.
-	SubjectSource string `json:"subject_source" yaml:"subject_source"`
+	SubjectSource string `json:"subject_source" yaml:"subject_source" validate:"oneof=userinfo me"`
 
 	// TeamId is the Apple Developer Team ID that's needed for the `apple` `provider` to work.
 	// It can be found Apple Developer website and combined with `apple_private_key` and `apple_private_key_id`
 	// is used to generate `client_secret`
-	TeamId string `json:"apple_team_id" yaml:"apple_team_id"`
+	TeamId string `json:"apple_team_id" yaml:"apple_team_id" validate:"required_if=Provider apple"`
 
 	// PrivateKeyId is the private Apple key identifier. Keys can be generated via developer.apple.com.
 	// This key should be generated with the `Sign In with Apple` option checked.
 	// This is needed when `provider` is set to `apple`
-	PrivateKeyId string `json:"apple_private_key_id" yaml:"apple_private_key_id"`
+	PrivateKeyId string `json:"apple_private_key_id" yaml:"apple_private_key_id" validate:"required_if=Provider apple"`
 
 	// PrivateKeyId is the Apple private key identifier that can be downloaded during key generation.
 	// This is needed when `provider` is set to `apple`
-	PrivateKey string `json:"apple_private_key" yaml:"apple_private_key"`
+	PrivateKey string `json:"apple_private_key" yaml:"apple_private_key" validate:"required_if=Provider apple"`
 
 	// Scope specifies optional requested permissions.
-	Scope []string `json:"scope" yaml:"scope"`
+	Scope []string `json:"scope" yaml:"scope" validate:"omitempty,dive,required"`
 
 	// Mapper specifies the JSONNet code snippet which uses the OpenID Connect Provider's data (e.g. GitHub or Google
 	// profile information) to hydrate the identity's data.
 	//
 	// It can be either a URL (file://, http(s)://, base64://) or an inline JSONNet code snippet.
-	Mapper string `json:"mapper_url" yaml:"mapper_url"`
+	Mapper string `json:"mapper_url" yaml:"mapper_url" validate:"required"`
 
 	// RequestedClaims string encoded json object that specifies claims and optionally their properties which should be
 	// included in the id_token or returned from the UserInfo Endpoint.

--- a/pkg/idp/third_party.go
+++ b/pkg/idp/third_party.go
@@ -31,6 +31,7 @@ type Configuration struct {
 	// - dingtalk
 	// - linkedin
 	// - patreon
+	// validate that Provider is not nil and not empty string, and its value is one of the supported ones
 	Provider string `json:"provider" yaml:"provider" validate:"required,supported_provider"`
 
 	// Label represents an optional label which can be used in the UI generation.
@@ -44,21 +45,25 @@ type Configuration struct {
 
 	// IssuerURL is the OpenID Connect Server URL. You can leave this empty if `provider` is not set to `generic`.
 	// If set, neither `auth_url` nor `token_url` are required.
+	// validate that this field is required only when Provider field == "generic"
 	IssuerURL string `json:"issuer_url" yaml:"issuer_url" validate:"required_if=Provider generic"`
 
 	// AuthURL is the authorize url, typically something like: https://example.org/oauth2/auth
 	// Should only be used when the OAuth2 / OpenID Connect server is not supporting OpenID Connect Discovery and when
 	// `provider` is set to `generic`.
+	// validate that this field is required only when Provider field == "generic"
 	AuthURL string `json:"auth_url" yaml:"auth_url" validate:"required_if=Provider generic"`
 
 	// TokenURL is the token url, typically something like: https://example.org/oauth2/token
 	// Should only be used when the OAuth2 / OpenID Connect server is not supporting OpenID Connect Discovery and when
 	// `provider` is set to `generic`.
+	// validate that this field is required only when Provider field == "generic"
 	TokenURL string `json:"token_url" yaml:"token_url" validate:"required_if=Provider generic"`
 
 	// Tenant is the Azure AD Tenant to use for authentication, and must be set when `provider` is set to `microsoft`.
 	// Can be either `common`, `organizations`, `consumers` for a multitenant application or a specific tenant like
 	// `8eaef023-2b34-4da1-9baa-8bc8c9d6a490` or `contoso.onmicrosoft.com`.
+	// validate that this field is required only when Provider field == "microsoft"
 	Tenant string `json:"microsoft_tenant" yaml:"microsoft_tenant" validate:"required_if=Provider microsoft"`
 
 	// SubjectSource is a flag which controls from which endpoint the subject identifier is taken by microsoft provider.
@@ -66,23 +71,28 @@ type Configuration struct {
 	// If the value is `userinfo` then the subject identifier is taken from sub field of userinfo standard endpoint response.
 	// If the value is `me` then the `id` field of https://graph.microsoft.com/v1.0/me response is taken as subject.
 	// The default is `userinfo`.
+	// validate that SubjectSource is either "userinfo" or "me"
 	SubjectSource string `json:"subject_source" yaml:"subject_source" validate:"oneof=userinfo me"`
 
 	// TeamId is the Apple Developer Team ID that's needed for the `apple` `provider` to work.
 	// It can be found Apple Developer website and combined with `apple_private_key` and `apple_private_key_id`
 	// is used to generate `client_secret`
+	// validate that this field is required only when Provider field == "apple"
 	TeamId string `json:"apple_team_id" yaml:"apple_team_id" validate:"required_if=Provider apple"`
 
 	// PrivateKeyId is the private Apple key identifier. Keys can be generated via developer.apple.com.
 	// This key should be generated with the `Sign In with Apple` option checked.
 	// This is needed when `provider` is set to `apple`
+	// validate that this field is required only when Provider field == "apple"
 	PrivateKeyId string `json:"apple_private_key_id" yaml:"apple_private_key_id" validate:"required_if=Provider apple"`
 
 	// PrivateKeyId is the Apple private key identifier that can be downloaded during key generation.
 	// This is needed when `provider` is set to `apple`
+	// validate that this field is required only when Provider field == "apple"
 	PrivateKey string `json:"apple_private_key" yaml:"apple_private_key" validate:"required_if=Provider apple"`
 
 	// Scope specifies optional requested permissions.
+	// validate that Scope is either nil or a slice with non-empty strings
 	Scope []string `json:"scope" yaml:"scope" validate:"omitempty,dive,required"`
 
 	// Mapper specifies the JSONNet code snippet which uses the OpenID Connect Provider's data (e.g. GitHub or Google

--- a/pkg/idp/validation.go
+++ b/pkg/idp/validation.go
@@ -1,0 +1,71 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package idp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/validation"
+)
+
+type PayloadValidator struct {
+	apiKey    string
+	validator *validator.Validate
+}
+
+func (p *PayloadValidator) setupValidator() {
+	p.validator.RegisterAlias("supported_provider", "oneof=generic google github githubapp gitlab microsoft discord slack facebook auth0 vk yandex apple spotify netid dingtalk linkedin patreon")
+}
+
+func (p *PayloadValidator) NeedsValidation(r *http.Request) bool {
+	return r.Method == http.MethodPost || r.Method == http.MethodPatch
+}
+
+func (p *PayloadValidator) Validate(ctx context.Context, method, endpoint string, body []byte) (context.Context, validator.ValidationErrors, error) {
+	validated := false
+	var err error
+
+	if p.isCreateIdP(method, endpoint) || p.isPartialUpdateIdP(method, endpoint) {
+		conf := new(Configuration)
+		if err := json.Unmarshal(body, conf); err != nil {
+			return ctx, nil, err
+		}
+
+		err = p.validator.Struct(conf)
+		validated = true
+	}
+
+	if !validated {
+		return ctx, nil, validation.NoMatchError(p.apiKey)
+	}
+
+	if err == nil {
+		return ctx, nil, nil
+	}
+
+	return ctx, err.(validator.ValidationErrors), nil
+}
+
+func (p *PayloadValidator) isCreateIdP(method, endpoint string) bool {
+	return method == http.MethodPost && endpoint == ""
+}
+
+func (p *PayloadValidator) isPartialUpdateIdP(method, endpoint string) bool {
+	return method == http.MethodPatch && strings.HasPrefix(endpoint, "/")
+}
+
+func NewIdPPayloadValidator(apiKey string) *PayloadValidator {
+	p := new(PayloadValidator)
+	p.apiKey = apiKey
+	p.validator = validation.NewValidator()
+
+	p.setupValidator()
+
+	return p
+}

--- a/pkg/idp/validation.go
+++ b/pkg/idp/validation.go
@@ -20,6 +20,7 @@ type PayloadValidator struct {
 }
 
 func (p *PayloadValidator) setupValidator() {
+	// validate Provider to be one of the supported ones
 	p.validator.RegisterAlias("supported_provider", "oneof=generic google github githubapp gitlab microsoft discord slack facebook auth0 vk yandex apple spotify netid dingtalk linkedin patreon")
 }
 

--- a/pkg/idp/validation_test.go
+++ b/pkg/idp/validation_test.go
@@ -1,0 +1,213 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package idp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/validation"
+)
+
+func TestNeedsValidation(t *testing.T) {
+	p := new(PayloadValidator)
+	p.validator = validation.NewValidator()
+
+	for _, tt := range []struct {
+		name           string
+		req            *http.Request
+		expectedResult bool
+	}{
+		{
+			name:           http.MethodPost,
+			req:            httptest.NewRequest(http.MethodPost, "/", nil),
+			expectedResult: true,
+		},
+		{
+			name:           http.MethodPatch,
+			req:            httptest.NewRequest(http.MethodPatch, "/", nil),
+			expectedResult: true,
+		},
+		{
+			name:           http.MethodPut,
+			req:            httptest.NewRequest(http.MethodPut, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodGet,
+			req:            httptest.NewRequest(http.MethodGet, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodDelete,
+			req:            httptest.NewRequest(http.MethodDelete, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodConnect,
+			req:            httptest.NewRequest(http.MethodConnect, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodHead,
+			req:            httptest.NewRequest(http.MethodHead, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodTrace,
+			req:            httptest.NewRequest(http.MethodTrace, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodOptions,
+			req:            httptest.NewRequest(http.MethodOptions, "/", nil),
+			expectedResult: false,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.NeedsValidation(tt.req)
+
+			if result != tt.expectedResult {
+				t.Fatalf("Result doesn't match expected one, obtained %t instead of %t", result, tt.expectedResult)
+			}
+		})
+	}
+
+}
+
+func TestValidate(t *testing.T) {
+	p := new(PayloadValidator)
+	p.apiKey = "roles"
+	p.validator = validation.NewValidator()
+
+	p.setupValidator()
+
+	for _, tt := range []struct {
+		name           string
+		method         string
+		endpoint       string
+		body           func() []byte
+		expectedResult validator.ValidationErrors
+		expectedError  error
+	}{
+		{
+			name:     "CreateIdPSuccess",
+			method:   http.MethodPost,
+			endpoint: "",
+			body: func() []byte {
+				conf := new(Configuration)
+				conf.Provider = "generic"
+				conf.IssuerURL = "mock-url"
+				conf.AuthURL = "mock-url"
+				conf.TokenURL = "mock-url"
+				conf.SubjectSource = "me"
+				conf.Scope = []string{}
+				conf.Mapper = "mock-url"
+
+				marshal, _ := json.Marshal(conf)
+				return marshal
+			},
+			expectedResult: nil,
+			expectedError:  nil,
+		},
+		{
+			name:     "PartialUpdateIdPSuccess",
+			method:   http.MethodPatch,
+			endpoint: "/",
+			body: func() []byte {
+				conf := new(Configuration)
+				conf.Provider = "microsoft"
+				conf.Tenant = "mock-tenant"
+				conf.SubjectSource = "me"
+				conf.Scope = []string{"profile"}
+				conf.Mapper = "mock-url"
+
+				marshal, _ := json.Marshal(conf)
+				return marshal
+			},
+			expectedResult: nil,
+			expectedError:  nil,
+		},
+		{
+			name:     "NoMatch",
+			method:   http.MethodPost,
+			endpoint: "no-match-endpoint",
+			body: func() []byte {
+				return nil
+			},
+			expectedResult: nil,
+			expectedError:  validation.NoMatchError(p.apiKey),
+		},
+		{
+			name:     "CreateIdPValidationError",
+			method:   http.MethodPost,
+			endpoint: "",
+			body: func() []byte {
+				conf := new(Configuration)
+				conf.Provider = "microsoft"
+				conf.SubjectSource = "me"
+				conf.Scope = []string{"profile"}
+				conf.Mapper = "mock-url"
+
+				marshal, _ := json.Marshal(conf)
+				return marshal
+			},
+			expectedResult: validator.ValidationErrors{},
+			expectedError:  nil,
+		},
+		{
+			name:     "PartialUpdateIdPValidationError",
+			method:   http.MethodPatch,
+			endpoint: "/identity-id",
+			body: func() []byte {
+				conf := new(Configuration)
+				conf.Provider = "apple"
+				conf.SubjectSource = "me"
+				conf.Scope = []string{""}
+				conf.Mapper = "mock-url"
+
+				marshal, _ := json.Marshal(conf)
+				return marshal
+			},
+			expectedResult: validator.ValidationErrors{},
+			expectedError:  nil,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, result, err := p.Validate(context.TODO(), tt.method, tt.endpoint, tt.body())
+
+			if err != nil {
+				if tt.expectedError == nil {
+					t.Fatalf("Unexpected error for '%s'", tt.name)
+				}
+
+				if err.Error() != tt.expectedError.Error() {
+					t.Fatalf("Returned error doesn't match expected, obtained '%v' instead of '%v'", err, tt.expectedError)
+				}
+
+				return
+			}
+
+			if result != nil {
+				if tt.expectedResult == nil {
+					t.Fatalf("Unexpected result for '%s'", tt.name)
+				}
+
+				if errors.Is(result, tt.expectedResult) {
+					t.Fatalf("Returned validation errors don't match expected, obtained '%v' instead of '%v'", result, tt.expectedResult)
+				}
+
+				return
+			}
+		})
+	}
+}

--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -30,7 +30,7 @@ type Permission struct {
 }
 
 type UpdatePermissionsRequest struct {
-	Permissions []Permission `json:"permissions" validate:"required"`
+	Permissions []Permission `json:"permissions" validate:"required,dive,required"`
 }
 
 type RoleRequest struct {
@@ -467,7 +467,7 @@ func NewAPI(service ServiceInterface, tracer tracing.TracingInterface, monitor m
 	a := new(API)
 
 	a.service = service
-	//a.payloadValidator = NewRolesPayloadValidator(a.apiKey)
+	a.payloadValidator = NewRolesPayloadValidator(a.apiKey)
 	a.logger = logger
 	a.tracer = tracer
 	a.monitor = monitor

--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -64,7 +64,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator("roles", a.payloadValidator)
 	if err != nil {
-		a.logger.Fatalf("unexpected validatingFunc already registered for roles, %s", err)
+		a.logger.Fatalf("unexpected error while registering PayloadValidator for roles, %s", err)
 	}
 }
 

--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -30,6 +30,7 @@ type Permission struct {
 }
 
 type UpdatePermissionsRequest struct {
+	// validate slice is not nil, and each item is not nil
 	Permissions []Permission `json:"permissions" validate:"required,dive,required"`
 }
 

--- a/pkg/roles/handlers_test.go
+++ b/pkg/roles/handlers_test.go
@@ -29,6 +29,7 @@ import (
 //go:generate mockgen -build_flags=--mod=mod -package roles -destination ./mock_interfaces.go -source=./interfaces.go
 //go:generate mockgen -build_flags=--mod=mod -package roles -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
 //go:generate mockgen -build_flags=--mod=mod -package roles -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+//go:generate mockgen -build_flags=--mod=mod -package roles -destination ./mock_validation.go -source=../../internal/validation/registry.go
 
 // + http :8000/api/v0/roles X-Authorization:c2hpcHBlcml6ZXI=
 // HTTP/1.1 200 OK
@@ -1326,4 +1327,31 @@ func TestHandleCreateBadRoleFormat(t *testing.T) {
 
 		})
 	}
+}
+
+func TestRegisterValidation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
+	mockService := NewMockServiceInterface(ctrl)
+	mockValidationRegistry := NewMockValidationRegistryInterface(ctrl)
+
+	apiKey := "roles"
+	mockValidationRegistry.EXPECT().
+		RegisterPayloadValidator(gomock.Eq(apiKey), gomock.Any()).
+		Return(nil)
+	mockValidationRegistry.EXPECT().
+		RegisterPayloadValidator(gomock.Eq(apiKey), gomock.Any()).
+		Return(fmt.Errorf("key is already registered"))
+
+	// first registration of `apiKey` is successful
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)
+
+	mockLogger.EXPECT().Fatalf(gomock.Any(), gomock.Any()).Times(1)
+
+	// second registration of `apiKey` causes logger.Fatal invocation
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)
 }

--- a/pkg/roles/validation.go
+++ b/pkg/roles/validation.go
@@ -1,0 +1,84 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package roles
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/validation"
+)
+
+type PayloadValidator struct {
+	apiKey    string
+	validator *validator.Validate
+}
+
+func (p *PayloadValidator) NeedsValidation(r *http.Request) bool {
+	return r.Method == http.MethodPost || r.Method == http.MethodPatch
+}
+
+func (p *PayloadValidator) Validate(ctx context.Context, method, endpoint string, body []byte) (context.Context, validator.ValidationErrors, error) {
+	validated := false
+	var err error
+
+	if p.isCreateRole(method, endpoint) {
+		roleRequest := new(RoleRequest)
+		if err := json.Unmarshal(body, roleRequest); err != nil {
+			return ctx, nil, err
+		}
+
+		err = p.validator.Struct(roleRequest)
+		validated = true
+	}
+
+	if p.isUpdateRole(method, endpoint) {
+		// TODO: @barco to implement when the UpdateGroup is implemented
+		validated = true
+	}
+
+	if p.isAssignPermissions(method, endpoint) {
+		updatePermissions := new(UpdatePermissionsRequest)
+		if err := json.Unmarshal(body, updatePermissions); err != nil {
+			return ctx, nil, err
+		}
+
+		err = p.validator.Struct(updatePermissions)
+		validated = true
+	}
+
+	if !validated {
+		return ctx, nil, validation.NoMatchError(p.apiKey)
+	}
+
+	if err == nil {
+		return ctx, nil, nil
+	}
+
+	return ctx, err.(validator.ValidationErrors), nil
+}
+
+func (p *PayloadValidator) isCreateRole(method, endpoint string) bool {
+	return method == http.MethodPost && endpoint == ""
+}
+
+func (p *PayloadValidator) isUpdateRole(method, endpoint string) bool {
+	return method == http.MethodPatch && strings.HasPrefix(endpoint, "/")
+}
+
+func (p *PayloadValidator) isAssignPermissions(method, endpoint string) bool {
+	return method == http.MethodPatch && strings.HasSuffix(endpoint, "/entitlements")
+}
+
+func NewRolesPayloadValidator(apiKey string) *PayloadValidator {
+	p := new(PayloadValidator)
+	p.apiKey = apiKey
+	p.validator = validation.NewValidator()
+
+	return p
+}

--- a/pkg/roles/validation_test.go
+++ b/pkg/roles/validation_test.go
@@ -1,0 +1,245 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package roles
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/validation"
+)
+
+func TestNeedsValidation(t *testing.T) {
+	p := new(PayloadValidator)
+	p.validator = validation.NewValidator()
+
+	for _, tt := range []struct {
+		name           string
+		req            *http.Request
+		expectedResult bool
+	}{
+		{
+			name:           http.MethodPost,
+			req:            httptest.NewRequest(http.MethodPost, "/", nil),
+			expectedResult: true,
+		},
+		{
+			name:           http.MethodPatch,
+			req:            httptest.NewRequest(http.MethodPatch, "/", nil),
+			expectedResult: true,
+		},
+		{
+			name:           http.MethodPut,
+			req:            httptest.NewRequest(http.MethodPut, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodGet,
+			req:            httptest.NewRequest(http.MethodGet, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodDelete,
+			req:            httptest.NewRequest(http.MethodDelete, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodConnect,
+			req:            httptest.NewRequest(http.MethodConnect, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodHead,
+			req:            httptest.NewRequest(http.MethodHead, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodTrace,
+			req:            httptest.NewRequest(http.MethodTrace, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodOptions,
+			req:            httptest.NewRequest(http.MethodOptions, "/", nil),
+			expectedResult: false,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.NeedsValidation(tt.req)
+
+			if result != tt.expectedResult {
+				t.Fatalf("Result doesn't match expected one, obtained %t instead of %t", result, tt.expectedResult)
+			}
+		})
+	}
+
+}
+
+func TestValidate(t *testing.T) {
+	p := new(PayloadValidator)
+	p.apiKey = "roles"
+	p.validator = validation.NewValidator()
+
+	for _, tt := range []struct {
+		name           string
+		method         string
+		endpoint       string
+		body           func() []byte
+		expectedResult validator.ValidationErrors
+		expectedError  error
+	}{
+		{
+			name:     "CreateRoleSuccess",
+			method:   http.MethodPost,
+			endpoint: "",
+			body: func() []byte {
+				role := new(RoleRequest)
+				role.ID = "mock-role-id"
+
+				marshal, _ := json.Marshal(role)
+				return marshal
+			},
+			expectedResult: nil,
+			expectedError:  nil,
+		},
+		{
+			name:     "UpdateRoleSuccess",
+			method:   http.MethodPatch,
+			endpoint: "/",
+			body: func() []byte {
+				role := new(RoleRequest)
+				role.ID = "mock-role-id"
+
+				marshal, _ := json.Marshal(role)
+				return marshal
+			},
+			expectedResult: nil,
+			expectedError:  nil,
+		},
+		{
+			name:     "AssignPermissionsSuccess",
+			method:   http.MethodPatch,
+			endpoint: "/",
+			body: func() []byte {
+				permissionsRequest := new(UpdatePermissionsRequest)
+				permissionsRequest.Permissions = []Permission{
+					{
+						Relation: "mock-relation",
+						Object:   "mock-object",
+					},
+				}
+
+				marshal, _ := json.Marshal(permissionsRequest)
+				return marshal
+			},
+			expectedResult: nil,
+			expectedError:  nil,
+		},
+		{
+			name:     "AssignPermissionsEmptySuccess",
+			method:   http.MethodPatch,
+			endpoint: "/",
+			body: func() []byte {
+				permissionsRequest := new(UpdatePermissionsRequest)
+				permissionsRequest.Permissions = []Permission{}
+
+				marshal, _ := json.Marshal(permissionsRequest)
+				return marshal
+			},
+			expectedResult: nil,
+			expectedError:  nil,
+		},
+		{
+			name:     "NoMatch",
+			method:   http.MethodPost,
+			endpoint: "no-match-endpoint",
+			body: func() []byte {
+				return nil
+			},
+			expectedResult: nil,
+			expectedError:  validation.NoMatchError(p.apiKey),
+		},
+		{
+			name:     "CreateRoleValidationError",
+			method:   http.MethodPost,
+			endpoint: "",
+			body: func() []byte {
+				role := new(RoleRequest)
+
+				marshal, _ := json.Marshal(role)
+				return marshal
+			},
+			expectedResult: validator.ValidationErrors{},
+			expectedError:  nil,
+		},
+		{
+			name:     "UpdateRoleValidationError",
+			method:   http.MethodPatch,
+			endpoint: "/identity-id",
+			body: func() []byte {
+				role := new(RoleRequest)
+
+				marshal, _ := json.Marshal(role)
+				return marshal
+			},
+			expectedResult: validator.ValidationErrors{},
+			expectedError:  nil,
+		},
+		{
+			name:     "AssignPermissionsValidationError",
+			method:   http.MethodPatch,
+			endpoint: "/identity-id",
+			body: func() []byte {
+				permissionsRequest := new(UpdatePermissionsRequest)
+				permissionsRequest.Permissions = []Permission{
+					{
+						Relation: "mock-relation",
+						Object:   "",
+					},
+				}
+
+				marshal, _ := json.Marshal(permissionsRequest)
+				return marshal
+			},
+			expectedResult: validator.ValidationErrors{},
+			expectedError:  nil,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, result, err := p.Validate(context.TODO(), tt.method, tt.endpoint, tt.body())
+
+			if err != nil {
+				if tt.expectedError == nil {
+					t.Fatalf("Unexpected error for '%s'", tt.name)
+				}
+
+				if err.Error() != tt.expectedError.Error() {
+					t.Fatalf("Returned error doesn't match expected, obtained '%v' instead of '%v'", err, tt.expectedError)
+				}
+
+				return
+			}
+
+			if result != nil {
+				if tt.expectedResult == nil {
+					t.Fatalf("Unexpected result for '%s'", tt.name)
+				}
+
+				if errors.Is(result, tt.expectedResult) {
+					t.Fatalf("Returned validation errors don't match expected, obtained '%v' instead of '%v'", result, tt.expectedResult)
+				}
+
+				return
+			}
+		})
+	}
+}

--- a/pkg/rules/handlers.go
+++ b/pkg/rules/handlers.go
@@ -250,7 +250,7 @@ func (a *API) handleRemove(w http.ResponseWriter, r *http.Request) {
 func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
 	a := new(API)
 	a.apiKey = "rules"
-
+	a.payloadValidator = NewRulesPayloadValidator(a.apiKey)
 	a.service = service
 	a.logger = logger
 

--- a/pkg/rules/handlers.go
+++ b/pkg/rules/handlers.go
@@ -36,7 +36,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator(a.apiKey, a.payloadValidator)
 	if err != nil {
-		a.logger.Fatalf("unexpected validatingFunc already registered for rules, %s", err)
+		a.logger.Fatalf("unexpected error while registering PayloadValidator for rules, %s", err)
 	}
 }
 

--- a/pkg/rules/validation.go
+++ b/pkg/rules/validation.go
@@ -1,0 +1,92 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package rules
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+	oathkeeper "github.com/ory/oathkeeper-client-go"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/validation"
+)
+
+var (
+	ruleRules = map[string]string{
+		"Authenticators": "required,min=1,dive,required",
+		"Authorizer":     "required",
+		"Match":          "required",
+		"Mutators":       "omitempty,dive,required",
+		"Upstream":       "omitempty,required",
+	}
+
+	ruleMatchRules = map[string]string{
+		"Methods": "required,min=1,dive,httpmethod",
+		"Url":     "required",
+	}
+
+	ruleHandlerRules = map[string]string{
+		"Handler": "required",
+	}
+)
+
+type PayloadValidator struct {
+	apiKey    string
+	validator *validator.Validate
+}
+
+func (p *PayloadValidator) setupValidator() {
+	p.validator.RegisterAlias("httpmethod", "oneof=GET HEAD POST PUT PATCH DELETE CONNECT OPTIONS TRACE")
+
+	p.validator.RegisterStructValidationMapRules(ruleRules, oathkeeper.Rule{})
+	p.validator.RegisterStructValidationMapRules(ruleMatchRules, oathkeeper.RuleMatch{})
+	p.validator.RegisterStructValidationMapRules(ruleHandlerRules, oathkeeper.RuleHandler{})
+}
+
+func (p *PayloadValidator) NeedsValidation(req *http.Request) bool {
+	return req.Method == http.MethodPost || req.Method == http.MethodPut
+}
+
+func (p *PayloadValidator) Validate(ctx context.Context, method, endpoint string, body []byte) (context.Context, validator.ValidationErrors, error) {
+	validated := false
+	var err error
+
+	if p.isCreateOrUpdateRule(method, endpoint) {
+		ruleRequest := new(oathkeeper.Rule)
+		if err := json.Unmarshal(body, ruleRequest); err != nil {
+			return ctx, nil, err
+		}
+
+		err = p.validator.Struct(ruleRequest)
+		validated = true
+
+	}
+
+	if !validated {
+		return ctx, nil, validation.NoMatchError(p.apiKey)
+	}
+
+	if err == nil {
+		return ctx, nil, nil
+	}
+
+	return ctx, err.(validator.ValidationErrors), nil
+}
+
+func (p *PayloadValidator) isCreateOrUpdateRule(method string, endpoint string) bool {
+	return (method == http.MethodPost && endpoint == "") || (method == http.MethodPut && strings.HasPrefix(endpoint, "/"))
+}
+
+func NewRulesPayloadValidator(apiKey string) *PayloadValidator {
+	p := new(PayloadValidator)
+	p.apiKey = apiKey
+	p.validator = validation.NewValidator()
+
+	p.setupValidator()
+
+	return p
+}

--- a/pkg/rules/validation.go
+++ b/pkg/rules/validation.go
@@ -17,14 +17,17 @@ import (
 
 var (
 	ruleRules = map[string]string{
+		// validate slice is not empty
 		"Authenticators": "required,min=1,dive,required",
 		"Authorizer":     "required",
 		"Match":          "required",
-		"Mutators":       "omitempty,dive,required",
-		"Upstream":       "omitempty,required",
+		// if not empy, validate every item is not nil and not empty
+		"Mutators": "omitempty,dive,required",
+		"Upstream": "omitempty,required",
 	}
 
 	ruleMatchRules = map[string]string{
+		// validate slice is not empty, and each item is a valid uppercase http method
 		"Methods": "required,min=1,dive,httpmethod",
 		"Url":     "required",
 	}

--- a/pkg/rules/validation_test.go
+++ b/pkg/rules/validation_test.go
@@ -1,0 +1,249 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package rules
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	oathkeeper "github.com/ory/oathkeeper-client-go"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/validation"
+)
+
+func TestNeedsValidation(t *testing.T) {
+	p := new(PayloadValidator)
+	p.validator = validation.NewValidator()
+	p.setupValidator()
+
+	for _, tt := range []struct {
+		name           string
+		req            *http.Request
+		expectedResult bool
+	}{
+		{
+			name:           http.MethodPost,
+			req:            httptest.NewRequest(http.MethodPost, "/", nil),
+			expectedResult: true,
+		},
+		{
+			name:           http.MethodPut,
+			req:            httptest.NewRequest(http.MethodPut, "/", nil),
+			expectedResult: true,
+		},
+		{
+			name:           http.MethodGet,
+			req:            httptest.NewRequest(http.MethodGet, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodPatch,
+			req:            httptest.NewRequest(http.MethodPatch, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodDelete,
+			req:            httptest.NewRequest(http.MethodDelete, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodConnect,
+			req:            httptest.NewRequest(http.MethodConnect, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodHead,
+			req:            httptest.NewRequest(http.MethodHead, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodTrace,
+			req:            httptest.NewRequest(http.MethodTrace, "/", nil),
+			expectedResult: false,
+		},
+		{
+			name:           http.MethodOptions,
+			req:            httptest.NewRequest(http.MethodOptions, "/", nil),
+			expectedResult: false,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.NeedsValidation(tt.req)
+
+			if result != tt.expectedResult {
+				t.Fatalf("Result doesn't match expected one, obtained %t instead of %t", result, tt.expectedResult)
+			}
+		})
+	}
+
+}
+
+func TestValidate(t *testing.T) {
+	p := new(PayloadValidator)
+	p.apiKey = "rules"
+	p.validator = validation.NewValidator()
+	p.setupValidator()
+
+	mockHandlerIdentifier := "mock-handler"
+	mockUrl := "mock-url-with-oathkeeper-rules"
+
+	for _, tt := range []struct {
+		name           string
+		method         string
+		endpoint       string
+		body           func() []byte
+		expectedResult validator.ValidationErrors
+		expectedError  error
+	}{
+		{
+			name:     "CreateRuleSuccess",
+			method:   http.MethodPost,
+			endpoint: "",
+			body: func() []byte {
+				rule := new(oathkeeper.Rule)
+				rule.Authorizer = &oathkeeper.RuleHandler{
+					Handler: &mockHandlerIdentifier,
+				}
+				rule.Authenticators = []oathkeeper.RuleHandler{
+					{
+						Handler: &mockHandlerIdentifier,
+					},
+				}
+
+				rule.Match = &oathkeeper.RuleMatch{
+					Methods: []string{"GET", "POST"},
+					Url:     &mockUrl,
+				}
+
+				marshal, _ := json.Marshal(rule)
+				return marshal
+			},
+			expectedResult: nil,
+			expectedError:  nil,
+		},
+		{
+			name:     "UpdateRuleSuccess",
+			method:   http.MethodPut,
+			endpoint: "/",
+			body: func() []byte {
+				rule := new(oathkeeper.Rule)
+				rule.Authorizer = &oathkeeper.RuleHandler{
+					Handler: &mockHandlerIdentifier,
+				}
+				rule.Authenticators = []oathkeeper.RuleHandler{
+					{
+						Handler: &mockHandlerIdentifier,
+					},
+				}
+
+				rule.Match = &oathkeeper.RuleMatch{
+					Methods: []string{"GET", "POST"},
+					Url:     &mockUrl,
+				}
+
+				marshal, _ := json.Marshal(rule)
+				return marshal
+			},
+			expectedResult: nil,
+			expectedError:  nil,
+		},
+		{
+			name:     "NoMatch",
+			method:   http.MethodPost,
+			endpoint: "no-match-endpoint",
+			body: func() []byte {
+				return nil
+			},
+			expectedResult: nil,
+			expectedError:  validation.NoMatchError(p.apiKey),
+		},
+		{
+			name:     "CreateRuleValidationError",
+			method:   http.MethodPost,
+			endpoint: "",
+			body: func() []byte {
+				rule := new(oathkeeper.Rule)
+				rule.Authorizer = &oathkeeper.RuleHandler{
+					Handler: &mockHandlerIdentifier,
+				}
+				rule.Authenticators = []oathkeeper.RuleHandler{
+					{
+						Handler: &mockHandlerIdentifier,
+					},
+				}
+
+				rule.Match = &oathkeeper.RuleMatch{
+					Methods: []string{},
+					Url:     &mockUrl,
+				}
+
+				marshal, _ := json.Marshal(rule)
+				return marshal
+			},
+			expectedResult: validator.ValidationErrors{},
+			expectedError:  nil,
+		},
+		{
+			name:     "UpdateRuleValidationError",
+			method:   http.MethodPut,
+			endpoint: "/identity-id",
+			body: func() []byte {
+				wrongHandlerIdentifier := ""
+
+				rule := new(oathkeeper.Rule)
+				rule.Authorizer = &oathkeeper.RuleHandler{}
+				rule.Authenticators = []oathkeeper.RuleHandler{
+					{
+						Handler: &wrongHandlerIdentifier,
+					},
+				}
+
+				rule.Match = &oathkeeper.RuleMatch{
+					Methods: []string{"GET", "non-http-verb"},
+					Url:     &mockUrl,
+				}
+
+				marshal, _ := json.Marshal(rule)
+				return marshal
+			},
+			expectedResult: validator.ValidationErrors{},
+			expectedError:  nil,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			_, result, err := p.Validate(context.TODO(), tt.method, tt.endpoint, tt.body())
+
+			if err != nil {
+				if tt.expectedError == nil {
+					t.Fatalf("Unexpected error for '%s'", tt.name)
+				}
+
+				if err.Error() != tt.expectedError.Error() {
+					t.Fatalf("Returned error doesn't match expected, obtained '%v' instead of '%v'", err, tt.expectedError)
+				}
+
+				return
+			}
+
+			if result != nil {
+				if tt.expectedResult == nil {
+					t.Fatalf("Unexpected result for '%s'", tt.name)
+				}
+
+				if errors.Is(result, tt.expectedResult) {
+					t.Fatalf("Returned validation errors don't match expected, obtained '%v' instead of '%v'", result, tt.expectedResult)
+				}
+
+				return
+			}
+		})
+	}
+}

--- a/pkg/schemas/handlers.go
+++ b/pkg/schemas/handlers.go
@@ -37,7 +37,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator(a.apiKey, a.payloadValidator)
 	if err != nil {
-		a.logger.Fatalf("unexpected validatingFunc already registered for schemas, %s", err)
+		a.logger.Fatalf("unexpected error while registering PayloadValidator for schemas, %s", err)
 	}
 }
 

--- a/pkg/schemas/validation.go
+++ b/pkg/schemas/validation.go
@@ -33,7 +33,7 @@ func (p *PayloadValidator) setupValidator() {
 	)
 }
 
-func (_ *PayloadValidator) NeedsValidation(r *http.Request) bool {
+func (p *PayloadValidator) NeedsValidation(r *http.Request) bool {
 	return r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch
 }
 

--- a/pkg/schemas/validation.go
+++ b/pkg/schemas/validation.go
@@ -37,19 +37,23 @@ func (p *PayloadValidator) NeedsValidation(r *http.Request) bool {
 	return r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch
 }
 
+func (p *PayloadValidator) isCreateSchema(method, endpoint string) bool {
+	return endpoint == "" && method == http.MethodPost
+}
+
 func (p *PayloadValidator) isPartialUpdate(method, endpoint string) bool {
 	return strings.HasPrefix(endpoint, "/") && method == http.MethodPatch
 }
 
-func (p *PayloadValidator) isCreateOrUpdateSchema(method, endpoint string) bool {
-	return (endpoint == "" && method == http.MethodPost) || (endpoint == "/default" && method == http.MethodPut)
+func (p *PayloadValidator) isUpdateDefaultSchema(method, endpoint string) bool {
+	return endpoint == "/default" && method == http.MethodPut
 }
 
 func (p *PayloadValidator) Validate(ctx context.Context, method, endpoint string, body []byte) (context.Context, validator.ValidationErrors, error) {
 	validated := false
 	var err error
 
-	if p.isCreateOrUpdateSchema(method, endpoint) {
+	if p.isCreateSchema(method, endpoint) || p.isPartialUpdate(method, endpoint) {
 		schema := new(kClient.IdentitySchemaContainer)
 		if err := json.Unmarshal(body, schema); err != nil {
 			return ctx, nil, err
@@ -59,7 +63,7 @@ func (p *PayloadValidator) Validate(ctx context.Context, method, endpoint string
 		validated = true
 	}
 
-	if p.isPartialUpdate(method, endpoint) {
+	if p.isUpdateDefaultSchema(method, endpoint) {
 		schema := new(DefaultSchema)
 		if err := json.Unmarshal(body, schema); err != nil {
 			return ctx, nil, err

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -34,7 +34,7 @@ func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, rulesConfig
 	monitor := ollyConfig.Monitor()
 	tracer := ollyConfig.Tracer()
 
-	vldtr := validation.NewRegistry(tracer, monitor, logger)
+	validationRegistry := validation.NewRegistry(tracer, monitor, logger)
 
 	middlewares := make(chi.Middlewares, 0)
 	middlewares = append(
@@ -58,7 +58,7 @@ func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, rulesConfig
 	router = router.With(
 		authorization.NewMiddleware(
 			authorization.NewAuthorizer(externalConfig.Authorizer(), tracer, monitor, logger), monitor, logger).Authorize(),
-		vldtr.ValidationMiddleware,
+		validationRegistry.ValidationMiddleware,
 	).(*chi.Mux)
 
 	status.NewAPI(tracer, monitor, logger).RegisterEndpoints(router)
@@ -69,35 +69,35 @@ func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, rulesConfig
 		logger,
 	)
 	identitiesAPI.RegisterEndpoints(router)
-	// identitiesAPI.RegisterValidation(vldtr)
+	identitiesAPI.RegisterValidation(validationRegistry)
 
 	clientsAPI := clients.NewAPI(
 		clients.NewService(externalConfig.HydraAdmin(), tracer, monitor, logger),
 		logger,
 	)
 	clientsAPI.RegisterEndpoints(router)
-	// clientsAPI.RegisterValidation(vldtr)
+	clientsAPI.RegisterValidation(validationRegistry)
 
 	idpAPI := idp.NewAPI(
 		idp.NewService(idpConfig, tracer, monitor, logger),
 		logger,
 	)
 	idpAPI.RegisterEndpoints(router)
-	// idpAPI.RegisterValidation(vldtr)
+	idpAPI.RegisterValidation(validationRegistry)
 
 	schemasAPI := schemas.NewAPI(
 		schemas.NewService(schemasConfig, tracer, monitor, logger),
 		logger,
 	)
 	schemasAPI.RegisterEndpoints(router)
-	// schemasAPI.RegisterValidation(vldtr)
+	schemasAPI.RegisterValidation(validationRegistry)
 
 	rulesAPI := rules.NewAPI(
 		rules.NewService(rulesConfig, tracer, monitor, logger),
 		logger,
 	)
 	rulesAPI.RegisterEndpoints(router)
-	// rulesAPI.RegisterValidation(vldtr)
+	rulesAPI.RegisterValidation(validationRegistry)
 
 	rolesAPI := roles.NewAPI(
 		roles.NewService(externalConfig.OpenFGA(), wpool, tracer, monitor, logger),
@@ -106,7 +106,7 @@ func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, rulesConfig
 		logger,
 	)
 	rolesAPI.RegisterEndpoints(router)
-	// rolesAPI.RegisterValidation(vldtr)
+	rolesAPI.RegisterValidation(validationRegistry)
 
 	groupsAPI := groups.NewAPI(
 		groups.NewService(externalConfig.OpenFGA(), wpool, tracer, monitor, logger),
@@ -115,7 +115,7 @@ func NewRouter(idpConfig *idp.Config, schemasConfig *schemas.Config, rulesConfig
 		logger,
 	)
 	groupsAPI.RegisterEndpoints(router)
-	// groupsAPI.RegisterValidation(vldtr)
+	groupsAPI.RegisterValidation(validationRegistry)
 
 	return tracing.NewMiddleware(monitor, logger).OpenTelemetry(router)
 }


### PR DESCRIPTION
## Description
This PR implements validation for remaining APIs, and add tests for all of them.
It also improves previously added tests from #275 .
It also enables validation (basically reverting the changes from #278 ), while also renaming the variable to something more explicit.
Added comments on validation tags to be explicit about what validation is performed.