### PR TITLE
IAM 829 Use token pagination strategy for Rules API

### DIFF
--- a/internal/http/types/generic.go
+++ b/internal/http/types/generic.go
@@ -1,5 +1,5 @@
-// Copyright 2024 Canonical Ltd
-// SPDX-License-Identifier: AGPL
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package types
 
@@ -21,7 +21,7 @@ type Response struct {
 
 // NavigationTokens are parameters used to navigate `list` result endpoints
 type NavigationTokens struct {
-	// deserialization only
+	// serialization only
 	Next string `json:"next,omitempty"`
 	Prev string `json:"prev,omitempty"`
 }
@@ -29,11 +29,11 @@ type NavigationTokens struct {
 // Pagination object is used to serialize and deserialize pagination parameters
 // it will populate the `meta` part for the `Response` struct
 type Pagination struct {
-	PageToken string `json:"page_token,omitempty"` // serialization only
+	PageToken string `json:"page_token,omitempty"` // deserialization only
 	Size      int64  `json:"size"`
 	Page      int64  `json:"page"` // to be deprecated
 
-	// deserialization only
+	// serialization only
 	NavigationTokens
 }
 
@@ -51,6 +51,7 @@ func ParsePagination(q url.Values) *Pagination {
 
 	p := NewPaginationWithDefaults()
 
+	// TODO @barco deprecate `page`
 	if page, err := strconv.ParseInt(q.Get("page"), 10, 64); err == nil && page > 1 {
 		p.Page = page
 	}

--- a/pkg/rules/handlers_test.go
+++ b/pkg/rules/handlers_test.go
@@ -82,12 +82,12 @@ func TestHandleListSuccess(t *testing.T) {
 		},
 	}
 
-	var page int64 = 1
+	var offset int64 = 0
 	var size int64 = 100
 
-	mockService.EXPECT().ListRules(gomock.Any(), page, size).Return(serviceOutput, nil)
+	mockService.EXPECT().ListRules(gomock.Any(), offset, size).Return(serviceOutput, nil)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v0/rules?page=1&size=100", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v0/rules?page_token=eyJvZmZzZXQiOjB9&size=100", nil)
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
 	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
@@ -130,10 +130,10 @@ func TestHandleListFailed(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
-	var page int64 = 1
+	var offset int64 = 0
 	var size int64 = 100
 
-	mockService.EXPECT().ListRules(gomock.Any(), page, size).Return(nil, fmt.Errorf("mock_error"))
+	mockService.EXPECT().ListRules(gomock.Any(), offset, size).Return(nil, fmt.Errorf("mock_error"))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v0/rules?page=0&offset=100", nil)
 	w := httptest.NewRecorder()

--- a/pkg/rules/service.go
+++ b/pkg/rules/service.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd
+// Copyright 2024 Canonical Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 
 package rules
@@ -52,14 +52,11 @@ type Service struct {
 	logger  logging.LoggerInterface
 }
 
-func (s *Service) ListRules(ctx context.Context, page, size int64) ([]oathkeeper.Rule, error) {
+func (s *Service) ListRules(ctx context.Context, offset, size int64) ([]oathkeeper.Rule, error) {
 	ctx, span := s.tracer.Start(ctx, "rules.Service.ListRules")
 	defer span.End()
 
-	limit := size
-	offset := (page - 1) * size
-
-	rules, _, err := s.oathkeeper.ListRules(ctx).Limit(limit).Offset(offset).Execute()
+	rules, _, err := s.oathkeeper.ListRules(ctx).Limit(size).Offset(offset).Execute()
 
 	if err != nil {
 		s.logger.Error(err.Error())


### PR DESCRIPTION
## Description
This PR adopts the page_token strategy for pagination of Rules List API, with an encoded offset.

Fixes #268