### PR TITLE
IAM 848

### DIFF
--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -62,6 +62,7 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 	mux.Delete("/api/v0/roles/{id:.+}/entitlements/{e_id:.+}", a.handleRemovePermission)
 	mux.Get("/api/v0/roles/{id:.+}/groups", a.handleListRoleGroup)
 }
+
 func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	err := v.RegisterPayloadValidator("roles", a.payloadValidator)
 	if err != nil {


### PR DESCRIPTION
IAM-848: address bugs on Delete<X> 

- **fix: remove assignees tuples on DeleteRole**
- **fix: remove assignees tuples on DeleteGroup**


```
shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-848 ● ● λ http :8000/api/v0/roles/newrole/groups  X-    Authorization:$PRIVILEGED_USER                                   
HTTP/1.1 200 OK
Content-Length: 87
Content-Type: application/json
Date: Tue, 23 Apr 2024 08:47:18 GMT
X-Token-Pagination:

{
    "_meta": null,
    "data": [
        "group:c-level#member"
    ],
    "message": "List of groups",
    "status": 200
}


shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-848 ● ● λ http   :8000/api/v0/roles/newrole/entitlements  X-Authorization:$PRIVILEGED_USER                                 
HTTP/1.1 200 OK
Content-Length: 120
Content-Type: application/json
Date: Tue, 23 Apr 2024 08:47:22 GMT
X-Token-Pagination:

{
    "_meta": null,
    "data": [
        "can_view::client:okta",
        "can_delete::client:okta"
    ],
    "message": "List of entitlements",
    "status": 200
}


shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-848 ● ● λ http PATCH :8000/api/v0/roles/newrole/entitlements  X-Authorization:$PRIVILEGED_USER permissions:='[{"object":"client:okta","relation":"can_view"},{"object":"client:okta","relation":"can_delete"}]'
HTTP/1.1 201 Created
Content-Length: 89
Content-Type: application/json
Date: Tue, 23 Apr 2024 09:16:20 GMT

{
"_meta": null,
"data": null,
"message": "Updated permissions for role newrole",
"status": 201
}

shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-848 ● ● λ http DELETE :8000/api/v0/roles/newrole  X-Authorization:$PRIVILEGED_USER
HTTP/1.1 200 OK
Content-Length: 73
Content-Type: application/json
Date: Tue, 23 Apr 2024 09:16:27 GMT

{
"_meta": null,
"data": null,
"message": "Deleted role newrole",
"status": 200
}


shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-848 ● ● λ http DELETE :8000/api/v0/roles/newrole  X-Authorization:$PRIVILEGED_USER
HTTP/1.1 403 Forbidden
Content-Length: 98
Content-Type: text/plain; charset=utf-8
Date: Tue, 23 Apr 2024 09:16:32 GMT

{
"_meta": null,
"data": null,
"message": "insufficient permissions to execute operation",
"status": 403
}


shipperizer in ~/shipperizer/identity-platform-admin-ui on IAM-848 ● ● λ http POST :8000/api/v0/roles id=newrole  X-Authorization:$PRIVILEGED_USER
HTTP/1.1 201 Created
Content-Length: 73
Content-Type: application/json
Date: Tue, 23 Apr 2024 09:16:44 GMT

{
"_meta": null,
"data": null,
"message": "Created role newrole",
"status": 201
}
```
