### PR TITLE
IAM 889 Implement logout feature

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -71,8 +71,9 @@ func serve() {
 		logger.Fatalf("issue with ui files %s", err)
 	}
 
+	hydraAdminClient := ih.NewClient(specs.HydraAdminURL, specs.Debug)
 	externalConfig := web.NewExternalClientsConfig(
-		ih.NewClient(specs.HydraAdminURL, specs.Debug),
+		hydraAdminClient,
 		ik.NewClient(specs.KratosAdminURL, specs.Debug),
 		ik.NewClient(specs.KratosPublicURL, specs.Debug),
 		io.NewClient(specs.OathkeeperPublicURL, specs.Debug),
@@ -149,6 +150,8 @@ func serve() {
 		specs.OAuth2UserSessionTTLSeconds,
 		specs.OAuth2AuthCookiesEncryptionKey,
 		specs.OAuth2CodeGrantScopes,
+		ih.NewClient(specs.OIDCIssuer, specs.Debug),
+		hydraAdminClient,
 	)
 
 	ollyConfig := web.NewO11yConfig(tracer, monitor, logger)

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -19,8 +19,9 @@ type EnvSpec struct {
 
 	KubeconfigFile string `envconfig:"kubeconfig_file"`
 
-	KratosPublicURL     string `envconfig:"kratos_public_url" required:"true"`
-	KratosAdminURL      string `envconfig:"kratos_admin_url" required:"true"`
+	KratosPublicURL string `envconfig:"kratos_public_url" required:"true"`
+	KratosAdminURL  string `envconfig:"kratos_admin_url" required:"true"`
+	// with no slash suffix
 	HydraAdminURL       string `envconfig:"hydra_admin_url" required:"true"`
 	OathkeeperPublicURL string `envconfig:"oathkeeper_public_url" required:"true"`
 

--- a/pkg/authentication/cookies.go
+++ b/pkg/authentication/cookies.go
@@ -11,12 +11,13 @@ import (
 )
 
 const (
-	authCookiePath  = "/api/v0/auth/callback"
-	nonceCookieName = "nonce"
-	stateCookieName = "state"
-	itCookieName    = "id-token"
-	atCookieName    = "access-token"
-	rtCookieName    = "refresh-token"
+	defaultCookiePath = "/"
+	authCookiePath    = "/api/v0/auth/callback"
+	nonceCookieName   = "nonce"
+	stateCookieName   = "state"
+	itCookieName      = "id-token"
+	atCookieName      = "access-token"
+	rtCookieName      = "refresh-token"
 )
 
 var (
@@ -32,7 +33,7 @@ type AuthCookieManager struct {
 }
 
 func (a *AuthCookieManager) SetIDTokenCookie(w http.ResponseWriter, rawIDToken string) {
-	a.setCookie(w, itCookieName, rawIDToken, "/", a.userSessionCookieTTL)
+	a.setCookie(w, itCookieName, rawIDToken, defaultCookiePath, a.userSessionCookieTTL)
 }
 
 func (a *AuthCookieManager) GetIDTokenCookie(r *http.Request) string {
@@ -40,11 +41,11 @@ func (a *AuthCookieManager) GetIDTokenCookie(r *http.Request) string {
 }
 
 func (a *AuthCookieManager) ClearIDTokenCookie(w http.ResponseWriter) {
-	a.clearCookie(w, itCookieName)
+	a.clearCookie(w, itCookieName, defaultCookiePath)
 }
 
 func (a *AuthCookieManager) SetAccessTokenCookie(w http.ResponseWriter, rawAccessToken string) {
-	a.setCookie(w, atCookieName, rawAccessToken, "/", a.userSessionCookieTTL)
+	a.setCookie(w, atCookieName, rawAccessToken, defaultCookiePath, a.userSessionCookieTTL)
 }
 
 func (a *AuthCookieManager) GetAccessTokenCookie(r *http.Request) string {
@@ -52,11 +53,11 @@ func (a *AuthCookieManager) GetAccessTokenCookie(r *http.Request) string {
 }
 
 func (a *AuthCookieManager) ClearAccessTokenCookie(w http.ResponseWriter) {
-	a.clearCookie(w, atCookieName)
+	a.clearCookie(w, atCookieName, defaultCookiePath)
 }
 
 func (a *AuthCookieManager) SetRefreshTokenCookie(w http.ResponseWriter, rawRefreshToken string) {
-	a.setCookie(w, rtCookieName, rawRefreshToken, "/", a.userSessionCookieTTL)
+	a.setCookie(w, rtCookieName, rawRefreshToken, defaultCookiePath, a.userSessionCookieTTL)
 }
 
 func (a *AuthCookieManager) GetRefreshTokenCookie(r *http.Request) string {
@@ -64,7 +65,7 @@ func (a *AuthCookieManager) GetRefreshTokenCookie(r *http.Request) string {
 }
 
 func (a *AuthCookieManager) ClearRefreshTokenCookie(w http.ResponseWriter) {
-	a.clearCookie(w, rtCookieName)
+	a.clearCookie(w, rtCookieName, defaultCookiePath)
 }
 
 func (a *AuthCookieManager) SetNonceCookie(w http.ResponseWriter, nonce string) {
@@ -76,7 +77,7 @@ func (a *AuthCookieManager) GetNonceCookie(r *http.Request) string {
 }
 
 func (a *AuthCookieManager) ClearNonceCookie(w http.ResponseWriter) {
-	a.clearCookie(w, nonceCookieName)
+	a.clearCookie(w, nonceCookieName, authCookiePath)
 }
 
 func (a *AuthCookieManager) SetStateCookie(w http.ResponseWriter, state string) {
@@ -88,7 +89,7 @@ func (a *AuthCookieManager) GetStateCookie(r *http.Request) string {
 }
 
 func (a *AuthCookieManager) ClearStateCookie(w http.ResponseWriter) {
-	a.clearCookie(w, stateCookieName)
+	a.clearCookie(w, stateCookieName, authCookiePath)
 }
 
 func (a *AuthCookieManager) setCookie(w http.ResponseWriter, name, value string, path string, ttl time.Duration) {
@@ -117,8 +118,18 @@ func (a *AuthCookieManager) setCookie(w http.ResponseWriter, name, value string,
 	})
 }
 
-func (a *AuthCookieManager) clearCookie(w http.ResponseWriter, name string) {
-	http.SetCookie(w, &http.Cookie{Name: name, Expires: epoch, MaxAge: -1})
+func (a *AuthCookieManager) clearCookie(w http.ResponseWriter, name string, path string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     path,
+		Domain:   "",
+		Expires:  epoch,
+		MaxAge:   -1,
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
 }
 
 func (a *AuthCookieManager) getCookie(r *http.Request, name string) string {

--- a/pkg/authentication/handlers.go
+++ b/pkg/authentication/handlers.go
@@ -12,8 +12,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
+	"github.com/canonical/identity-platform-admin-ui/internal/hydra"
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
 	"github.com/canonical/identity-platform-admin-ui/internal/validation"
+	"github.com/canonical/identity-platform-admin-ui/pkg/clients"
 	"github.com/canonical/identity-platform-admin-ui/pkg/ui"
 )
 
@@ -23,19 +25,28 @@ const (
 )
 
 type Config struct {
-	Enabled                     bool     `validate:"required,boolean"`
-	AuthCookieTTLSeconds        int      `validate:"required"`
-	UserSessionCookieTTLSeconds int      `validate:"required"`
-	CookiesEncryptionKey        string   `validate:"required,min=32,max=32"`
-	issuer                      string   `validate:"required"`
-	clientID                    string   `validate:"required"`
-	clientSecret                string   `validate:"required"`
-	redirectURL                 string   `validate:"required"`
-	verificationStrategy        string   `validate:"required,oneof=jwks userinfo"`
-	scopes                      []string `validate:"required,dive,required"`
+	Enabled                     bool                         `validate:"required,boolean"`
+	AuthCookieTTLSeconds        int                          `validate:"required"`
+	UserSessionCookieTTLSeconds int                          `validate:"required"`
+	CookiesEncryptionKey        string                       `validate:"required,min=32,max=32"`
+	issuer                      string                       `validate:"required"`
+	clientID                    string                       `validate:"required"`
+	clientSecret                string                       `validate:"required"`
+	redirectURL                 string                       `validate:"required"`
+	verificationStrategy        string                       `validate:"required,oneof=jwks userinfo"`
+	scopes                      []string                     `validate:"required,dive,required"`
+	hydraPublicAPIClient        clients.HydraClientInterface `validate:"required"`
+	hydraAdminAPIClient         clients.HydraClientInterface `validate:"required"`
 }
 
-func NewAuthenticationConfig(enabled bool, issuer, clientID, clientSecret, redirectURL, verificationStrategy string, authCookiesTTLSeconds, userSessionCookieTTLSeconds int, cookiesEncryptionKey string, scopes []string) *Config {
+func NewAuthenticationConfig(
+	enabled bool,
+	issuer, clientID, clientSecret, redirectURL, verificationStrategy string,
+	authCookiesTTLSeconds, userSessionCookieTTLSeconds int,
+	cookiesEncryptionKey string,
+	scopes []string,
+	hydraPublicAPIClient, hydraAdminAPIClient *hydra.Client,
+) *Config {
 	c := new(Config)
 	c.Enabled = enabled
 	c.CookiesEncryptionKey = cookiesEncryptionKey
@@ -49,6 +60,8 @@ func NewAuthenticationConfig(enabled bool, issuer, clientID, clientSecret, redir
 	c.AuthCookieTTLSeconds = authCookiesTTLSeconds
 	c.UserSessionCookieTTLSeconds = userSessionCookieTTLSeconds
 
+	c.hydraPublicAPIClient = hydraPublicAPIClient
+	c.hydraAdminAPIClient = hydraAdminAPIClient
 	return c
 }
 

--- a/pkg/authentication/interfaces.go
+++ b/pkg/authentication/interfaces.go
@@ -41,6 +41,8 @@ type OAuth2ContextInterface interface {
 	RetrieveTokens(context.Context, string) (*oauth2.Token, error)
 	// RefreshToken performs the OAuth2 refresh_token grant
 	RefreshToken(context.Context, string) (*oauth2.Token, error)
+	// Logout performs session and tokens revocation against the Hydra Admin APIs
+	Logout(ctx context.Context, principal *Principal) error
 }
 
 type ReadableClaims interface {
@@ -91,4 +93,8 @@ type EncryptInterface interface {
 	Encrypt(string) (string, error)
 	// Decrypt a hex string, returns the decrypted string or an error
 	Decrypt(string) (string, error)
+}
+
+type HTTPClientInterface interface {
+	Do(*http.Request) (*http.Response, error)
 }

--- a/pkg/authentication/oidc.go
+++ b/pkg/authentication/oidc.go
@@ -57,16 +57,29 @@ func PrincipalFromContext(ctx context.Context) *Principal {
 		return nil
 	}
 
-	value := ctx.Value(PrincipalContextKey)
-	if value == nil {
-		return nil
+	if value, ok := ctx.Value(PrincipalContextKey).(*Principal); ok {
+		return value
 	}
 
-	return value.(*Principal)
+	return nil
 }
 
 func OtelHTTPClientContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, oauth2.HTTPClient, otelHTTPClient)
+}
+
+func HTTPClientFromContext(ctx context.Context) *http.Client {
+	client := http.DefaultClient
+
+	if ctx == nil {
+		return client
+	}
+
+	if c, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
+		client = c
+	}
+
+	return client
 }
 
 type OIDCProviderSupplier = func(ctx context.Context, issuer string) (*oidc.Provider, error)

--- a/pkg/authentication/oidc.go
+++ b/pkg/authentication/oidc.go
@@ -85,9 +85,10 @@ func HTTPClientFromContext(ctx context.Context) *http.Client {
 type OIDCProviderSupplier = func(ctx context.Context, issuer string) (*oidc.Provider, error)
 
 type OAuth2Context struct {
-	hydraAdminURL string
-	client        *oauth2.Config
-	verifier      TokenVerifier
+	client      *oauth2.Config
+	verifier    TokenVerifier
+	hydraAdmin  clients.HydraClientInterface
+	hydraPublic clients.HydraClientInterface
 
 	tracer  trace.Tracer
 	logger  logging.LoggerInterface
@@ -155,7 +156,8 @@ func NewOAuth2Context(config *Config, getProvider OIDCProviderSupplier, tracer t
 		Scopes:   config.scopes,
 	}
 
-	o.hydraAdminURL = config.hydraAdminURL
+	o.hydraAdmin = config.hydraAdminAPIClient
+	o.hydraPublic = config.hydraPublicAPIClient
 
 	return o
 }

--- a/pkg/authentication/oidc.go
+++ b/pkg/authentication/oidc.go
@@ -72,8 +72,9 @@ func OtelHTTPClientContext(ctx context.Context) context.Context {
 type OIDCProviderSupplier = func(ctx context.Context, issuer string) (*oidc.Provider, error)
 
 type OAuth2Context struct {
-	client   *oauth2.Config
-	verifier TokenVerifier
+	hydraAdminURL string
+	client        *oauth2.Config
+	verifier      TokenVerifier
 
 	tracer  trace.Tracer
 	logger  logging.LoggerInterface
@@ -140,6 +141,8 @@ func NewOAuth2Context(config *Config, getProvider OIDCProviderSupplier, tracer t
 		Endpoint: provider.Endpoint(),
 		Scopes:   config.scopes,
 	}
+
+	o.hydraAdminURL = config.hydraAdminURL
 
 	return o
 }


### PR DESCRIPTION
## Description
Adds the logout handler `/api/v0/auth/logout` which does two things mainly
- deletes the hydra session (in case the Principal is a browser user, otherwise no session info is availble for CLI)
- revokes the refresh token (if present, access token otherwise) so they cannot be used anymore

Of course it also deletes the encrypted auth cookies.

Hydra admin url is used for the revoke session API invocation, here we rely on hydra implementation of this so I made explicit reference to hydra url since there is no need to keep it generic. In case we ever change from Hydra to another OIDC provider, we'll have to switch the logout implementation anyway.

This PR also fixes cookie deletion for the cookie manager, since a bug was present and it slipped in the PR it introduced it.

**NB**: The revoke token API invocation is based on the fact that the token endpoint auth method is set to client-secret-basic at client creation (against Hydra), and this is set in the admin-ui-operator right [here](https://github.com/canonical/identity-platform-admin-ui-operator/blob/cbef94404f00055034412e34c357faa6758b2cd9/lib/charms/hydra/v0/oauth.py#L271).
If we ever change client-authentication to `client-secret-post`, this will mean that we will have to add client id and secret to the revoke token request body. I don't see a reason why we would do that, but the info is here for posterity.

This PR will benefit from solving issue #337 , which will be worked on right after this.