### PR TITLE
Add contextual tuples for global read and admin access

### DIFF
--- a/internal/authorization/admin.go
+++ b/internal/authorization/admin.go
@@ -12,7 +12,8 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
 )
 
-const ADMIN_OBJECT = "privileged:user"
+const PRIVILEGED_RELATION = "privileged"
+const ADMIN_OBJECT = "privileged:superuser"
 
 type AdminAuthorizer struct {
 	client AuthzClientInterface

--- a/internal/authorization/authorization.go
+++ b/internal/authorization/authorization.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
 	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-admin-ui/internal/openfga"
 	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
 )
 
@@ -24,11 +25,11 @@ type Authorizer struct {
 	AdminAuthorizer
 }
 
-func (a *Authorizer) Check(ctx context.Context, user string, relation string, object string) (bool, error) {
+func (a *Authorizer) Check(ctx context.Context, user string, relation string, object string, contextualTuples ...openfga.Tuple) (bool, error) {
 	ctx, span := a.tracer.Start(ctx, "authorization.Authorizer.Check")
 	defer span.End()
 
-	return a.client.Check(ctx, user, relation, object)
+	return a.client.Check(ctx, user, relation, object, contextualTuples...)
 }
 
 func (a *Authorizer) ListObjects(ctx context.Context, user string, relation string, objectType string) ([]string, error) {

--- a/internal/authorization/converters_test.go
+++ b/internal/authorization/converters_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/canonical/identity-platform-admin-ui/internal/openfga"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -30,14 +31,28 @@ func TestIdentityConverterMapReturnsPermissions(t *testing.T) {
 			name:  "GET /api/v0/identities",
 			input: input{method: http.MethodGet, endpoint: "/api/v0/identities"},
 			output: []Permission{
-				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "global")},
+				{
+					Relation:   CAN_VIEW,
+					ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", IDENTITY_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", IDENTITY_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{
 			name:  "POST /api/v0/identities",
 			input: input{method: http.MethodPost, endpoint: "/api/v0/identities"},
 			output: []Permission{
-				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "global")},
+				{
+					Relation:   CAN_CREATE,
+					ResourceID: fmt.Sprintf("%s:%s", IDENTITY_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", IDENTITY_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", IDENTITY_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{
@@ -97,14 +112,28 @@ func TestClientConverterMapReturnsPermissions(t *testing.T) {
 			name:  "GET /api/v0/clients",
 			input: input{method: http.MethodGet, endpoint: "/api/v0/clients"},
 			output: []Permission{
-				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", CLIENT_TYPE, "global")},
+				{
+					Relation:   CAN_VIEW,
+					ResourceID: fmt.Sprintf("%s:%s", CLIENT_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", CLIENT_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", CLIENT_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{
 			name:  "POST /api/v0/clients",
 			input: input{method: http.MethodPost, endpoint: "/api/v0/clients"},
 			output: []Permission{
-				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", CLIENT_TYPE, "global")},
+				{
+					Relation:   CAN_CREATE,
+					ResourceID: fmt.Sprintf("%s:%s", CLIENT_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", CLIENT_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", CLIENT_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{
@@ -142,7 +171,7 @@ func TestClientConverterMapReturnsPermissions(t *testing.T) {
 			result := new(ClientConverter).Map(r)
 
 			if !reflect.DeepEqual(result, test.output) {
-				t.Errorf("Map returned %v", result)
+				t.Errorf("Map returned %v, expected %v", result, test.output)
 			}
 		})
 	}
@@ -164,14 +193,28 @@ func TestProviderConverterMapReturnsPermissions(t *testing.T) {
 			name:  "GET /api/v0/idps",
 			input: input{method: http.MethodGet, endpoint: "/api/v0/idps"},
 			output: []Permission{
-				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", PROVIDER_TYPE, "global")},
+				{
+					Relation:   CAN_VIEW,
+					ResourceID: fmt.Sprintf("%s:%s", PROVIDER_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", PROVIDER_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", PROVIDER_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{
 			name:  "POST /api/v0/idps",
 			input: input{method: http.MethodPost, endpoint: "/api/v0/idps"},
 			output: []Permission{
-				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", PROVIDER_TYPE, "global")},
+				{
+					Relation:   CAN_CREATE,
+					ResourceID: fmt.Sprintf("%s:%s", PROVIDER_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", PROVIDER_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", PROVIDER_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{
@@ -231,14 +274,28 @@ func TestRuleConverterMapReturnsPermissions(t *testing.T) {
 			name:  "GET /api/v0/rules",
 			input: input{method: http.MethodGet, endpoint: "/api/v0/rules"},
 			output: []Permission{
-				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", RULE_TYPE, "global")},
+				{
+					Relation:   CAN_VIEW,
+					ResourceID: fmt.Sprintf("%s:%s", RULE_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", RULE_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", RULE_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{
 			name:  "POST /api/v0/rules",
 			input: input{method: http.MethodPost, endpoint: "/api/v0/rules"},
 			output: []Permission{
-				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", RULE_TYPE, "global")},
+				{
+					Relation:   CAN_CREATE,
+					ResourceID: fmt.Sprintf("%s:%s", RULE_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", RULE_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", RULE_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{
@@ -298,14 +355,28 @@ func TestSchemeConverterMapReturnsPermissions(t *testing.T) {
 			name:  "GET /api/v0/schemas",
 			input: input{method: http.MethodGet, endpoint: "/api/v0/schemas"},
 			output: []Permission{
-				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", SCHEME_TYPE, "global")},
+				{
+					Relation:   CAN_VIEW,
+					ResourceID: fmt.Sprintf("%s:%s", SCHEME_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", SCHEME_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", SCHEME_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{
 			name:  "POST /api/v0/schemas",
 			input: input{method: http.MethodPost, endpoint: "/api/v0/schemas"},
 			output: []Permission{
-				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", SCHEME_TYPE, "global")},
+				{
+					Relation:   CAN_CREATE,
+					ResourceID: fmt.Sprintf("%s:%s", SCHEME_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", SCHEME_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", SCHEME_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{
@@ -381,14 +452,28 @@ func TestRoleConverterMapReturnsPermissions(t *testing.T) {
 			name:  "GET /api/v0/roles",
 			input: input{method: http.MethodGet, endpoint: "/api/v0/roles"},
 			output: []Permission{
-				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "global")},
+				{
+					Relation:   CAN_VIEW,
+					ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", ROLE_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", ROLE_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{
 			name:  "POST /api/v0/roles",
 			input: input{method: http.MethodPost, endpoint: "/api/v0/roles"},
 			output: []Permission{
-				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "global")},
+				{
+					Relation:   CAN_CREATE,
+					ResourceID: fmt.Sprintf("%s:%s", ROLE_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", ROLE_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", ROLE_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{
@@ -482,14 +567,28 @@ func TestGroupConverterMapReturnsPermissions(t *testing.T) {
 			name:  "GET /api/v0/groups",
 			input: input{method: http.MethodGet, endpoint: "/api/v0/groups"},
 			output: []Permission{
-				{Relation: CAN_VIEW, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "global")},
+				{
+					Relation:   CAN_VIEW,
+					ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", GROUP_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", GROUP_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{
 			name:  "POST /api/v0/groups",
 			input: input{method: http.MethodPost, endpoint: "/api/v0/groups"},
 			output: []Permission{
-				{Relation: CAN_CREATE, ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "global")},
+				{
+					Relation:   CAN_CREATE,
+					ResourceID: fmt.Sprintf("%s:%s", GROUP_TYPE, "__system__global"),
+					ContextualTuples: []openfga.Tuple{
+						*openfga.NewTuple("user:*", CAN_VIEW, fmt.Sprintf("%s:%s", GROUP_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+						*openfga.NewTuple("privileged:superuser", "privileged", fmt.Sprintf("%s:%s", GROUP_TYPE, GLOBAL_ACCESS_OBJECT_NAME)),
+					},
+				},
 			},
 		},
 		{

--- a/internal/authorization/interfaces.go
+++ b/internal/authorization/interfaces.go
@@ -6,19 +6,20 @@ package authorization
 import (
 	"context"
 
+	"github.com/canonical/identity-platform-admin-ui/internal/openfga"
 	fga "github.com/openfga/go-sdk"
 )
 
 type AuthorizerInterface interface {
 	ListObjects(context.Context, string, string, string) ([]string, error)
-	Check(context.Context, string, string, string) (bool, error)
+	Check(context.Context, string, string, string, ...openfga.Tuple) (bool, error)
 	FilterObjects(context.Context, string, string, string, []string) ([]string, error)
 	ValidateModel(context.Context) error
 }
 
 type AuthzClientInterface interface {
 	ListObjects(context.Context, string, string, string) ([]string, error)
-	Check(context.Context, string, string, string) (bool, error)
+	Check(context.Context, string, string, string, ...openfga.Tuple) (bool, error)
 	ReadModel(context.Context) (*fga.AuthorizationModel, error)
 	CompareModel(context.Context, fga.AuthorizationModel) (bool, error)
 	WriteTuple(ctx context.Context, user, relation, object string) error

--- a/internal/authorization/middlewares.go
+++ b/internal/authorization/middlewares.go
@@ -116,7 +116,9 @@ func (mdw *Middleware) check(ctx context.Context, userID string, r *http.Request
 
 	// TODO @shipperizer implement BatchCheck
 	for _, permission := range mdw.mapper(r) {
-		authorized, err := mdw.auth.Check(ctx, userID, permission.Relation, permission.ResourceID)
+		authorized, err := mdw.auth.Check(
+			ctx, userID, permission.Relation, permission.ResourceID, permission.ContextualTuples...,
+		)
 
 		select {
 		case <-ctx.Done():

--- a/internal/openfga/client.go
+++ b/internal/openfga/client.go
@@ -219,15 +219,24 @@ func (c *Client) DeleteTuples(ctx context.Context, tuples ...Tuple) error {
 // ########################## Write Operations #######################################
 
 // ########################## Check Operations #######################################
-func (c *Client) Check(ctx context.Context, user, relation, object string) (bool, error) {
+func (c *Client) Check(ctx context.Context, user, relation, object string, tuples ...Tuple) (bool, error) {
 	ctx, span := c.tracer.Start(ctx, "openfga.Client.Check")
 	defer span.End()
 
+	contextualTuples := make([]client.ClientContextualTupleKey, len(tuples))
+	for i, t := range tuples {
+		contextualTuples[i] = client.ClientContextualTupleKey{
+			User:     t.User,
+			Relation: t.Relation,
+			Object:   t.Object,
+		}
+	}
 	r := c.c.Check(ctx)
 	body := client.ClientCheckRequest{
-		User:     user,
-		Relation: relation,
-		Object:   object,
+		User:             user,
+		Relation:         relation,
+		Object:           object,
+		ContextualTuples: contextualTuples,
 	}
 
 	r = r.Body(body)

--- a/internal/openfga/noop.go
+++ b/internal/openfga/noop.go
@@ -34,7 +34,7 @@ func (c *NoopClient) ListObjects(ctx context.Context, user, relation, objectType
 	return make([]string, 0), nil
 }
 
-func (c *NoopClient) Check(ctx context.Context, user, relation, object string) (bool, error) {
+func (c *NoopClient) Check(ctx context.Context, user, relation, object string, tuples ...Tuple) (bool, error) {
 	return true, nil
 }
 

--- a/pkg/groups/interfaces.go
+++ b/pkg/groups/interfaces.go
@@ -34,5 +34,5 @@ type OpenFGAClientInterface interface {
 	ReadTuples(context.Context, string, string, string, string) (*client.ClientReadResponse, error)
 	WriteTuples(context.Context, ...ofga.Tuple) error
 	DeleteTuples(context.Context, ...ofga.Tuple) error
-	Check(context.Context, string, string, string) (bool, error)
+	Check(context.Context, string, string, string, ...ofga.Tuple) (bool, error)
 }

--- a/pkg/roles/interfaces.go
+++ b/pkg/roles/interfaces.go
@@ -29,5 +29,5 @@ type OpenFGAClientInterface interface {
 	ReadTuples(context.Context, string, string, string, string) (*client.ClientReadResponse, error)
 	WriteTuples(context.Context, ...ofga.Tuple) error
 	DeleteTuples(context.Context, ...ofga.Tuple) error
-	Check(context.Context, string, string, string) (bool, error)
+	Check(context.Context, string, string, string, ...ofga.Tuple) (bool, error)
 }

--- a/pkg/web/interfaces.go
+++ b/pkg/web/interfaces.go
@@ -22,7 +22,7 @@ type OpenFGAClientInterface interface {
 	CompareModel(context.Context, fga.AuthorizationModel) (bool, error)
 	WriteTuple(context.Context, string, string, string) error
 	DeleteTuple(context.Context, string, string, string) error
-	Check(context.Context, string, string, string) (bool, error)
+	Check(context.Context, string, string, string, ...ofga.Tuple) (bool, error)
 	ListObjects(context.Context, string, string, string) ([]string, error)
 	WriteTuples(context.Context, ...ofga.Tuple) error
 	DeleteTuples(context.Context, ...ofga.Tuple) error


### PR DESCRIPTION
IAM-910

- Prefix the global object
- Use contextual tuples so that logic for global read and admin access is not persisted to openfga

One issue that we need to look into is that users will be able to create a role or a group called `__system__global` and it will collide with our tuples. One way around this is to add a check either on the roles/groups API or on the openfga module to prevent writes and deleted of objects that start with the system prefix. I can work on this on this PR or I can create an issue (I prefer the latter).

Once this PR is merged, we will no longer need to add the tuples with `<resource>:global` to openfga. I will remove them from the wiki.

I have tested it manually, but please take some time to test it yourselves as I might have missed some functionality.

Closes #290 