### PR TITLE
fix: removing extra #member on assignIdentities service call

### DIFF
--- a/internal/authorization/converters.go
+++ b/internal/authorization/converters.go
@@ -243,6 +243,10 @@ func (c GroupConverter) Map(r *http.Request) []Permission {
 		// edit permission on group {id} and view permissions on identity {i_id}
 		return []Permission{
 			{Relation: CAN_EDIT, ResourceID: fmt.Sprintf("%s:%s", c.TypeName(), group_id)},
+			// TODO @shipperizer this checks for an identity being present, even though the relation
+			// is between a user type and the group
+			// we need to work and sync users and identities or drop the check below as this would
+			// be missing 100% of the times
 			{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, identity_id)},
 		}
 	}

--- a/pkg/groups/service.go
+++ b/pkg/groups/service.go
@@ -376,7 +376,7 @@ func (s *Service) RemoveIdentities(ctx context.Context, ID string, identities ..
 
 	for _, identity := range identities {
 		// TODO @shipperizer swap user for identity if/when model changes
-		ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", identity), MEMBER_RELATION, s.buildGroupMember(ctx, ID)))
+		ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", identity), MEMBER_RELATION, fmt.Sprintf("group:%s", ID)))
 	}
 
 	err := s.ofga.DeleteTuples(ctx, ids...)

--- a/pkg/groups/service.go
+++ b/pkg/groups/service.go
@@ -354,7 +354,7 @@ func (s *Service) AssignIdentities(ctx context.Context, ID string, identities ..
 
 	for _, identity := range identities {
 		// TODO @shipperizer swap user for identity if/when model changes
-		ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", identity), MEMBER_RELATION, s.buildGroupMember(ctx, ID)))
+		ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", identity), MEMBER_RELATION, fmt.Sprintf("group:%s", ID)))
 	}
 
 	err := s.ofga.WriteTuples(ctx, ids...)

--- a/pkg/groups/service_test.go
+++ b/pkg/groups/service_test.go
@@ -541,7 +541,7 @@ func TestServiceAssignIdentities(t *testing.T) {
 					ids := make([]ofga.Tuple, 0)
 
 					for _, i := range test.input.identities {
-						ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", i), MEMBER_RELATION, fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION)))
+						ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", i), MEMBER_RELATION, fmt.Sprintf("group:%s", test.input.group)))
 					}
 
 					if !reflect.DeepEqual(ids, tuples) {

--- a/pkg/groups/service_test.go
+++ b/pkg/groups/service_test.go
@@ -615,7 +615,7 @@ func TestServiceRemoveIdentities(t *testing.T) {
 					ids := make([]ofga.Tuple, 0)
 
 					for _, i := range test.input.identities {
-						ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", i), MEMBER_RELATION, fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION)))
+						ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", i), MEMBER_RELATION, fmt.Sprintf("group:%s", test.input.group)))
 					}
 
 					if !reflect.DeepEqual(ids, tuples) {


### PR DESCRIPTION
closes #283


```
shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-847 ● λ http :8000/api/v0/groups/test/identities  X-Authorization:$PRIVILEGED_USER
HTTP/1.1 200 OK
Content-Length: 87
Content-Type: application/json
Date: Mon, 22 Apr 2024 12:33:28 GMT
X-Token-Pagination:

{
    "_meta": null,
    "data": [
        "user:shipperizer"
    ],
    "message": "List of identities",
    "status": 200
}


shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-847 ● λ http PATCH :8000/api/v0/groups/test/identities identities:='["tom","jerry"]' X-Authorization:$PRIVILEGED_USER
HTTP/1.1 201 Created
Content-Length: 86
Content-Type: application/json
Date: Mon, 22 Apr 2024 12:33:36 GMT

{
    "_meta": null,
    "data": null,
    "message": "Updated identities for group test",
    "status": 201
}


shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-847 ● λ http :8000/api/v0/groups/test/identities  X-Authorization:$PRIVILEGED_USER
HTTP/1.1 200 OK
Content-Length: 111
Content-Type: application/json
Date: Mon, 22 Apr 2024 12:33:40 GMT
X-Token-Pagination:

{
    "_meta": null,
    "data": [
        "user:shipperizer",
        "user:tom",
        "user:jerry"
    ],
    "message": "List of identities",
    "status": 200
}

shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-847 ● ● λ http DELETE :8000/api/v0/groups/test/identities/jerry  X-Authorization:$PRIVILEGED_USER
HTTP/1.1 200 OK
Content-Length: 90
Content-Type: application/json
Date: Mon, 22 Apr 2024 14:31:58 GMT

{
    "_meta": null,
    "data": null,
    "message": "Removed identity jerry for group test",
    "status": 200
}

shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-847 ● ● λ http GET :8000/api/v0/groups/test/identities  X-Authorization:$PRIVILEGED_USER      
HTTP/1.1 200 OK
Content-Length: 98
Content-Type: application/json
Date: Mon, 22 Apr 2024 14:35:35 GMT
X-Token-Pagination:

{
    "_meta": null,
    "data": [
        "user:shipperizer",
        "user:tom"
    ],
    "message": "List of identities",
    "status": 200
}

```