### PR TITLE
feat: return created entity in response body for `Role`s and `Group`s

### DIFF
--- a/pkg/groups/handlers.go
+++ b/pkg/groups/handlers.go
@@ -228,7 +228,7 @@ func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user := a.userFromContext(r.Context())
-	err = a.service.CreateGroup(r.Context(), user.ID, group.Name)
+	group, err = a.service.CreateGroup(r.Context(), user.ID, group.Name)
 
 	if err != nil {
 
@@ -246,6 +246,7 @@ func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(
 		types.Response{
+			Data:    []Group{*group},
 			Message: fmt.Sprintf("Created group %s", group.Name),
 			Status:  http.StatusCreated,
 		},

--- a/pkg/groups/handlers_test.go
+++ b/pkg/groups/handlers_test.go
@@ -1184,7 +1184,11 @@ func TestHandleCreate(t *testing.T) {
 
 			req := httptest.NewRequest(http.MethodPost, "/api/v0/groups", bytes.NewReader(payload))
 
-			mockService.EXPECT().CreateGroup(gomock.Any(), "anonymous", test.input).Return(test.expected)
+			var group *Group = nil
+			if test.expected == nil {
+				group = &Group{ID: test.input, Name: test.input}
+			}
+			mockService.EXPECT().CreateGroup(gomock.Any(), "anonymous", test.input).Return(group, test.expected)
 
 			w := httptest.NewRecorder()
 			mux := chi.NewMux()
@@ -1206,7 +1210,7 @@ func TestHandleCreate(t *testing.T) {
 
 			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
 			type Response struct {
-				Data    []string          `json:"data"`
+				Data    []Group           `json:"data"`
 				Message string            `json:"message"`
 				Status  int               `json:"status"`
 				Meta    *types.Pagination `json:"_meta"`
@@ -1218,7 +1222,7 @@ func TestHandleCreate(t *testing.T) {
 				t.Errorf("expected error to be nil got %v", err)
 			}
 
-			if test.expected == nil && len(rr.Data) != 0 {
+			if test.expected == nil && (len(rr.Data) != 1 || rr.Data[0].Name != test.input || rr.Data[0].ID != test.input) {
 				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
 			}
 

--- a/pkg/groups/interfaces.go
+++ b/pkg/groups/interfaces.go
@@ -15,7 +15,7 @@ import (
 type ServiceInterface interface {
 	ListGroups(context.Context, string) ([]string, error) // list of groups, continuation token, error
 	GetGroup(context.Context, string, string) (*Group, error)
-	CreateGroup(context.Context, string, string) error
+	CreateGroup(context.Context, string, string) (*Group, error)
 	DeleteGroup(context.Context, string) error
 	ListRoles(context.Context, string) ([]string, error)
 	AssignRoles(context.Context, string, ...string) error

--- a/pkg/groups/service.go
+++ b/pkg/groups/service.go
@@ -166,7 +166,7 @@ func (s *Service) GetGroup(ctx context.Context, userID, ID string) (*Group, erro
 
 // CreateGroup creates a group and associates it with the userID passed as argument
 // an extra tuple is created to estabilish the "privileged" relatin for admin users
-func (s *Service) CreateGroup(ctx context.Context, userID, groupName string) error {
+func (s *Service) CreateGroup(ctx context.Context, userID, groupName string) (*Group, error) {
 	ctx, span := s.tracer.Start(ctx, "groups.Service.CreateGroup")
 	defer span.End()
 
@@ -190,10 +190,13 @@ func (s *Service) CreateGroup(ctx context.Context, userID, groupName string) err
 
 	if err != nil {
 		s.logger.Error(err.Error())
-		return err
+		return nil, err
 	}
 
-	return nil
+	return &Group{
+		ID:   groupName,
+		Name: groupName,
+	}, nil
 }
 
 // AssignRoles assigns roles to a group

--- a/pkg/groups/service_test.go
+++ b/pkg/groups/service_test.go
@@ -794,10 +794,14 @@ func TestServiceCreateGroup(t *testing.T) {
 				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
 			}
 
-			err := svc.CreateGroup(context.Background(), test.input.user, test.input.group)
+			group, err := svc.CreateGroup(context.Background(), test.input.user, test.input.group)
 
 			if err != test.expected {
 				t.Errorf("expected error to be %v got %v", test.expected, err)
+			}
+
+			if group != nil && (group.ID != test.input.group || group.Name != test.input.group) {
+				t.Errorf("expected group ID and Name to be %v got %s, %s", test.input.group, group.ID, group.Name)
 			}
 		})
 	}

--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -213,7 +213,7 @@ func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user := a.userFromContext(r.Context())
-	err = a.service.CreateRole(r.Context(), user.ID, role.Name)
+	role, err = a.service.CreateRole(r.Context(), user.ID, role.Name)
 
 	if err != nil {
 
@@ -231,6 +231,7 @@ func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(
 		types.Response{
+			Data:    []Role{*role},
 			Message: fmt.Sprintf("Created role %s", role.Name),
 			Status:  http.StatusCreated,
 		},

--- a/pkg/roles/handlers_test.go
+++ b/pkg/roles/handlers_test.go
@@ -1210,7 +1210,11 @@ func TestHandleCreate(t *testing.T) {
 
 			req := httptest.NewRequest(http.MethodPost, "/api/v0/roles", bytes.NewReader(payload))
 
-			mockService.EXPECT().CreateRole(gomock.Any(), "anonymous", test.input).Return(test.expected)
+			var role *Role = nil
+			if test.expected == nil {
+				role = &Role{ID: test.input, Name: test.input}
+			}
+			mockService.EXPECT().CreateRole(gomock.Any(), "anonymous", test.input).Return(role, test.expected)
 
 			w := httptest.NewRecorder()
 			mux := chi.NewMux()
@@ -1232,7 +1236,7 @@ func TestHandleCreate(t *testing.T) {
 
 			// duplicate types.Response attribute we care and assign the proper type instead of interface{}
 			type Response struct {
-				Data    []string          `json:"data"`
+				Data    []Role            `json:"data"`
 				Message string            `json:"message"`
 				Status  int               `json:"status"`
 				Meta    *types.Pagination `json:"_meta"`
@@ -1244,7 +1248,7 @@ func TestHandleCreate(t *testing.T) {
 				t.Errorf("expected error to be nil got %v", err)
 			}
 
-			if test.expected == nil && len(rr.Data) != 0 {
+			if test.expected == nil && (len(rr.Data) != 1 || rr.Data[0].Name != test.input || rr.Data[0].ID != test.input) {
 				t.Errorf("invalid result, expected: %v, got: %v", test.output.Data, rr.Data)
 			}
 

--- a/pkg/roles/interfaces.go
+++ b/pkg/roles/interfaces.go
@@ -15,7 +15,7 @@ import (
 type ServiceInterface interface {
 	ListRoles(context.Context, string) ([]string, error)
 	GetRole(context.Context, string, string) (*Role, error)
-	CreateRole(context.Context, string, string) error
+	CreateRole(context.Context, string, string) (*Role, error)
 	DeleteRole(context.Context, string) error
 	ListRoleGroups(context.Context, string, string) ([]string, string, error)
 	ListPermissions(context.Context, string, map[string]string) ([]string, map[string]string, error)

--- a/pkg/roles/service.go
+++ b/pkg/roles/service.go
@@ -112,7 +112,7 @@ func (s *Service) GetRole(ctx context.Context, userID, ID string) (*Role, error)
 
 // CreateRole creates a role and associates it with the userID passed as argument
 // an extra tuple is created to estabilish the "privileged" relatin for admin users
-func (s *Service) CreateRole(ctx context.Context, userID, ID string) error {
+func (s *Service) CreateRole(ctx context.Context, userID, ID string) (*Role, error) {
 	ctx, span := s.tracer.Start(ctx, "roles.Service.CreateRole")
 	defer span.End()
 
@@ -136,10 +136,13 @@ func (s *Service) CreateRole(ctx context.Context, userID, ID string) error {
 
 	if err != nil {
 		s.logger.Error(err.Error())
-		return err
+		return nil, err
 	}
 
-	return nil
+	return &Role{
+		ID:   ID,
+		Name: ID,
+	}, nil
 }
 
 // AssignPermissions assigns permissions to a role

--- a/pkg/roles/service_test.go
+++ b/pkg/roles/service_test.go
@@ -423,10 +423,14 @@ func TestServiceCreateRole(t *testing.T) {
 				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
 			}
 
-			err := svc.CreateRole(context.Background(), test.input.user, test.input.role)
+			role, err := svc.CreateRole(context.Background(), test.input.user, test.input.role)
 
 			if test.expected != nil && err != test.expected {
 				t.Errorf("expected error to be %v got %v", test.expected, err)
+			}
+
+			if role != nil && (role.ID != test.input.role || role.Name != test.input.role) {
+				t.Errorf("expected role ID and Name to be %v got %s, %s", test.input.role, role.ID, role.Name)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
With this PR creation endpoints for Roles and Groups now also return the body of the created entity as the only element of the `data` array.

Closes #302 .