### PR TITLE
feat: add config env var for enabling/disabling payload validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,5 +55,6 @@ dev:
 	@$(MICROK8S_REGISTRY_FLAG) $(SKAFFOLD) run \
 		--port-forward \
 		--no-prune=false \
+		--tail \
 		--cache-artifacts=false
 .PHONY: dev

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This is the Admin UI for the Canonical Identity Platform.
 - `OPENFGA_STORE_ID`: ID of the OpenFGA store the application will talk to 
 - `OPENFGA_AUTHORIZATION_MODEL_ID`: ID of the OpenFGA authorization model the application will talk to
 - `AUTHORIZATION_ENABLED`: flag defining if the OpenFGA authorization middleware is enabled default to `false`
+- `PAYLOAD_VALIDATION_ENABLED`: flag defining if the Payload Validation middleware is enabled default to `true`
 
 ## Development setup
 

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -39,7 +39,8 @@ type EnvSpec struct {
 	StoreId   string `envconfig:"openfga_store_id"`
 	ModelId   string `envconfig:"openfga_authorization_model_id" default:""`
 
-	AuthorizationEnabled bool `envconfig:"authorization_enabled" default:"false"`
+	AuthorizationEnabled     bool `envconfig:"authorization_enabled" default:"false"`
+	PayloadValidationEnabled bool `envconfig:"payload_validation_enabled" default:"true"`
 
 	OpenFGAWorkersTotal int `envconfig:"openfga_workers_total" default:"150"`
 }


### PR DESCRIPTION
## Description
This PR adds a config key to allow developers to run the backend with control over the payload validation process (enabled/disabled). Defaults to true.

## Changes
- refactor `NewRouter` func to take one holder object instead of multiple config objects
- added `payload_validation_enabled` config key to allow control over payload validation processes
- updated Readme `Environment Variables` sections
- added `--tail` flag to `skaffold` command in `make dev` in order to have skaffold tail logs