### PR TITLE
IAM 834 Use `name` identifier for `Groups`, and `Roles` creation

### DIFF
--- a/pkg/groups/handlers.go
+++ b/pkg/groups/handlers.go
@@ -40,8 +40,9 @@ type UpdatePermissionsRequest struct {
 	Permissions []Permission `json:"permissions" validate:"required,dive,required"`
 }
 
-type GroupRequest struct {
-	ID string `json:"id" validate:"required"`
+type Group struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty" validate:"required,notblank"`
 }
 
 type UpdateIdentitiesRequest struct {
@@ -200,7 +201,7 @@ func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	group := new(GroupRequest)
+	group := new(Group)
 	if err := json.Unmarshal(body, group); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(

--- a/pkg/groups/handlers.go
+++ b/pkg/groups/handlers.go
@@ -162,7 +162,7 @@ func (a *API) handleDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if group == "" {
+	if group == nil {
 		w.WriteHeader(http.StatusNotFound)
 		json.NewEncoder(w).Encode(
 			types.Response{
@@ -176,7 +176,7 @@ func (a *API) handleDetail(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(
 		types.Response{
-			Data:    []string{group},
+			Data:    []Group{*group},
 			Message: "Group detail",
 			Status:  http.StatusOK,
 		},
@@ -214,8 +214,21 @@ func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 
 	}
+
+	if group.ID != "" {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Group ID field is not allowed to be passed in",
+				Status:  http.StatusBadRequest,
+			},
+		)
+
+		return
+	}
+
 	user := a.userFromContext(r.Context())
-	err = a.service.CreateGroup(r.Context(), user.ID, group.ID)
+	err = a.service.CreateGroup(r.Context(), user.ID, group.Name)
 
 	if err != nil {
 
@@ -233,7 +246,7 @@ func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(
 		types.Response{
-			Message: fmt.Sprintf("Created group %s", group.ID),
+			Message: fmt.Sprintf("Created group %s", group.Name),
 			Status:  http.StatusCreated,
 		},
 	)

--- a/pkg/groups/handlers_test.go
+++ b/pkg/groups/handlers_test.go
@@ -196,7 +196,10 @@ func TestHandleDetail(t *testing.T) {
 			input:    "administrator",
 			expected: nil,
 			output: &types.Response{
-				Data:    []string{"administrator"},
+				Data: []Group{{
+					ID:   "administrator",
+					Name: "administrator",
+				}},
 				Message: "Group detail",
 				Status:  http.StatusOK,
 			},
@@ -216,12 +219,15 @@ func TestHandleDetail(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/groups/%s", test.input), nil)
 
 			mockService.EXPECT().GetGroup(gomock.Any(), "anonymous", test.input).DoAndReturn(
-				func(context.Context, string, string) (string, error) {
+				func(context.Context, string, string) (*Group, error) {
 					if test.expected != nil {
-						return "", test.expected
+						return nil, test.expected
 					}
 
-					return test.input, nil
+					return &Group{
+						ID:   test.input,
+						Name: test.input,
+					}, nil
 
 				},
 			)
@@ -246,7 +252,7 @@ func TestHandleDetail(t *testing.T) {
 
 			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
 			type Response struct {
-				Data    []string          `json:"data"`
+				Data    []Group           `json:"data"`
 				Message string            `json:"message"`
 				Status  int               `json:"status"`
 				Meta    *types.Pagination `json:"_meta"`
@@ -1172,8 +1178,8 @@ func TestHandleCreate(t *testing.T) {
 			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
 			mockService := NewMockServiceInterface(ctrl)
 
-			upr := new(GroupRequest)
-			upr.ID = test.input
+			upr := new(Group)
+			upr.Name = test.input
 			payload, _ := json.Marshal(upr)
 
 			req := httptest.NewRequest(http.MethodPost, "/api/v0/groups", bytes.NewReader(payload))

--- a/pkg/groups/interfaces.go
+++ b/pkg/groups/interfaces.go
@@ -14,7 +14,7 @@ import (
 // ServiceInterface is the interface that each business logic service needs to implement
 type ServiceInterface interface {
 	ListGroups(context.Context, string) ([]string, error) // list of groups, continuation token, error
-	GetGroup(context.Context, string, string) (string, error)
+	GetGroup(context.Context, string, string) (*Group, error)
 	CreateGroup(context.Context, string, string) error
 	DeleteGroup(context.Context, string) error
 	ListRoles(context.Context, string) ([]string, error)

--- a/pkg/groups/service_test.go
+++ b/pkg/groups/service_test.go
@@ -718,7 +718,7 @@ func TestServiceGetGroup(t *testing.T) {
 				t.Errorf("expected error to be %v got %v", test.expected.err, err)
 			}
 
-			if test.expected.err == nil && test.expected.check && group != test.input.group {
+			if test.expected.err == nil && test.expected.check && group.ID != test.input.group {
 				t.Errorf("invalid result, expected: %v, got: %v", test.input.group, group)
 			}
 		})

--- a/pkg/groups/validation.go
+++ b/pkg/groups/validation.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/go-playground/validator/v10/non-standard/validators"
 
 	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 )
@@ -17,6 +18,10 @@ import (
 type PayloadValidator struct {
 	apiKey    string
 	validator *validator.Validate
+}
+
+func (p *PayloadValidator) setupValidator() {
+	_ = p.validator.RegisterValidation("notblank", validators.NotBlank)
 }
 
 func (p *PayloadValidator) NeedsValidation(r *http.Request) bool {
@@ -28,7 +33,7 @@ func (p *PayloadValidator) Validate(ctx context.Context, method, endpoint string
 	var err error
 
 	if p.isCreateGroup(method, endpoint) {
-		group := new(GroupRequest)
+		group := new(Group)
 		if err := json.Unmarshal(body, group); err != nil {
 			return ctx, nil, err
 		}
@@ -107,6 +112,8 @@ func NewGroupsPayloadValidator(apiKey string) *PayloadValidator {
 	p := new(PayloadValidator)
 	p.apiKey = apiKey
 	p.validator = validation.NewValidator()
+
+	p.setupValidator()
 
 	return p
 }

--- a/pkg/groups/validation_test.go
+++ b/pkg/groups/validation_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/go-playground/validator/v10/non-standard/validators"
 
 	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 )
@@ -86,6 +87,7 @@ func TestValidate(t *testing.T) {
 	p := new(PayloadValidator)
 	p.apiKey = "groups"
 	p.validator = validation.NewValidator()
+	_ = p.validator.RegisterValidation("notblank", validators.NotBlank)
 
 	for _, tt := range []struct {
 		name           string
@@ -100,8 +102,8 @@ func TestValidate(t *testing.T) {
 			method:   http.MethodPost,
 			endpoint: "",
 			body: func() []byte {
-				r := new(GroupRequest)
-				r.ID = "mock-id"
+				r := new(Group)
+				r.Name = "mock-name"
 
 				marshal, _ := json.Marshal(r)
 				return marshal
@@ -115,7 +117,7 @@ func TestValidate(t *testing.T) {
 			endpoint: "/mock-id",
 			body: func() []byte {
 				id := "mock-id"
-				r := new(GroupRequest)
+				r := new(Group)
 				r.ID = id
 
 				marshal, _ := json.Marshal(r)
@@ -190,7 +192,7 @@ func TestValidate(t *testing.T) {
 			method:   http.MethodPost,
 			endpoint: "",
 			body: func() []byte {
-				r := new(GroupRequest)
+				r := new(Group)
 
 				marshal, _ := json.Marshal(r)
 				return marshal
@@ -203,7 +205,7 @@ func TestValidate(t *testing.T) {
 			method:   http.MethodPatch,
 			endpoint: "/mock-id",
 			body: func() []byte {
-				r := new(GroupRequest)
+				r := new(Group)
 
 				marshal, _ := json.Marshal(r)
 				return marshal

--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -147,7 +147,7 @@ func (a *API) handleDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if role == "" {
+	if role == nil {
 		w.WriteHeader(http.StatusNotFound)
 		json.NewEncoder(w).Encode(
 			types.Response{
@@ -161,7 +161,7 @@ func (a *API) handleDetail(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(
 		types.Response{
-			Data:    []string{role},
+			Data:    []Role{*role},
 			Message: "Rule detail",
 			Status:  http.StatusOK,
 		},

--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -34,8 +34,9 @@ type UpdatePermissionsRequest struct {
 	Permissions []Permission `json:"permissions" validate:"required,dive,required"`
 }
 
-type RoleRequest struct {
-	ID string `json:"id" validate:"required"`
+type Role struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty" validate:"required,notblank"`
 }
 
 // API is the core HTTP object that implements all the HTTP and business logic for the roles
@@ -185,7 +186,7 @@ func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	role := new(RoleRequest)
+	role := new(Role)
 	if err := json.Unmarshal(body, role); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(

--- a/pkg/roles/handlers_test.go
+++ b/pkg/roles/handlers_test.go
@@ -196,7 +196,10 @@ func TestHandleDetail(t *testing.T) {
 			input:    "administrator",
 			expected: nil,
 			output: &types.Response{
-				Data:    []string{"administrator"},
+				Data: []Role{{
+					ID:   "administrator",
+					Name: "administrator",
+				}},
 				Message: "Rule detail",
 				Status:  http.StatusOK,
 			},
@@ -216,12 +219,15 @@ func TestHandleDetail(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/roles/%s", test.input), nil)
 
 			mockService.EXPECT().GetRole(gomock.Any(), "anonymous", test.input).DoAndReturn(
-				func(context.Context, string, string) (string, error) {
+				func(context.Context, string, string) (*Role, error) {
 					if test.expected != nil {
-						return "", test.expected
+						return nil, test.expected
 					}
 
-					return test.input, nil
+					return &Role{
+						ID:   test.input,
+						Name: test.input,
+					}, nil
 
 				},
 			)
@@ -246,7 +252,7 @@ func TestHandleDetail(t *testing.T) {
 
 			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
 			type Response struct {
-				Data    []string          `json:"data"`
+				Data    []Role            `json:"data"`
 				Message string            `json:"message"`
 				Status  int               `json:"status"`
 				Meta    *types.Pagination `json:"_meta"`
@@ -1198,7 +1204,7 @@ func TestHandleCreate(t *testing.T) {
 			mockMonitor := monitoring.NewMockMonitorInterface(ctrl)
 			mockService := NewMockServiceInterface(ctrl)
 
-			upr := new(RoleRequest)
+			upr := new(Role)
 			upr.ID = test.input
 			payload, _ := json.Marshal(upr)
 

--- a/pkg/roles/interfaces.go
+++ b/pkg/roles/interfaces.go
@@ -14,7 +14,7 @@ import (
 // ServiceInterface is the interface that each business logic service needs to implement
 type ServiceInterface interface {
 	ListRoles(context.Context, string) ([]string, error)
-	GetRole(context.Context, string, string) (string, error)
+	GetRole(context.Context, string, string) (*Role, error)
 	CreateRole(context.Context, string, string) error
 	DeleteRole(context.Context, string) error
 	ListRoleGroups(context.Context, string, string) ([]string, string, error)

--- a/pkg/roles/service.go
+++ b/pkg/roles/service.go
@@ -88,24 +88,26 @@ func (s *Service) ListRoleGroups(ctx context.Context, ID, continuationToken stri
 
 // GetRole returns the specified role using the ID argument, userID is used to validate the visibility by the user
 // making the call
-func (s *Service) GetRole(ctx context.Context, userID, ID string) (string, error) {
+func (s *Service) GetRole(ctx context.Context, userID, ID string) (*Role, error) {
 	ctx, span := s.tracer.Start(ctx, "roles.Service.GetRole")
 	defer span.End()
 
 	exists, err := s.ofga.Check(ctx, fmt.Sprintf("user:%s", userID), "can_view", fmt.Sprintf("role:%s", ID))
 
 	if err != nil {
-
 		s.logger.Error(err.Error())
-		return "", err
+		return nil, err
 	}
 
-	if exists {
-		return ID, nil
+	if !exists {
+		return nil, nil
 	}
 
-	// if we got here it means authorization check hasn't worked
-	return "", nil
+	role := new(Role)
+	role.ID = ID
+	role.Name = ID
+
+	return role, nil
 }
 
 // CreateRole creates a role and associates it with the userID passed as argument

--- a/pkg/roles/service_test.go
+++ b/pkg/roles/service_test.go
@@ -348,7 +348,7 @@ func TestServiceGetRole(t *testing.T) {
 				t.Errorf("expected error to be %v got %v", test.expected.err, err)
 			}
 
-			if test.expected.err == nil && test.expected.check && role != test.input.role {
+			if test.expected.err == nil && test.expected.check && role.ID != test.input.role {
 				t.Errorf("invalid result, expected: %v, got: %v", test.input.role, role)
 			}
 		})

--- a/pkg/roles/validation.go
+++ b/pkg/roles/validation.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/go-playground/validator/v10/non-standard/validators"
 
 	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 )
@@ -17,6 +18,10 @@ import (
 type PayloadValidator struct {
 	apiKey    string
 	validator *validator.Validate
+}
+
+func (p *PayloadValidator) setupValidator() {
+	_ = p.validator.RegisterValidation("notblank", validators.NotBlank)
 }
 
 func (p *PayloadValidator) NeedsValidation(r *http.Request) bool {
@@ -28,7 +33,7 @@ func (p *PayloadValidator) Validate(ctx context.Context, method, endpoint string
 	var err error
 
 	if p.isCreateRole(method, endpoint) {
-		roleRequest := new(RoleRequest)
+		roleRequest := new(Role)
 		if err := json.Unmarshal(body, roleRequest); err != nil {
 			return ctx, nil, err
 		}
@@ -79,6 +84,8 @@ func NewRolesPayloadValidator(apiKey string) *PayloadValidator {
 	p := new(PayloadValidator)
 	p.apiKey = apiKey
 	p.validator = validation.NewValidator()
+
+	p.setupValidator()
 
 	return p
 }

--- a/pkg/roles/validation_test.go
+++ b/pkg/roles/validation_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/go-playground/validator/v10/non-standard/validators"
 
 	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 )
@@ -87,6 +88,7 @@ func TestValidate(t *testing.T) {
 	p := new(PayloadValidator)
 	p.apiKey = "roles"
 	p.validator = validation.NewValidator()
+	_ = p.validator.RegisterValidation("notblank", validators.NotBlank)
 
 	for _, tt := range []struct {
 		name           string
@@ -101,8 +103,8 @@ func TestValidate(t *testing.T) {
 			method:   http.MethodPost,
 			endpoint: "",
 			body: func() []byte {
-				role := new(RoleRequest)
-				role.ID = "mock-role-id"
+				role := new(Role)
+				role.Name = "mock-role-id"
 
 				marshal, _ := json.Marshal(role)
 				return marshal
@@ -115,7 +117,7 @@ func TestValidate(t *testing.T) {
 			method:   http.MethodPatch,
 			endpoint: "/",
 			body: func() []byte {
-				role := new(RoleRequest)
+				role := new(Role)
 				role.ID = "mock-role-id"
 
 				marshal, _ := json.Marshal(role)
@@ -172,7 +174,7 @@ func TestValidate(t *testing.T) {
 			method:   http.MethodPost,
 			endpoint: "",
 			body: func() []byte {
-				role := new(RoleRequest)
+				role := new(Role)
 
 				marshal, _ := json.Marshal(role)
 				return marshal
@@ -185,7 +187,7 @@ func TestValidate(t *testing.T) {
 			method:   http.MethodPatch,
 			endpoint: "/identity-id",
 			body: func() []byte {
-				role := new(RoleRequest)
+				role := new(Role)
 
 				marshal, _ := json.Marshal(role)
 				return marshal


### PR DESCRIPTION
## Description
This PR tries to bring uniformity to Admin UI APIs in order to avoid breaking changes in the future (or at least reduce them to the least possible). This involves never letting users specify ID for resource creations, but rely on a different identifier.
Also, now invocations like `GET /groups/{id}` will return a json instead of a single string. The json response will include both the ID and the identifier provided at creation time.

This fixes #271 
