### PR TITLE
IAM 933 - Fix UI serving and implement `next` param passing for FE deep redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is the Admin UI for the Canonical Identity Platform.
   to `error`
 - `LOG_FILE`: file where to dump logs, defaults to `log.txt`
 - `PORT`: http server port, defaults to `8080`
-- `BASE_URL`: the base url that the application will be running on, needed if the application runs under a path
+- `CONTEXT_PATH`: the context path that the application will be served on, needed to perform redirection correctly
 - `DEBUG`: debugging flag for hydra and kratos clients
 - `KUBECONFIG_FILE`: optional path of kube config file, default to empty string
 - `KRATOS_PUBLIC_URL`: Kratos public endpoints address

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -122,8 +122,7 @@ func serve() {
 	rulesConfig := rules.NewConfig(specs.RulesConfigMapName, specs.RulesConfigFileName, specs.RulesConfigMapNamespace, k8sCoreV1, externalConfig.OathkeeperPublic().ApiApi())
 
 	uiConfig := &ui.Config{
-		DistFS:  distFS,
-		BaseURL: specs.BaseURL,
+		DistFS: distFS,
 	}
 
 	if specs.AuthorizationEnabled {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -155,7 +155,7 @@ func serve() {
 
 	ollyConfig := web.NewO11yConfig(tracer, monitor, logger)
 
-	routerConfig := web.NewRouterConfig(specs.PayloadValidationEnabled, idpConfig, schemasConfig, rulesConfig, uiConfig, externalConfig, oauth2Config, ollyConfig)
+	routerConfig := web.NewRouterConfig(specs.ContextPath, specs.PayloadValidationEnabled, idpConfig, schemasConfig, rulesConfig, uiConfig, externalConfig, oauth2Config, ollyConfig)
 
 	wpool := pool.NewWorkerPool(specs.OpenFGAWorkersTotal, tracer, monitor, logger)
 	defer wpool.Stop()

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -12,7 +12,8 @@ type EnvSpec struct {
 	LogLevel string `envconfig:"log_level" default:"error"`
 	LogFile  string `envconfig:"log_file" default:"log.txt"`
 
-	Port int `envconfig:"port" default:"8080"`
+	Port        int    `envconfig:"port" default:"8080"`
+	ContextPath string `envconfig:"context_path" default:"/"`
 
 	Debug bool `envconfig:"debug" default:"false"`
 

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -12,8 +12,7 @@ type EnvSpec struct {
 	LogLevel string `envconfig:"log_level" default:"error"`
 	LogFile  string `envconfig:"log_file" default:"log.txt"`
 
-	Port    int    `envconfig:"port" default:"8080"`
-	BaseURL string `envconfig:"base_url" default:""`
+	Port int `envconfig:"port" default:"8080"`
 
 	Debug bool `envconfig:"debug" default:"false"`
 

--- a/pkg/authentication/cookies.go
+++ b/pkg/authentication/cookies.go
@@ -15,6 +15,7 @@ const (
 	authCookiePath    = "/api/v0/auth/callback"
 	nonceCookieName   = "nonce"
 	stateCookieName   = "state"
+	nextToCookieName  = "nextTo"
 	itCookieName      = "id-token"
 	atCookieName      = "access-token"
 	rtCookieName      = "refresh-token"
@@ -90,6 +91,18 @@ func (a *AuthCookieManager) GetStateCookie(r *http.Request) string {
 
 func (a *AuthCookieManager) ClearStateCookie(w http.ResponseWriter) {
 	a.clearCookie(w, stateCookieName, authCookiePath)
+}
+
+func (a *AuthCookieManager) SetNextToCookie(w http.ResponseWriter, next string) {
+	a.setCookie(w, nextToCookieName, next, authCookiePath, a.authCookiesTTL)
+}
+
+func (a *AuthCookieManager) GetNextToCookie(r *http.Request) string {
+	return a.getCookie(r, nextToCookieName)
+}
+
+func (a *AuthCookieManager) ClearNextToCookie(w http.ResponseWriter) {
+	a.clearCookie(w, nextToCookieName, authCookiePath)
 }
 
 func (a *AuthCookieManager) setCookie(w http.ResponseWriter, name, value string, path string, ttl time.Duration) {

--- a/pkg/authentication/cookies.go
+++ b/pkg/authentication/cookies.go
@@ -135,7 +135,6 @@ func (a *AuthCookieManager) clearCookie(w http.ResponseWriter, name string, path
 func (a *AuthCookieManager) getCookie(r *http.Request, name string) string {
 	cookie, err := r.Cookie(name)
 	if err != nil {
-		a.logger.Errorf("can't get cookie %s, %v", name, err)
 		return ""
 	}
 

--- a/pkg/authentication/cookies_test.go
+++ b/pkg/authentication/cookies_test.go
@@ -154,7 +154,6 @@ func TestAuthCookieManager_GetNonceCookieFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockLogger := NewMockLoggerInterface(ctrl)
-	mockLogger.EXPECT().Errorf("can't get cookie %s, %v", "nonce", gomock.Any()).Times(1)
 	mockRequest := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	manager := NewAuthCookieManager(5, 5, nil, mockLogger)
@@ -208,7 +207,6 @@ func TestAuthCookieManager_GetStateCookieFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockLogger := NewMockLoggerInterface(ctrl)
-	mockLogger.EXPECT().Errorf("can't get cookie %s, %v", "state", gomock.Any()).Times(1)
 	mockRequest := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	manager := NewAuthCookieManager(5, 5, nil, mockLogger)
@@ -262,7 +260,6 @@ func TestAuthCookieManager_GetIDTokenCookieFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockLogger := NewMockLoggerInterface(ctrl)
-	mockLogger.EXPECT().Errorf("can't get cookie %s, %v", "id-token", gomock.Any()).Times(1)
 	mockRequest := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	manager := NewAuthCookieManager(5, 5, nil, mockLogger)
@@ -316,7 +313,6 @@ func TestAuthCookieManager_GetAccessTokenCookieFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockLogger := NewMockLoggerInterface(ctrl)
-	mockLogger.EXPECT().Errorf("can't get cookie %s, %v", "access-token", gomock.Any()).Times(1)
 	mockRequest := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	manager := NewAuthCookieManager(5, 5, nil, mockLogger)
@@ -370,7 +366,6 @@ func TestAuthCookieManager_GetRefreshTokenCookieFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockLogger := NewMockLoggerInterface(ctrl)
-	mockLogger.EXPECT().Errorf("can't get cookie %s, %v", "refresh-token", gomock.Any()).Times(1)
 	mockRequest := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	manager := NewAuthCookieManager(5, 5, nil, mockLogger)

--- a/pkg/authentication/handlers_test.go
+++ b/pkg/authentication/handlers_test.go
@@ -244,7 +244,6 @@ func TestHandleLoginCallbackFailures(t *testing.T) {
 			request: mockRequestNoStateCookie,
 			setupMocks: func(oauth2Ctx *MockOAuth2ContextInterface, logger *MockLoggerInterface, verifier *MockTokenVerifier, encrypt *MockEncryptInterface) {
 				logger.EXPECT().Error("state cookie not found")
-				logger.EXPECT().Errorf("can't get cookie %s, %v", "state", gomock.Any())
 			},
 			errorMessage: "state cookie not found",
 		},
@@ -301,7 +300,6 @@ func TestHandleLoginCallbackFailures(t *testing.T) {
 			setupMocks: func(oauth2Ctx *MockOAuth2ContextInterface, logger *MockLoggerInterface, verifier *MockTokenVerifier, encrypt *MockEncryptInterface) {
 				logger.EXPECT().Debugf("user login second leg with code '%s'", "mock-code").Times(1)
 				logger.EXPECT().Error("nonce cookie not found")
-				logger.EXPECT().Errorf("can't get cookie %s, %v", "nonce", gomock.Any())
 				mockToken = mockToken.WithExtra(map[string]interface{}{"id_token": "mock-id-token"})
 				oauth2Ctx.EXPECT().RetrieveTokens(gomock.Any(), gomock.Eq("mock-code")).Return(mockToken, nil)
 

--- a/pkg/authentication/handlers_test.go
+++ b/pkg/authentication/handlers_test.go
@@ -63,6 +63,7 @@ func TestHandleLogin(t *testing.T) {
 	}
 
 	api := NewAPI(
+		"",
 		NewOAuth2Context(config, mockOIDCProviderSupplier(&oidc.Provider{}, nil), mockTracer, mockLogger, mockMonitor),
 		mockHelper,
 		NewAuthCookieManager(mockTTLSeconds, mockTTLSeconds, mockEncrypt, mockLogger),
@@ -143,6 +144,7 @@ func TestHandleLoginCallback(t *testing.T) {
 	mockResponse := httptest.NewRecorder()
 
 	api := NewAPI(
+		"",
 		mockOauth2Ctx,
 		mockHelper,
 		NewAuthCookieManager(mockTTLSeconds, mockTTLSeconds, mockEncrypt, mockLogger),
@@ -349,6 +351,7 @@ func TestHandleLoginCallbackFailures(t *testing.T) {
 			mockResponse := httptest.NewRecorder()
 
 			api := NewAPI(
+				"",
 				mockOauth2Ctx,
 				mockHelper,
 				NewAuthCookieManager(mockTTLSeconds, mockTTLSeconds, mockEncrypt, mockLogger),
@@ -404,6 +407,7 @@ func TestHandleMe(t *testing.T) {
 	mockResponse := httptest.NewRecorder()
 
 	api := NewAPI(
+		"",
 		mockOauth2Ctx,
 		mockHelper,
 		NewAuthCookieManager(mockTTLSeconds, mockTTLSeconds, mockEncrypt, mockLogger),
@@ -473,6 +477,7 @@ func TestLogout(t *testing.T) {
 
 				m.EXPECT().ClearNonceCookie(gomock.Any()).Times(1)
 				m.EXPECT().ClearStateCookie(gomock.Any()).Times(1)
+				m.EXPECT().ClearNextToCookie(gomock.Any()).Times(1)
 			},
 		},
 	} {
@@ -499,6 +504,7 @@ func TestLogout(t *testing.T) {
 
 			mockCookieManager := NewMockAuthCookieManagerInterface(ctrl)
 			api := NewAPI(
+				"",
 				mockOauth2Ctx,
 				mockHelper,
 				mockCookieManager,

--- a/pkg/authentication/interfaces.go
+++ b/pkg/authentication/interfaces.go
@@ -86,6 +86,12 @@ type AuthCookieManagerInterface interface {
 	GetRefreshTokenCookie(*http.Request) string
 	// ClearRefreshTokenCookie sets the expiration of the cookie to epoch
 	ClearRefreshTokenCookie(http.ResponseWriter)
+	// SetNextToCookie sets the encrypted nextTo relative url value cookie
+	SetNextToCookie(http.ResponseWriter, string)
+	// GetNextToCookie  returns the string value of the nextTo cookie if present, or empty string otherwise
+	GetNextToCookie(*http.Request) string
+	// ClearNextToCookie sets the expiration of the cookie to epoch
+	ClearNextToCookie(http.ResponseWriter)
 }
 
 type EncryptInterface interface {

--- a/pkg/ui/handlers.go
+++ b/pkg/ui/handlers.go
@@ -18,8 +18,7 @@ import (
 const UIPrefix = "/ui"
 
 type Config struct {
-	DistFS  fs.FS
-	BaseURL string
+	DistFS fs.FS
 }
 
 type API struct {

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -30,6 +30,7 @@ import (
 )
 
 type RouterConfig struct {
+	contextPath              string
 	payloadValidationEnabled bool
 	idp                      *idp.Config
 	schemas                  *schemas.Config
@@ -40,8 +41,9 @@ type RouterConfig struct {
 	olly                     O11yConfigInterface
 }
 
-func NewRouterConfig(payloadValidationEnabled bool, idp *idp.Config, schemas *schemas.Config, rules *rules.Config, ui *ui.Config, external ExternalClientsConfigInterface, oauth2 *authentication.Config, olly O11yConfigInterface) *RouterConfig {
+func NewRouterConfig(contextPath string, payloadValidationEnabled bool, idp *idp.Config, schemas *schemas.Config, rules *rules.Config, ui *ui.Config, external ExternalClientsConfigInterface, oauth2 *authentication.Config, olly O11yConfigInterface) *RouterConfig {
 	return &RouterConfig{
+		contextPath:              contextPath,
 		payloadValidationEnabled: payloadValidationEnabled,
 		idp:                      idp,
 		schemas:                  schemas,
@@ -188,6 +190,7 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 	if oauth2Config.Enabled {
 
 		login := authentication.NewAPI(
+			config.contextPath,
 			oauth2Context,
 			authentication.NewOAuth2Helper(),
 			cookieManager,


### PR DESCRIPTION
## Description
Two things come with this PR
- a small fix to the ui serving handlers and semplification of the implementation
- a feature which allows the frontend to pass a `next` query param with the login GET request, which allows the FE to get that value back **after** login completes so it can use/interpret it (this should be used by the FE to know where the login request originated from in order to bring the user back to that UI).
The `next` parameter does not need to be a relative url or anything similar, it's just parsed as a string and it is returned as it is.
The UI can use it in whichever way it wants.

This closes #337 