### PR TITLE
WD-10953 - feat: upgrade rebac-admin to 0.0.1-alpha.3

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@canonical/react-components": "0.51.1",
-    "@canonical/rebac-admin": "0.0.1-alpha.2",
+    "@canonical/rebac-admin": "0.0.1-alpha.3",
     "@tanstack/react-query": "^5.28.6",
     "@use-it/event-listener": "0.1.7",
     "axios": "1.6.8",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1163,10 +1163,10 @@
     react-table "7.8.0"
     react-useportal "1.0.19"
 
-"@canonical/rebac-admin@0.0.1-alpha.2":
-  version "0.0.1-alpha.2"
-  resolved "https://registry.yarnpkg.com/@canonical/rebac-admin/-/rebac-admin-0.0.1-alpha.2.tgz#0f64303c80f2489a23da4f063a5aab0e100204b4"
-  integrity sha512-zr4DoVpKa2Mj/9XFWFiyTmPkox62h2V3d2XqxvO1hqEdnXIYQetIHQkpfHSaga4cu6bHStzqYmGlwkD0cG+YYw==
+"@canonical/rebac-admin@0.0.1-alpha.3":
+  version "0.0.1-alpha.3"
+  resolved "https://registry.yarnpkg.com/@canonical/rebac-admin/-/rebac-admin-0.0.1-alpha.3.tgz#4bb249ad2db2da63869e8aaa4351c3cda2df95b2"
+  integrity sha512-ouHaQ2/KU0FJ+e16+cdLVrBSuIId+U/FooL0R/5ysZ7n1Q7/tswttuPbRjjk/lZ+PfwiNi9lyOmyEG0seyToxw==
   dependencies:
     async-limiter "2.0.0"
     classnames "2.5.1"


### PR DESCRIPTION
## Changes
Upgrade to the latest rebac-admin with support for `name` attributes (https://github.com/canonical/identity-platform-admin-ui/pull/297).



## Details

https://warthogs.atlassian.net/browse/WD-10953