### PR TITLE
IAM 887 Add `/auth/me` endpoint to retrieve info about currently logged user

### DIFF
--- a/pkg/authentication/middlewares.go
+++ b/pkg/authentication/middlewares.go
@@ -40,12 +40,8 @@ func (m *Middleware) SetAllowListedEndpoints(endpointsPrefixes ...string) {
 
 func (m *Middleware) isAllowListed(r *http.Request) bool {
 	endpoint := r.URL.Path
-	for prefix, _ := range m.allowListedEndpoints {
-		if strings.HasPrefix(endpoint, prefix) {
-			return true
-		}
-	}
-	return false
+	_, ok := m.allowListedEndpoints[endpoint]
+	return ok
 }
 
 func (m *Middleware) OAuth2AuthenticationChain() []func(http.Handler) http.Handler {


### PR DESCRIPTION
## Description
This PR builds on top of #338 , so it will need a rebase after that one is merged.
It introduces a simple `me` handler to allow clients to retrieve info about the currently logged user.
This is useful for frontend applications which can rely on this endpoint to know who is the user that is currently logged in.

## Changes
- `isAllowListed` method now relies on an exact match for it's matching strategy, leaving the previous prefix based matching behind
- `nonce` field is now ignored when serializing the `Principal` struct