### PR TITLE
refactor: k8s client with externalized kubeconfig file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This is the Admin UI for the Canonical Identity Platform.
 - `LOG_FILE`: file where to dump logs, defaults to `log.txt`
 - `PORT `: http server port, defaults to `8080`
 - `DEBUG`: debugging flag for hydra and kratos clients
+- `KUBECONFIG_FILE`: optional path of kube config file, default to empty string
 - `KRATOS_PUBLIC_URL`: Kratos public endpoints address
 - `KRATOS_ADMIN_URL`: Kratos admin endpoints address
 - `HYDRA_ADMIN_URL`: Hydra admin endpoints address

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,5 +1,5 @@
-// Copyright 2024 Canonical Ltd
-// SPDX-License-Identifier: AGPL
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package cmd
 
@@ -85,7 +85,7 @@ func serve() {
 		extCfg.SetAuthorizer(extCfg.OpenFGA())
 	}
 
-	k8sCoreV1, err := k8s.NewCoreV1Client("")
+	k8sCoreV1, err := k8s.NewCoreV1Client(specs.KubeconfigFile)
 
 	if err != nil {
 		panic(err)

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -1,5 +1,5 @@
-// Copyright 2024 Canonical Ltd
-// SPDX-License-Identifier: AGPL
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package config
 
@@ -15,6 +15,8 @@ type EnvSpec struct {
 	Port int `envconfig:"port" default:"8080"`
 
 	Debug bool `envconfig:"debug" default:"false"`
+
+	KubeconfigFile string `envconfig:"kubeconfig_file"`
 
 	KratosPublicURL     string `envconfig:"kratos_public_url" required:"true"`
 	KratosAdminURL      string `envconfig:"kratos_admin_url" required:"true"`

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -1,5 +1,5 @@
-// Copyright 2024 Canonical Ltd
-// SPDX-License-Identifier: AGPL
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package k8s
 
@@ -17,18 +17,11 @@ func NewCoreV1Client(kubeconfig string) (coreV1.CoreV1Interface, error) {
 	var config *rest.Config
 	var err error
 
-	if kubeconfig != "" {
-		// use the current context in kubeconfig
-		if config, err = clientcmd.BuildConfigFromFlags("", kubeconfig); err != nil {
-			return nil, err
-		}
-	} else {
-		// creates the in-cluster config
-		config, err = rest.InClusterConfig()
-		if err != nil {
-			return nil, err
-		}
+	// use the current context in kubeconfig
+	if config, err = clientcmd.BuildConfigFromFlags("", kubeconfig); err != nil {
+		return nil, err
 	}
+
 	// creates the clientset
 	// clientset, err := kubernetes.NewForConfigAndClient(config, httpClient)
 	clientset, err := kubernetes.NewForConfig(config)


### PR DESCRIPTION
## Description
Applied @shipperizer changes to streamline K8s client and to externalize the kubeconfig file path for development purposes.

Updated license.