### PR TITLE
IAM 892 - login handler and authentication middleware implementation according to spec ID036

### DIFF
--- a/OAUTH2.md
+++ b/OAUTH2.md
@@ -10,6 +10,7 @@ OAUTH2_CLIENT_SECRET=client secret
 OAUTH2_REDIRECT_URI=http://localhost:${PORT}/api/v0/auth/callback
 OAUTH2_CODEGRANT_SCOPES=openid,offline_access (defaults to these two, technically two more would be needed: "profile,email")
 OAUTH2_AUTH_COOKIES_ENCRYPTION_KEY="WrfOcYmVBwyduEbKYTUhO4X7XVaOQ1wF" (required, this needs to be exactly 32 bytes in lenght secret key)
+OAUTH2_REFRESHTOKEN_COOKIE_TTL_SECONDS=expiration in seconds for the refresh token cookie, should match the hydra refresh token ttl, (defaults to 21600)
 ACCESS_TOKEN_VERIFICATION_STRATEGY="jwks|userinfo", (defaults to jwks)
 ```
 
@@ -79,7 +80,9 @@ The Hydra client for Admin UI needs to be set with the proper:
 - response types: `"token,code,id_token"`
 - grant types: `"authorization_code,refresh_token"`
 
-If you use the Login UI [docker compose](https://github.com/canonical/identity-platform-login-ui/blob/main/docker-compose.yml) to deploy the solution with Github integration, you can first create an OAuth2
+If you use the Login
+UI [docker compose](https://github.com/canonical/identity-platform-login-ui/blob/main/docker-compose.yml) to deploy the
+solution with Github integration, you can first create an OAuth2
 client.
 Then update it with the correct values, as in the following script:
 

--- a/OAUTH2.md
+++ b/OAUTH2.md
@@ -10,7 +10,7 @@ OAUTH2_CLIENT_SECRET=client secret
 OAUTH2_REDIRECT_URI=http://localhost:${PORT}/api/v0/auth/callback
 OAUTH2_CODEGRANT_SCOPES=openid,offline_access (defaults to these two, technically two more would be needed: "profile,email")
 OAUTH2_AUTH_COOKIES_ENCRYPTION_KEY="WrfOcYmVBwyduEbKYTUhO4X7XVaOQ1wF" (required, this needs to be exactly 32 bytes in lenght secret key)
-OAUTH2_REFRESHTOKEN_COOKIE_TTL_SECONDS=expiration in seconds for the refresh token cookie, should match the hydra refresh token ttl, (defaults to 21600)
+OAUTH2_USER_SESSION_TTL_SECONDS=expiration in seconds for the refresh token cookie, should match the hydra refresh token ttl, (defaults to 21600)
 ACCESS_TOKEN_VERIFICATION_STRATEGY="jwks|userinfo", (defaults to jwks)
 ```
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -146,6 +146,7 @@ func serve() {
 		specs.OAuth2RedirectURI,
 		specs.AccessTokenVerificationStrategy,
 		specs.OAuth2AuthCookiesTTLSeconds,
+		specs.OAuth2UserSessionTTLSeconds,
 		specs.OAuth2AuthCookiesEncryptionKey,
 		specs.OAuth2CodeGrantScopes,
 	)

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -24,15 +24,17 @@ type EnvSpec struct {
 	HydraAdminURL       string `envconfig:"hydra_admin_url" required:"true"`
 	OathkeeperPublicURL string `envconfig:"oathkeeper_public_url" required:"true"`
 
-	AuthenticationEnabled           bool     `envconfig:"authentication_enabled" default:"false" validate:"required"`
-	OIDCIssuer                      string   `envconfig:"oidc_issuer" validate:"required"`
-	OAuth2ClientId                  string   `envconfig:"oauth2_client_id" validate:"required"`
-	OAuth2ClientSecret              string   `envconfig:"oauth2_client_secret" validate:"required"`
-	OAuth2RedirectURI               string   `envconfig:"oauth2_redirect_uri" validate:"required"`
-	OAuth2CodeGrantScopes           []string `envconfig:"oauth2_codegrant_scopes" default:"openid,offline_access" validate:"required"`
-	OAuth2AuthCookiesTTLSeconds     int      `envconfig:"oauth2_auth_cookies_ttl_seconds" default:"300" validate:"required"`
-	OAuth2AuthCookiesEncryptionKey  string   `envconfig:"oauth2_auth_cookies_encryption_key" required:"true" validate:"required,min=32,max=32"`
-	AccessTokenVerificationStrategy string   `envconfig:"access_token_verification_strategy" default:"jwks" validate:"oneof=jwks userinfo"`
+	AuthenticationEnabled       bool     `envconfig:"authentication_enabled" default:"false" validate:"required"`
+	OIDCIssuer                  string   `envconfig:"oidc_issuer" validate:"required"`
+	OAuth2ClientId              string   `envconfig:"oauth2_client_id" validate:"required"`
+	OAuth2ClientSecret          string   `envconfig:"oauth2_client_secret" validate:"required"`
+	OAuth2RedirectURI           string   `envconfig:"oauth2_redirect_uri" validate:"required"`
+	OAuth2CodeGrantScopes       []string `envconfig:"oauth2_codegrant_scopes" default:"openid,offline_access" validate:"required"`
+	OAuth2AuthCookiesTTLSeconds int      `envconfig:"oauth2_auth_cookies_ttl_seconds" default:"300" validate:"required"`
+	OAuth2UserSessionTTLSeconds int      `envconfig:"oauth2_user_session_ttl_seconds" default:"21600" validate:"required"`
+
+	OAuth2AuthCookiesEncryptionKey  string `envconfig:"oauth2_auth_cookies_encryption_key" required:"true" validate:"required,min=32,max=32"`
+	AccessTokenVerificationStrategy string `envconfig:"access_token_verification_strategy" default:"jwks" validate:"oneof=jwks userinfo"`
 
 	IDPConfigMapName      string `envconfig:"idp_configmap_name" required:"true"`
 	IDPConfigMapNamespace string `envconfig:"idp_configmap_namespace" required:"true"`

--- a/pkg/authentication/interfaces.go
+++ b/pkg/authentication/interfaces.go
@@ -6,7 +6,6 @@ package authentication
 import (
 	"context"
 	"net/http"
-	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
@@ -56,17 +55,35 @@ type OAuth2HelperInterface interface {
 
 type AuthCookieManagerInterface interface {
 	// SetNonceCookie sets the nonce cookie on the response with the specified duration as MaxAge
-	SetNonceCookie(http.ResponseWriter, string, time.Duration)
+	SetNonceCookie(http.ResponseWriter, string)
 	// GetNonceCookie returns the string value of the nonce cookie if present, or empty string otherwise
 	GetNonceCookie(*http.Request) string
 	// ClearNonceCookie sets the expiration of the cookie to epoch
 	ClearNonceCookie(http.ResponseWriter)
 	// SetStateCookie  sets the nonce cookie on the response with the specified duration as MaxAge
-	SetStateCookie(http.ResponseWriter, string, time.Duration)
+	SetStateCookie(http.ResponseWriter, string)
 	// GetStateCookie returns the string value of the state cookie if present, or empty string otherwise
 	GetStateCookie(*http.Request) string
 	// ClearStateCookie sets the expiration of the cookie to epoch
 	ClearStateCookie(http.ResponseWriter)
+	// SetIDTokenCookie sets the encrypted ID token value cookie
+	SetIDTokenCookie(http.ResponseWriter, string)
+	// GetIDTokenCookie returns the string value of the ID token cookie if present, or empty string otherwise
+	GetIDTokenCookie(*http.Request) string
+	// ClearIDTokenCookie sets the expiration of the cookie to epoch
+	ClearIDTokenCookie(http.ResponseWriter)
+	// SetAccessTokenCookie sets the encrypted access token value cookie
+	SetAccessTokenCookie(http.ResponseWriter, string)
+	// GetAccessTokenCookie returns the string value of the access token cookie if present, or empty string otherwise
+	GetAccessTokenCookie(*http.Request) string
+	// ClearAccessTokenCookie sets the expiration of the cookie to epoch
+	ClearAccessTokenCookie(http.ResponseWriter)
+	// SetRefreshTokenCookie sets the encrypted refresh token value cookie
+	SetRefreshTokenCookie(http.ResponseWriter, string)
+	// GetRefreshTokenCookie returns the string value of the refresh token cookie if present, or empty string otherwise
+	GetRefreshTokenCookie(*http.Request) string
+	// ClearRefreshTokenCookie sets the expiration of the cookie to epoch
+	ClearRefreshTokenCookie(http.ResponseWriter)
 }
 
 type EncryptInterface interface {

--- a/pkg/authentication/middlewares_test.go
+++ b/pkg/authentication/middlewares_test.go
@@ -6,13 +6,17 @@ package authentication
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/oauth2"
 
 	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
 )
@@ -21,14 +25,34 @@ import (
 //go:generate mockgen -build_flags=--mod=mod -package authentication -destination ./mock_interfaces.go -source=./interfaces.go
 //go:generate mockgen -build_flags=--mod=mod -package authentication -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
 
-func TestMiddleware_OAuth2Authentication(t *testing.T) {
+func TestMiddleware_OAuth2AuthenticationSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	tracer := NewMockTracer(ctrl)
 	logger := NewMockLoggerInterface(ctrl)
+
+	verifier := NewMockTokenVerifier(ctrl)
+	verifier.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).Return(nil, errors.New("mock-error"))
+	verifier.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+
 	oauth2 := NewMockOAuth2ContextInterface(ctrl)
+	oauth2.EXPECT().Verifier().Times(2).Return(verifier)
+
+	cookieManager := NewMockAuthCookieManagerInterface(ctrl)
+	cookieManager.EXPECT().GetIDTokenCookie(gomock.Any()).Return("mock-id-token")
+	cookieManager.EXPECT().GetAccessTokenCookie(gomock.Any()).Return("mock-access-token")
+	cookieManager.EXPECT().GetRefreshTokenCookie(gomock.Any()).Return("mock-refresh-token")
+
+	cookieManager.EXPECT().ClearIDTokenCookie(gomock.Any())
+	cookieManager.EXPECT().ClearAccessTokenCookie(gomock.Any())
+	cookieManager.EXPECT().ClearRefreshTokenCookie(gomock.Any())
 
 	tracer.EXPECT().
-		Start(gomock.Any(), gomock.Eq("authentication.Middleware.OAuth2Authentication")).
+		Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2BearerAuthentication")).
+		Times(2).
+		Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+
+	tracer.EXPECT().
+		Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2CookieAuthentication")).
 		Times(2).
 		Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 
@@ -36,7 +60,7 @@ func TestMiddleware_OAuth2Authentication(t *testing.T) {
 		_, _ = w.Write([]byte("main handler\n"))
 	})
 
-	middleware := NewAuthenticationMiddleware(oauth2, tracer, logger)
+	middleware := NewAuthenticationMiddleware(oauth2, cookieManager, tracer, logger)
 	middleware.SetAllowListedEndpoints("/api/v0/different-mock-key")
 
 	for _, tt := range []struct {
@@ -62,7 +86,7 @@ func TestMiddleware_OAuth2Authentication(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockResponse := httptest.NewRecorder()
 
-			decoratedHandler := middleware.OAuth2Authentication(mainHandler)
+			decoratedHandler := applyMiddlewares(mainHandler, middleware.OAuth2AuthenticationChain()...)
 			decoratedHandler.ServeHTTP(mockResponse, tt.mockRequest)
 
 			result := mockResponse.Result()
@@ -92,4 +116,374 @@ func TestMiddleware_OAuth2Authentication(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMiddleware_OAuth2AuthenticationMiddlewareFailures(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mainHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("main handler\n"))
+	})
+
+	mockRequestNoBearer := httptest.NewRequest(http.MethodGet, "/api/v0/protected", nil)
+
+	mockReqWithBearer := httptest.NewRequest(http.MethodGet, "/api/v0/protected", nil)
+	mockReqWithBearer.Header.Set("Authorization", "Bearer mock-access-token")
+
+	tests := []struct {
+		name       string
+		setupMocks func(*MockAuthCookieManagerInterface, *MockTokenVerifier, *MockOAuth2ContextInterface, *MockLoggerInterface, *MockTracer)
+		request    *http.Request
+		expected   string
+	}{
+		{
+			name:    "NoAuth",
+			request: mockRequestNoBearer,
+			setupMocks: func(c *MockAuthCookieManagerInterface, v *MockTokenVerifier, o *MockOAuth2ContextInterface, l *MockLoggerInterface, t *MockTracer) {
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2BearerAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2CookieAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+
+				c.EXPECT().GetIDTokenCookie(gomock.Any()).Return("")
+				c.EXPECT().GetAccessTokenCookie(gomock.Any()).Return("")
+				c.EXPECT().GetRefreshTokenCookie(gomock.Any()).Return("")
+
+				c.EXPECT().ClearIDTokenCookie(gomock.Any())
+				c.EXPECT().ClearAccessTokenCookie(gomock.Any())
+				c.EXPECT().ClearRefreshTokenCookie(gomock.Any())
+			},
+			expected: "unauthorized: unable to authenticate from either bearer or cookie token, no authentication token found",
+		},
+		{
+			name:    "BearerAuthFailure",
+			request: mockReqWithBearer,
+			setupMocks: func(c *MockAuthCookieManagerInterface, v *MockTokenVerifier, o *MockOAuth2ContextInterface, l *MockLoggerInterface, t *MockTracer) {
+				v.EXPECT().VerifyAccessToken(gomock.Any(), "mock-access-token").
+					Return(nil, errors.New("mock-error"))
+
+				o.EXPECT().Verifier().Times(1).Return(v)
+
+				c.EXPECT().ClearIDTokenCookie(gomock.Any())
+				c.EXPECT().ClearAccessTokenCookie(gomock.Any())
+				c.EXPECT().ClearRefreshTokenCookie(gomock.Any())
+
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2BearerAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			},
+			expected: "unauthorized: mock-error",
+		},
+		{
+			name:    "CookieAuthInvalidIDToken",
+			request: mockRequestNoBearer,
+			setupMocks: func(c *MockAuthCookieManagerInterface, v *MockTokenVerifier, o *MockOAuth2ContextInterface, l *MockLoggerInterface, t *MockTracer) {
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2BearerAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2CookieAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+
+				v.EXPECT().VerifyIDToken(gomock.Any(), "mock-id-token").
+					Times(1).
+					Return(nil, errors.New("mock-error"))
+				v.EXPECT().VerifyAccessToken(gomock.Any(), "mock-access-token").
+					Times(1).
+					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+
+				o.EXPECT().Verifier().Times(2).Return(v)
+
+				c.EXPECT().GetIDTokenCookie(gomock.Any()).Return("mock-id-token")
+				c.EXPECT().GetAccessTokenCookie(gomock.Any()).Return("mock-access-token")
+				c.EXPECT().GetRefreshTokenCookie(gomock.Any()).Return("mock-refresh-token")
+
+				c.EXPECT().ClearIDTokenCookie(gomock.Any())
+				c.EXPECT().ClearAccessTokenCookie(gomock.Any())
+				c.EXPECT().ClearRefreshTokenCookie(gomock.Any())
+			},
+			expected: "unauthorized: unable to authenticate from either bearer or cookie token, mock-error",
+		},
+		{
+			name:    "CookieAuthInvalidAccessToken",
+			request: mockRequestNoBearer,
+			setupMocks: func(c *MockAuthCookieManagerInterface, v *MockTokenVerifier, o *MockOAuth2ContextInterface, l *MockLoggerInterface, t *MockTracer) {
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2BearerAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2CookieAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+
+				v.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).
+					Times(1).
+					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+				v.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).
+					Times(1).
+					Return(nil, errors.New("mock-error"))
+
+				o.EXPECT().Verifier().Times(2).Return(v)
+
+				c.EXPECT().GetIDTokenCookie(gomock.Any()).Return("mock-id-token")
+				c.EXPECT().GetAccessTokenCookie(gomock.Any()).Return("mock-access-token")
+				c.EXPECT().GetRefreshTokenCookie(gomock.Any()).Return("mock-refresh-token")
+
+				c.EXPECT().ClearIDTokenCookie(gomock.Any())
+				c.EXPECT().ClearAccessTokenCookie(gomock.Any())
+				c.EXPECT().ClearRefreshTokenCookie(gomock.Any())
+			},
+			expected: "unauthorized: unable to authenticate from either bearer or cookie token, mock-error",
+		},
+		{
+			name:    "CookieAuthRefreshError",
+			request: mockRequestNoBearer,
+			setupMocks: func(c *MockAuthCookieManagerInterface, v *MockTokenVerifier, o *MockOAuth2ContextInterface, l *MockLoggerInterface, t *MockTracer) {
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2BearerAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2CookieAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+
+				v.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).
+					Times(1).
+					Return(nil, &oidc.TokenExpiredError{})
+				v.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).
+					Times(1).
+					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+
+				o.EXPECT().Verifier().Times(2).Return(v)
+
+				token := &oauth2.Token{
+					AccessToken:  "mock-access-token",
+					TokenType:    "bearer",
+					RefreshToken: "mock-refresh-token",
+				}
+				token = token.WithExtra(map[string]any{"id_token": "mock-id-token"})
+
+				o.EXPECT().RefreshToken(gomock.Any(), "mock-refresh-token").
+					Times(1).
+					Return(nil, errors.New("mock-refresh-error"))
+
+				c.EXPECT().GetIDTokenCookie(gomock.Any()).Return("mock-id-token")
+				c.EXPECT().GetAccessTokenCookie(gomock.Any()).Return("mock-access-token")
+				c.EXPECT().GetRefreshTokenCookie(gomock.Any()).Return("mock-refresh-token")
+
+				c.EXPECT().ClearIDTokenCookie(gomock.Any())
+				c.EXPECT().ClearAccessTokenCookie(gomock.Any())
+				c.EXPECT().ClearRefreshTokenCookie(gomock.Any())
+			},
+			expected: "unauthorized: unable to authenticate from either bearer or cookie token, mock-refresh-error",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			tracer := NewMockTracer(ctrl)
+			logger := NewMockLoggerInterface(ctrl)
+
+			verifier := NewMockTokenVerifier(ctrl)
+			oauth2 := NewMockOAuth2ContextInterface(ctrl)
+
+			cookieManager := NewMockAuthCookieManagerInterface(ctrl)
+
+			tt.setupMocks(cookieManager, verifier, oauth2, logger, tracer)
+
+			middleware := NewAuthenticationMiddleware(oauth2, cookieManager, tracer, logger)
+			m := applyMiddlewares(mainHandler, middleware.OAuth2AuthenticationChain()...)
+
+			mockResponse := httptest.NewRecorder()
+
+			m.ServeHTTP(mockResponse, tt.request)
+
+			response := mockResponse.Result()
+
+			if response.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("expected status does not match, exptected %d, got %d", http.StatusUnauthorized, response.StatusCode)
+			}
+
+			body := response.Body
+			defer body.Close()
+
+			respObj := new(types.Response)
+			_ = json.NewDecoder(body).Decode(respObj)
+
+			if respObj.Status != http.StatusUnauthorized {
+				t.Fatalf("expected status does not match, exptected %d, got %d", http.StatusUnauthorized, respObj.Status)
+			}
+
+			if respObj.Message != tt.expected {
+				t.Fatalf("expected error message does not match, expected %s, got %s", tt.expected, respObj.Message)
+			}
+		})
+	}
+}
+
+func TestMiddleware_OAuth2AuthenticationMiddlewareSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mainHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("main handler\n"))
+	})
+
+	mockReqWithBearer := httptest.NewRequest(http.MethodGet, "/api/v0/protected", nil)
+	mockReqWithBearer.Header.Set("Authorization", "Bearer mock-access-token")
+
+	mockReqWithCookies := httptest.NewRequest(http.MethodGet, "/api/v0/protected", nil)
+
+	mockReqWithCookiesRefresh := httptest.NewRequest(http.MethodGet, "/api/v0/protected", nil)
+
+	tests := []struct {
+		name       string
+		setupMocks func(*MockAuthCookieManagerInterface, *MockTokenVerifier, *MockOAuth2ContextInterface, *MockLoggerInterface, *MockTracer)
+		request    *http.Request
+	}{
+		{
+			name: "BearerAuthSuccess",
+			setupMocks: func(c *MockAuthCookieManagerInterface, v *MockTokenVerifier, o *MockOAuth2ContextInterface, l *MockLoggerInterface, t *MockTracer) {
+				v.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).
+					Times(1).
+					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+
+				o.EXPECT().Verifier().Times(1).Return(v)
+
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2BearerAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2CookieAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			},
+			request: mockReqWithBearer,
+		},
+		{
+			name: "CookieAuthSuccess",
+			setupMocks: func(c *MockAuthCookieManagerInterface, v *MockTokenVerifier, o *MockOAuth2ContextInterface, l *MockLoggerInterface, t *MockTracer) {
+				v.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).
+					Times(1).
+					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+				v.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).
+					Times(1).
+					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+
+				o.EXPECT().Verifier().Times(2).Return(v)
+
+				c.EXPECT().GetIDTokenCookie(gomock.Any()).Return("mock-id-token")
+				c.EXPECT().GetAccessTokenCookie(gomock.Any()).Return("mock-access-token")
+				c.EXPECT().GetRefreshTokenCookie(gomock.Any()).Return("mock-refresh-token")
+
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2BearerAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2CookieAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			},
+			request: mockReqWithCookies,
+		},
+		{
+			name: "CookieAuthRefreshSuccess",
+			setupMocks: func(c *MockAuthCookieManagerInterface, v *MockTokenVerifier, o *MockOAuth2ContextInterface, l *MockLoggerInterface, t *MockTracer) {
+				v.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).
+					Return(nil, nil)
+				v.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).
+					Return(nil, &oidc.TokenExpiredError{})
+
+				o.EXPECT().Verifier().Times(3).Return(v)
+				token := &oauth2.Token{
+					AccessToken:  "mock-access-token",
+					TokenType:    "bearer",
+					RefreshToken: "mock-refresh-token",
+				}
+				token = token.WithExtra(map[string]any{"id_token": "mock-id-token"})
+
+				o.EXPECT().RefreshToken(gomock.Any(), "mock-refresh-token").
+					Times(1).
+					Return(token, nil)
+
+				v.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).
+					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+
+				c.EXPECT().GetIDTokenCookie(gomock.Any()).Return("mock-id-token")
+				c.EXPECT().GetAccessTokenCookie(gomock.Any()).Return("mock-access-token")
+				c.EXPECT().GetRefreshTokenCookie(gomock.Any()).Return("mock-refresh-token")
+
+				c.EXPECT().SetIDTokenCookie(gomock.Any(), "mock-id-token")
+				c.EXPECT().SetAccessTokenCookie(gomock.Any(), "mock-access-token")
+				c.EXPECT().SetRefreshTokenCookie(gomock.Any(), "mock-refresh-token")
+
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2BearerAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+				t.EXPECT().
+					Start(gomock.Any(), gomock.Eq("authentication.Middleware.oAuth2CookieAuthentication")).
+					Times(1).
+					Return(context.TODO(), trace.SpanFromContext(context.TODO()))
+			},
+			request: mockReqWithCookiesRefresh,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			tracer := NewMockTracer(ctrl)
+			logger := NewMockLoggerInterface(ctrl)
+
+			verifier := NewMockTokenVerifier(ctrl)
+			oauth2Ctx := NewMockOAuth2ContextInterface(ctrl)
+
+			cookieManager := NewMockAuthCookieManagerInterface(ctrl)
+
+			tt.setupMocks(cookieManager, verifier, oauth2Ctx, logger, tracer)
+
+			middleware := NewAuthenticationMiddleware(oauth2Ctx, cookieManager, tracer, logger)
+			m := applyMiddlewares(mainHandler, middleware.OAuth2AuthenticationChain()...)
+
+			mockResponse := httptest.NewRecorder()
+
+			m.ServeHTTP(mockResponse, tt.request)
+
+			response := mockResponse.Result()
+
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("expected status does not match, exptected %d, got %d", http.StatusOK, response.StatusCode)
+			}
+
+			body := response.Body
+			defer body.Close()
+
+			stringBytes, _ := io.ReadAll(body)
+
+			expected := "main handler\n"
+			bodyString := string(stringBytes)
+
+			if expected != bodyString {
+				t.Fatalf("expected message does not match, expected %s, got %s", bodyString, expected)
+			}
+		})
+	}
+}
+
+func applyMiddlewares(handler http.Handler, ms ...func(http.Handler) http.Handler) http.Handler {
+	for i := len(ms) - 1; i >= 0; i-- {
+		handler = ms[i](handler)
+	}
+	return handler
 }

--- a/pkg/authentication/oidc.go
+++ b/pkg/authentication/oidc.go
@@ -24,8 +24,15 @@ var (
 )
 
 type Principal struct {
-	Subject string `json:"sub"`
-	Nonce   string `json:"nonce"`
+	Subject   string `json:"sub"`
+	Name      string `json:"name"`
+	Email     string `json:"email"`
+	SessionID string `json:"sid"`
+	Nonce     string `json:"nonce"`
+
+	RawAccessToken  string `json:"-"`
+	RawIdToken      string `json:"-"`
+	RawRefreshToken string `json:"-"`
 }
 
 func NewPrincipalFromClaims(c ReadableClaims) (*Principal, error) {
@@ -50,7 +57,12 @@ func PrincipalFromContext(ctx context.Context) *Principal {
 		return nil
 	}
 
-	return ctx.Value(PrincipalContextKey).(*Principal)
+	value := ctx.Value(PrincipalContextKey)
+	if value == nil {
+		return nil
+	}
+
+	return value.(*Principal)
 }
 
 func OtelHTTPClientContext(ctx context.Context) context.Context {

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -145,7 +145,7 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 		encrypt := authentication.NewEncrypt([]byte(oauth2Config.CookiesEncryptionKey), logger, tracer)
 		cookieManager = authentication.NewAuthCookieManager(
 			oauth2Config.AuthCookieTTLSeconds,
-			oauth2Config.RefreshTokenCookieTTLSeconds,
+			oauth2Config.UserSessionCookieTTLSeconds,
 			encrypt,
 			logger,
 		)
@@ -157,7 +157,7 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 			"/api/v0/status",
 			"/api/v0/metrics",
 		)
-		apiRouter.Use(authenticationMiddleware.OAuth2Authentication)
+		apiRouter.Use(authenticationMiddleware.OAuth2AuthenticationChain()...)
 	}
 
 	if config.payloadValidationEnabled {

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -137,12 +137,22 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 		r.Use(authorizationMiddleware)
 	}).(*chi.Mux)
 
-	var oauth2Context *authentication.OAuth2Context
+	var oauth2Context authentication.OAuth2ContextInterface
+	var cookieManager authentication.AuthCookieManagerInterface
 
 	if oauth2Config.Enabled {
 		oauth2Context = authentication.NewOAuth2Context(config.oauth2, oidc.NewProvider, tracer, logger, monitor)
+		encrypt := authentication.NewEncrypt([]byte(oauth2Config.CookiesEncryptionKey), logger, tracer)
+		cookieManager = authentication.NewAuthCookieManager(
+			oauth2Config.AuthCookieTTLSeconds,
+			oauth2Config.IdTokenCookieTTLSeconds,
+			oauth2Config.AccessTokenCookieTTLSeconds,
+			oauth2Config.RefreshTokenCookieTTLSeconds,
+			encrypt,
+			logger,
+		)
 
-		authenticationMiddleware := authentication.NewAuthenticationMiddleware(oauth2Context, tracer, logger)
+		authenticationMiddleware := authentication.NewAuthenticationMiddleware(oauth2Context, cookieManager, tracer, logger)
 		authenticationMiddleware.SetAllowListedEndpoints(
 			"/api/v0/auth",
 			"/api/v0/auth/callback",
@@ -178,8 +188,14 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 	groupsAPI.RegisterEndpoints(apiRouter)
 
 	if oauth2Config.Enabled {
-		encrypt := authentication.NewEncrypt([]byte(oauth2Config.CookiesEncryptionKey), logger, tracer)
-		login := authentication.NewAPI(oauth2Config.AuthCookieTTLSeconds, oauth2Context, authentication.NewOAuth2Helper(), authentication.NewAuthCookieManager(encrypt, logger), tracer, logger)
+
+		login := authentication.NewAPI(
+			oauth2Context,
+			authentication.NewOAuth2Helper(),
+			cookieManager,
+			tracer,
+			logger,
+		)
 		login.RegisterEndpoints(apiRouter)
 	}
 

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -145,8 +145,6 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 		encrypt := authentication.NewEncrypt([]byte(oauth2Config.CookiesEncryptionKey), logger, tracer)
 		cookieManager = authentication.NewAuthCookieManager(
 			oauth2Config.AuthCookieTTLSeconds,
-			oauth2Config.IdTokenCookieTTLSeconds,
-			oauth2Config.AccessTokenCookieTTLSeconds,
 			oauth2Config.RefreshTokenCookieTTLSeconds,
 			encrypt,
 			logger,


### PR DESCRIPTION
## Description
This PR introduces the middleware functionalities to authenticate invocations via either a bearer token (access token only, no refresh) or ID and access token (with possible refresh in case one of the tokens is expired and a refresh token is available and valid).
This PR also changes the behavior of the callback endpoint which previously returned a json response with three tokens, now redirects to the content of `UIPrefix` as a URL. This needs to be fixed/improved, and I opened the issue to track this - https://github.com/canonical/identity-platform-admin-ui/issues/337.

### Middleware request authentication flow
1. if the request is against an endpoint whose prefix is allowlisted, then no checks are run, otherwise...
2. check for bearer token in the `Authorization` header (CLI use case)
  2.a if available, we rely on that as an access token: if validated we go on, otherwise return 401
3. check for both ID and access tokens (browser user use case)
  3.a if both valid, we validate them and if all good we serve the request, otherwise
  3.b if one of them is not valid and the error is `oidc.TokenExpiredError` we try to refresh
    3.b.1 if refresh is fine then cookies get set again and the request is served 
  3.c if one of them is not valid and the error is **not** a token expired error then return 401
4. if all went well set the Principal in the context and serve the request
5. if anything went wrong return 401 and delete all cookies

**NB**: all encrypted token cookies now rely on the "refresh token" expiration (set via `OAUTH2_REFRESHTOKEN_COOKIE_TTL_SECONDS` env var): reason is that we need id token and access token be set as cookie for longer than their expiration, otherwise we would never get `TokenExpiredError` which is needed to trigger the refresh flow. If for example id token cookie expiration is equal to the token expiration, the backend would not be able to receive the expired token (in the just expired cookie), so the backend would just return a 401 since no cookie would be found on the incoming request.

About cookie attributes, some of them must be explicitly set, that's why we have this:
  ```golang
	Name:     name,
	Value:    encrypted,
	Path:     path,
	Domain:   "",
	Expires:  expires,
	MaxAge:   int(ttl.Seconds()),
	Secure:   true,
	HttpOnly: true,
	SameSite: http.SameSiteLaxMode,
  ```
Also, both `expires` and `max-age` are set to support most browser implementations.



## Changes
- introduced `OAuth2UserSessionCookieTTLSeconds` config
- added methods on Cookie manager with tests to cover them
- Principal object has been expanded on to take advantage of claims coming from the ID token, and also the orignal raw id token, access token and refresh token are kept in the same Principal structure that they generated
- middleware has been expanded along with test coverage