### PR TITLE
IAM 867 fix groups handlers

### DIFF
--- a/pkg/groups/handlers.go
+++ b/pkg/groups/handlers.go
@@ -146,7 +146,7 @@ func (a *API) handleDetail(w http.ResponseWriter, r *http.Request) {
 
 	ID := chi.URLParam(r, "id")
 	user := a.userFromContext(r.Context())
-	role, err := a.service.GetGroup(r.Context(), user.ID, ID)
+	group, err := a.service.GetGroup(r.Context(), user.ID, ID)
 
 	if err != nil {
 
@@ -161,10 +161,21 @@ func (a *API) handleDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if group == "" {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: "Group not found",
+				Status:  http.StatusNotFound,
+			},
+		)
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(
 		types.Response{
-			Data:    []string{role},
+			Data:    []string{group},
 			Message: "Group detail",
 			Status:  http.StatusOK,
 		},

--- a/pkg/groups/service.go
+++ b/pkg/groups/service.go
@@ -21,6 +21,8 @@ import (
 const (
 	MEMBER_RELATION   = "member"
 	ASSIGNEE_RELATION = "assignee"
+	// TODO: @barco centralize common relation name definitions
+	CAN_VIEW_RELATION = "can_view"
 )
 
 type listPermissionsResult struct {
@@ -174,10 +176,14 @@ func (s *Service) CreateGroup(ctx context.Context, userID, ID string) error {
 	// might sort the problem
 
 	// TODO @shipperizer offload to privileged creator object
+	group := fmt.Sprintf("group:%s", ID)
+	user := fmt.Sprintf("user:%s", userID)
+
 	err := s.ofga.WriteTuples(
 		ctx,
-		*ofga.NewTuple(fmt.Sprintf("user:%s", userID), MEMBER_RELATION, fmt.Sprintf("group:%s", ID)),
-		*ofga.NewTuple(authorization.ADMIN_PRIVILEGE, "privileged", fmt.Sprintf("group:%s", ID)),
+		*ofga.NewTuple(user, MEMBER_RELATION, group),
+		*ofga.NewTuple(authorization.ADMIN_PRIVILEGE, "privileged", group),
+		*ofga.NewTuple(user, CAN_VIEW_RELATION, group),
 	)
 
 	if err != nil {

--- a/pkg/groups/service.go
+++ b/pkg/groups/service.go
@@ -302,7 +302,10 @@ func (s *Service) DeleteGroup(ctx context.Context, ID string) error {
 	// https://go.dev/ref/spec#Send_statements
 	// A send on an unbuffered channel can proceed if a receiver is ready.
 	// A send on a buffered channel can proceed if there is room in the buffer
-	jobs := len(s.permissionTypes()) + 1
+	permissionTypes := s.permissionTypes()
+	directRelations := s.directRelations()
+
+	jobs := len(permissionTypes) + len(directRelations)
 
 	results := make(chan *pool.Result[any], jobs)
 	wg := sync.WaitGroup{}
@@ -317,11 +320,13 @@ func (s *Service) DeleteGroup(ctx context.Context, ID string) error {
 		)
 	}
 
-	s.wpool.Submit(
-		s.removeMembersFunc(ctx, ID),
-		results,
-		&wg,
-	)
+	for _, t := range directRelations {
+		s.wpool.Submit(
+			s.removeDirectAssociationsFunc(ctx, ID, t),
+			results,
+			&wg,
+		)
+	}
 
 	// wait for tasks to finish
 	wg.Wait()
@@ -329,7 +334,8 @@ func (s *Service) DeleteGroup(ctx context.Context, ID string) error {
 	// close result channel
 	close(results)
 
-	return s.ofga.DeleteTuples(ctx, *ofga.NewTuple(authorization.ADMIN_PRIVILEGE, "privileged", fmt.Sprintf("group:%s", ID)))
+	// TODO: @barco collect errors from results chan and return composite error or single summing up
+	return nil
 }
 
 // ListIdentities returns all the identities (users for now) assigned to a group
@@ -464,22 +470,22 @@ func (s *Service) removePermissionsByType(ctx context.Context, ID, pType string)
 	}
 }
 
-func (s *Service) removeMembers(ctx context.Context, ID string) {
-	ctx, span := s.tracer.Start(ctx, "roles.Service.removeMembers")
+func (s *Service) removeDirectAssociations(ctx context.Context, ID, relation string) {
+	ctx, span := s.tracer.Start(ctx, "groups.Service.removeDirectAssociations")
 	defer span.End()
 
 	cToken := ""
-	members := make([]ofga.Tuple, 0)
+	directs := make([]ofga.Tuple, 0)
 	for {
-		r, err := s.ofga.ReadTuples(ctx, "", MEMBER_RELATION, fmt.Sprintf("group:%s", ID), cToken)
+		r, err := s.ofga.ReadTuples(ctx, "", relation, fmt.Sprintf("group:%s", ID), cToken)
 
 		if err != nil {
-			s.logger.Errorf("error when retrieving tuples for %s group:%s", MEMBER_RELATION, ID)
+			s.logger.Errorf("error when retrieving tuples for %s group, %s relation", relation, ID)
 			return
 		}
 
 		for _, t := range r.Tuples {
-			members = append(members, *ofga.NewTuple(t.Key.User, t.Key.Relation, t.Key.Object))
+			directs = append(directs, *ofga.NewTuple(t.Key.User, t.Key.Relation, t.Key.Object))
 		}
 
 		// if there are more pages, keep going with the loop
@@ -487,15 +493,14 @@ func (s *Service) removeMembers(ctx context.Context, ID string) {
 			continue
 		}
 
-		// TODO @shipperizer understand if better breaking at every cycle or reverting if clause
 		break
 	}
 
-	if len(members) == 0 {
+	if len(directs) == 0 {
 		return
 	}
 
-	if err := s.ofga.DeleteTuples(ctx, members...); err != nil {
+	if err := s.ofga.DeleteTuples(ctx, directs...); err != nil {
 		s.logger.Error(err.Error())
 	}
 }
@@ -524,14 +529,18 @@ func (s *Service) removePermissionsFunc(ctx context.Context, groupID, ofgaType s
 	}
 }
 
-func (s *Service) removeMembersFunc(ctx context.Context, roleID string) func() {
+func (s *Service) removeDirectAssociationsFunc(ctx context.Context, groupID, relation string) func() {
 	return func() {
-		s.removeMembers(ctx, roleID)
+		s.removeDirectAssociations(ctx, groupID, relation)
 	}
 }
 
 func (s *Service) permissionTypes() []string {
 	return []string{"group", "role", "identity", "scheme", "provider", "client"}
+}
+
+func (s *Service) directRelations() []string {
+	return []string{"privileged", "member", "can_create", "can_delete", "can_edit", "can_view"}
 }
 
 // NewService returns the implementtation of the business logic for the groups API


### PR DESCRIPTION
## Description
This PR fixes unexpected behavior when invoking the group API.

Similar to the work done in #295 .

## Changes
- CreateGroup now adds the explicit entitlement `can_view` to user:{userID} since it would not work otherwise
- GetGroupDetail now returns
  - the group id in case it's present and the user is allowed to view it
  - 404 in case the group is not present and the user is allowed to view
  - 403 in case the user is not allowed to view it (no matter if the role is present or not, this info is concealed from the unauthorized user)
- DeleteRole now removes also all direct associations from the group, meaning all `can_view`, `can_edit`, `can_delete`, `can_create`, `member`, `privileged` are removed when the group is removed
- tests are adjusted

NB: a subsequent PR will take care of returning errors from the concurrent deletions, this requires more work on the worker pool side and on the role service, so it needs to be done separately. This is way the remove role test is not testing error for now.