### PR TITLE
Add `can_view` entitlement for each resource creation

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
 	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
 	"github.com/canonical/identity-platform-admin-ui/internal/openfga"
+	"github.com/canonical/identity-platform-admin-ui/internal/pool"
 	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
 )
 
@@ -57,7 +58,8 @@ func createAdmin(apiUrl, apiToken, storeId, ModelId, user string) {
 	}
 	cfg := openfga.NewConfig(scheme, host, storeId, apiToken, "", false, tracer, monitor, logger)
 	fgaClient := openfga.NewClient(cfg)
-	auth := authorization.NewAuthorizer(fgaClient, tracer, monitor, logger)
+	wpool := pool.NewWorkerPool(1, tracer, monitor, logger)
+	auth := authorization.NewAuthorizer(fgaClient, wpool, tracer, monitor, logger)
 
 	err = auth.CreateAdmin(context.Background(), user)
 	if err != nil {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
 	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
 	"github.com/canonical/identity-platform-admin-ui/internal/openfga"
+	"github.com/canonical/identity-platform-admin-ui/internal/pool"
 	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
 )
 
@@ -57,7 +58,8 @@ func removeAdmin(apiUrl, apiToken, storeId, ModelId, user string) {
 	}
 	cfg := openfga.NewConfig(scheme, host, storeId, apiToken, "", false, tracer, monitor, logger)
 	fgaClient := openfga.NewClient(cfg)
-	auth := authorization.NewAuthorizer(fgaClient, tracer, monitor, logger)
+	wpool := pool.NewWorkerPool(1, tracer, monitor, logger)
+	auth := authorization.NewAuthorizer(fgaClient, wpool, tracer, monitor, logger)
 
 	err = auth.RemoveAdmin(context.Background(), user)
 	if err != nil {

--- a/internal/authorization/authorization.go
+++ b/internal/authorization/authorization.go
@@ -10,6 +10,7 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
 	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
 	"github.com/canonical/identity-platform-admin-ui/internal/openfga"
+	"github.com/canonical/identity-platform-admin-ui/internal/pool"
 	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
 )
 
@@ -17,6 +18,8 @@ var ErrInvalidAuthModel = fmt.Errorf("Invalid authorization model schema")
 
 type Authorizer struct {
 	client AuthzClientInterface
+
+	wpool pool.WorkerPoolInterface
 
 	tracer  tracing.TracingInterface
 	monitor monitoring.MonitorInterface
@@ -71,9 +74,10 @@ func (a *Authorizer) ValidateModel(ctx context.Context) error {
 	return nil
 }
 
-func NewAuthorizer(client AuthzClientInterface, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *Authorizer {
+func NewAuthorizer(client AuthzClientInterface, wpool pool.WorkerPoolInterface, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *Authorizer {
 	authorizer := new(Authorizer)
 	authorizer.client = client
+	authorizer.wpool = wpool
 	authorizer.tracer = tracer
 	authorizer.monitor = monitor
 	authorizer.logger = logger

--- a/internal/authorization/resource_manager.go
+++ b/internal/authorization/resource_manager.go
@@ -1,0 +1,79 @@
+package authorization
+
+import (
+	"context"
+)
+
+func (a *Authorizer) createTuple(ctx context.Context, resourceID string) error {
+	user, ok := ctx.Value(USER_CTX).(*User)
+	if !ok {
+		// Should we panic?
+		return nil
+	}
+	go func() {
+		err := a.client.WriteTuple(context.Background(), "user:"+user.ID, CAN_VIEW, resourceID)
+		if err != nil {
+			a.logger.Errorf("Failed to create authorization tuple: %s", err)
+		}
+	}()
+	return nil
+}
+
+func (a *Authorizer) deleteTuple(ctx context.Context, resourceID string) error {
+	user, ok := ctx.Value(USER_CTX).(*User)
+	if !ok {
+		// Should we panic?
+		return nil
+	}
+	go func() {
+		err := a.client.DeleteTuple(context.Background(), "user:"+user.ID, CAN_VIEW, resourceID)
+		if err != nil {
+			a.logger.Errorf("Failed to create authorization tuple: %s", err)
+		}
+	}()
+	return nil
+}
+
+func (a *Authorizer) getResource(resourceID, resourceType string) string {
+	return resourceType + ":" + resourceID
+}
+
+func (a *Authorizer) CreateClient(ctx context.Context, clientID string) error {
+	return a.createTuple(ctx, a.getResource(clientID, CLIENT_TYPE))
+}
+
+func (a *Authorizer) DeleteClient(ctx context.Context, clientID string) error {
+	return a.deleteTuple(ctx, a.getResource(clientID, CLIENT_TYPE))
+}
+
+func (a *Authorizer) CreateIdentity(ctx context.Context, IdentityID string) error {
+	return a.createTuple(ctx, a.getResource(IdentityID, IDENTITY_TYPE))
+}
+
+func (a *Authorizer) DeleteIdentity(ctx context.Context, IdentityID string) error {
+	return a.deleteTuple(ctx, a.getResource(IdentityID, IDENTITY_TYPE))
+}
+
+func (a *Authorizer) CreateProvider(ctx context.Context, providerID string) error {
+	return a.createTuple(ctx, a.getResource(providerID, PROVIDER_TYPE))
+}
+
+func (a *Authorizer) DeleteProvider(ctx context.Context, providerID string) error {
+	return a.deleteTuple(ctx, a.getResource(providerID, PROVIDER_TYPE))
+}
+
+func (a *Authorizer) CreateRule(ctx context.Context, ruleID string) error {
+	return a.createTuple(ctx, a.getResource(ruleID, RULE_TYPE))
+}
+
+func (a *Authorizer) DeleteRule(ctx context.Context, ruleID string) error {
+	return a.deleteTuple(ctx, a.getResource(ruleID, RULE_TYPE))
+}
+
+func (a *Authorizer) CreateSchema(ctx context.Context, schemeID string) error {
+	return a.createTuple(ctx, a.getResource(schemeID, SCHEME_TYPE))
+}
+
+func (a *Authorizer) DeleteSchema(ctx context.Context, schemeID string) error {
+	return a.deleteTuple(ctx, a.getResource(schemeID, SCHEME_TYPE))
+}

--- a/internal/authorization/resource_manager.go
+++ b/internal/authorization/resource_manager.go
@@ -38,42 +38,42 @@ func (a *Authorizer) getResource(resourceID, resourceType string) string {
 	return resourceType + ":" + resourceID
 }
 
-func (a *Authorizer) CreateClient(ctx context.Context, clientID string) error {
+func (a *Authorizer) SetCreateClientEntitlements(ctx context.Context, clientID string) error {
 	return a.createTuple(ctx, a.getResource(clientID, CLIENT_TYPE))
 }
 
-func (a *Authorizer) DeleteClient(ctx context.Context, clientID string) error {
+func (a *Authorizer) SetDeleteClientEntitlements(ctx context.Context, clientID string) error {
 	return a.deleteTuple(ctx, a.getResource(clientID, CLIENT_TYPE))
 }
 
-func (a *Authorizer) CreateIdentity(ctx context.Context, IdentityID string) error {
+func (a *Authorizer) SetCreateIdentityEntitlements(ctx context.Context, IdentityID string) error {
 	return a.createTuple(ctx, a.getResource(IdentityID, IDENTITY_TYPE))
 }
 
-func (a *Authorizer) DeleteIdentity(ctx context.Context, IdentityID string) error {
+func (a *Authorizer) SetDeleteIdentityEntitlements(ctx context.Context, IdentityID string) error {
 	return a.deleteTuple(ctx, a.getResource(IdentityID, IDENTITY_TYPE))
 }
 
-func (a *Authorizer) CreateProvider(ctx context.Context, providerID string) error {
+func (a *Authorizer) SetCreateProviderEntitlements(ctx context.Context, providerID string) error {
 	return a.createTuple(ctx, a.getResource(providerID, PROVIDER_TYPE))
 }
 
-func (a *Authorizer) DeleteProvider(ctx context.Context, providerID string) error {
+func (a *Authorizer) SetDeleteProviderEntitlements(ctx context.Context, providerID string) error {
 	return a.deleteTuple(ctx, a.getResource(providerID, PROVIDER_TYPE))
 }
 
-func (a *Authorizer) CreateRule(ctx context.Context, ruleID string) error {
+func (a *Authorizer) SetCreateRuleEntitlements(ctx context.Context, ruleID string) error {
 	return a.createTuple(ctx, a.getResource(ruleID, RULE_TYPE))
 }
 
-func (a *Authorizer) DeleteRule(ctx context.Context, ruleID string) error {
+func (a *Authorizer) SetDeleteRuleEntitlements(ctx context.Context, ruleID string) error {
 	return a.deleteTuple(ctx, a.getResource(ruleID, RULE_TYPE))
 }
 
-func (a *Authorizer) CreateSchema(ctx context.Context, schemeID string) error {
+func (a *Authorizer) SetCreateSchemaEntitlements(ctx context.Context, schemeID string) error {
 	return a.createTuple(ctx, a.getResource(schemeID, SCHEME_TYPE))
 }
 
-func (a *Authorizer) DeleteSchema(ctx context.Context, schemeID string) error {
+func (a *Authorizer) SetDeleteSchemaEntitlements(ctx context.Context, schemeID string) error {
 	return a.deleteTuple(ctx, a.getResource(schemeID, SCHEME_TYPE))
 }

--- a/internal/openfga/client.go
+++ b/internal/openfga/client.go
@@ -145,6 +145,9 @@ func (c *Client) WriteTuple(ctx context.Context, user, relation, object string) 
 	ctx, span := c.tracer.Start(ctx, "openfga.Client.WriteTuple")
 	defer span.End()
 
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
 	r := c.c.Write(ctx)
 	body := client.ClientWriteRequest{
 		Writes: []openfga.TupleKey{

--- a/pkg/clients/handlers.go
+++ b/pkg/clients/handlers.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
 	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 )
 
@@ -21,7 +23,9 @@ type API struct {
 	service          ServiceInterface
 	payloadValidator validation.PayloadValidatorInterface
 
-	logger logging.LoggerInterface
+	tracer  tracing.TracingInterface
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
 }
 
 func (a *API) RegisterEndpoints(mux *chi.Mux) {
@@ -197,12 +201,20 @@ func (a *API) parseListClientsRequest(r *http.Request) (*ListClientsRequest, err
 	return NewListClientsRequest(cn, owner, page_token, size), nil
 }
 
-func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
+func NewAPI(
+	service ServiceInterface,
+	tracer tracing.TracingInterface,
+	monitor monitoring.MonitorInterface,
+	logger logging.LoggerInterface,
+) *API {
 	a := new(API)
 	a.apiKey = "clients"
 
 	a.service = service
 	a.payloadValidator = NewClientsPayloadValidator(a.apiKey, logger)
+
+	a.tracer = tracer
+	a.monitor = monitor
 	a.logger = logger
 
 	return a

--- a/pkg/clients/handlers_test.go
+++ b/pkg/clients/handlers_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 //go:generate mockgen -build_flags=--mod=mod -package clients -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package clients -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package clients -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
 //go:generate mockgen -build_flags=--mod=mod -package clients -destination ./mock_clients.go -source=./interfaces.go
 //go:generate mockgen -build_flags=--mod=mod -package clients -destination ./mock_validation.go -source=../../internal/validation/registry.go
 
@@ -28,6 +30,8 @@ func TestHandleGetClientSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	const clientId = "client_id"
@@ -43,7 +47,7 @@ func TestHandleGetClientSuccess(t *testing.T) {
 	mockService.EXPECT().GetClient(gomock.Any(), clientId).Return(resp, nil)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -79,6 +83,8 @@ func TestHandleGetClientServiceError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	const clientId = "client_id"
@@ -95,7 +101,7 @@ func TestHandleGetClientServiceError(t *testing.T) {
 	mockService.EXPECT().GetClient(gomock.Any(), clientId).Return(resp, nil)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -131,6 +137,8 @@ func TestHandleDeleteClientSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	const clientId = "client_id"
@@ -143,7 +151,7 @@ func TestHandleDeleteClientSuccess(t *testing.T) {
 	mockService.EXPECT().DeleteClient(gomock.Any(), clientId).Return(resp, nil)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -173,6 +181,8 @@ func TestHandleDeleteClientServiceError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	const clientId = "client_id"
@@ -189,7 +199,7 @@ func TestHandleDeleteClientServiceError(t *testing.T) {
 	mockService.EXPECT().DeleteClient(gomock.Any(), clientId).Return(resp, nil)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -225,6 +235,8 @@ func TestHandleCreateClientSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	c := hClient.NewOAuth2Client()
@@ -238,7 +250,7 @@ func TestHandleCreateClientSuccess(t *testing.T) {
 	mockService.EXPECT().CreateClient(gomock.Any(), c).Return(resp, nil)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -268,6 +280,8 @@ func TestHandleCreateClientServiceError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	c := hClient.NewOAuth2Client()
@@ -284,7 +298,7 @@ func TestHandleCreateClientServiceError(t *testing.T) {
 	mockService.EXPECT().CreateClient(gomock.Any(), c).Return(resp, nil)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -320,6 +334,8 @@ func TestHandleCreateClientBadRequest(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v0/clients", nil)
@@ -329,7 +345,7 @@ func TestHandleCreateClientBadRequest(t *testing.T) {
 	mockService.EXPECT().UnmarshalClient(gomock.Any()).Return(nil, fmt.Errorf("error"))
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -344,6 +360,8 @@ func TestHandleUpdateClientSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	const clientId = "client_id"
@@ -360,7 +378,7 @@ func TestHandleUpdateClientSuccess(t *testing.T) {
 	mockService.EXPECT().UpdateClient(gomock.Any(), c).Return(resp, nil)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -390,6 +408,8 @@ func TestHandleUpdateClientServiceError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	const clientId = "client_id"
@@ -408,7 +428,7 @@ func TestHandleUpdateClientServiceError(t *testing.T) {
 	mockService.EXPECT().UpdateClient(gomock.Any(), c).Return(resp, nil)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -444,6 +464,8 @@ func TestHandleUpdateClientBadRequest(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	const clientId = "client_id"
@@ -454,7 +476,7 @@ func TestHandleUpdateClientBadRequest(t *testing.T) {
 	mockService.EXPECT().UnmarshalClient(gomock.Any()).Return(nil, fmt.Errorf("error"))
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -469,6 +491,8 @@ func TestHandleListClientsSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	const clientId = "client_id"
@@ -492,7 +516,7 @@ func TestHandleListClientsSuccess(t *testing.T) {
 	mockService.EXPECT().ListClients(gomock.Any(), listReq).Return(resp, nil)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -522,6 +546,8 @@ func TestHandleListClientServiceError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	errResp := new(ErrorOAuth2)
@@ -544,7 +570,7 @@ func TestHandleListClientServiceError(t *testing.T) {
 	mockService.EXPECT().ListClients(gomock.Any(), listReq).Return(resp, nil)
 
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -580,6 +606,8 @@ func TestRegisterValidation(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 	mockValidationRegistry := NewMockValidationRegistryInterface(ctrl)
 
@@ -592,10 +620,10 @@ func TestRegisterValidation(t *testing.T) {
 		Return(fmt.Errorf("key is already registered"))
 
 	// first registration of `apiKey` is successful
-	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)
 
 	mockLogger.EXPECT().Fatalf(gomock.Any(), gomock.Any()).Times(1)
 
 	// second registration of `apiKey` causes logger.Fatal invocation
-	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)
 }

--- a/pkg/clients/interfaces.go
+++ b/pkg/clients/interfaces.go
@@ -15,6 +15,11 @@ type HydraClientInterface interface {
 
 type OAuth2Client = hClient.OAuth2Client
 
+type AuthorizerInterface interface {
+	SetCreateClientEntitlements(context.Context, string) error
+	SetDeleteClientEntitlements(context.Context, string) error
+}
+
 type ServiceInterface interface {
 	GetClient(context.Context, string) (*ServiceResponse, error)
 	CreateClient(context.Context, *hClient.OAuth2Client) (*ServiceResponse, error)

--- a/pkg/identities/handlers.go
+++ b/pkg/identities/handlers.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
 	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 )
 
@@ -31,7 +33,9 @@ type API struct {
 	service          ServiceInterface
 	payloadValidator validation.PayloadValidatorInterface
 
-	logger logging.LoggerInterface
+	tracer  tracing.TracingInterface
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
 }
 
 func (a *API) RegisterEndpoints(mux *chi.Mux) {
@@ -264,13 +268,15 @@ func (a *API) error(e *kClient.GenericError) types.Response {
 
 }
 
-func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
+func NewAPI(service ServiceInterface, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *API {
 	a := new(API)
 	a.apiKey = "identities"
 	a.service = service
 
 	a.payloadValidator = NewIdentitiesPayloadValidator(a.apiKey, logger)
 
+	a.tracer = tracer
+	a.monitor = monitor
 	a.logger = logger
 
 	return a

--- a/pkg/identities/handlers_test.go
+++ b/pkg/identities/handlers_test.go
@@ -34,6 +34,8 @@ func TestHandleListSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	identities := make([]kClient.Identity, 0)
@@ -60,7 +62,7 @@ func TestHandleListSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -118,6 +120,8 @@ func TestHandleListFailAndPropagatesKratosError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v0/identities", nil)
@@ -134,7 +138,7 @@ func TestHandleListFailAndPropagatesKratosError(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -169,6 +173,8 @@ func TestHandleDetailSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	credID := "test-1"
@@ -180,7 +186,7 @@ func TestHandleDetailSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -242,6 +248,8 @@ func TestHandleDetailFailAndPropagatesKratosError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	credID := "test-1"
@@ -256,7 +264,7 @@ func TestHandleDetailFailAndPropagatesKratosError(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -291,6 +299,8 @@ func TestHandleCreateSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	identity := kClient.NewIdentity("test", "test.json", "https://test.com/test.json", map[string]string{"name": "name"})
@@ -306,7 +316,7 @@ func TestHandleCreateSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -368,6 +378,8 @@ func TestHandleCreateFailAndPropagatesKratosError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	identityBody := kClient.NewCreateIdentityBodyWithDefaults()
@@ -387,7 +399,7 @@ func TestHandleCreateFailAndPropagatesKratosError(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -422,13 +434,15 @@ func TestHandleCreateFailBadRequest(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v0/identities", strings.NewReader("test"))
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -459,6 +473,8 @@ func TestHandleUpdateSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	credID := "test-1"
@@ -477,7 +493,7 @@ func TestHandleUpdateSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -539,6 +555,8 @@ func TestHandleUpdateFailAndPropagatesKratosError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	identityBody := kClient.NewUpdateIdentityBodyWithDefaults()
@@ -559,7 +577,7 @@ func TestHandleUpdateFailAndPropagatesKratosError(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -594,13 +612,15 @@ func TestHandleUpdateFailBadRequest(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodPut, "/api/v0/identities/test", strings.NewReader("test"))
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -631,6 +651,8 @@ func TestHandleRemoveSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	credID := "test-1"
@@ -641,7 +663,7 @@ func TestHandleRemoveSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -675,6 +697,8 @@ func TestHandleRemoveFailAndPropagatesKratosError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	credID := "test-1"
@@ -689,7 +713,7 @@ func TestHandleRemoveFailAndPropagatesKratosError(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -724,6 +748,8 @@ func TestRegisterValidation(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 	mockValidationRegistry := NewMockValidationRegistryInterface(ctrl)
 
@@ -736,10 +762,10 @@ func TestRegisterValidation(t *testing.T) {
 		Return(fmt.Errorf("key is already registered"))
 
 	// first registration of `apiKey` is successful
-	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)
 
 	mockLogger.EXPECT().Fatalf(gomock.Any(), gomock.Any()).Times(1)
 
 	// second registration of `apiKey` causes logger.Fatal invocation
-	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)
 }

--- a/pkg/identities/interfaces.go
+++ b/pkg/identities/interfaces.go
@@ -9,6 +9,11 @@ import (
 	kClient "github.com/ory/kratos-client-go"
 )
 
+type AuthorizerInterface interface {
+	SetCreateIdentityEntitlements(context.Context, string) error
+	SetDeleteIdentityEntitlements(context.Context, string) error
+}
+
 type ServiceInterface interface {
 	ListIdentities(context.Context, int64, string, string) (*IdentityData, error)
 	GetIdentity(context.Context, string) (*IdentityData, error)

--- a/pkg/identities/service_test.go
+++ b/pkg/identities/service_test.go
@@ -30,6 +30,7 @@ func TestListIdentitiesSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
@@ -70,7 +71,7 @@ func TestListIdentitiesSuccess(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).ListIdentities(ctx, 10, "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ", "")
+	ids, err := NewService(mockKratosIdentityAPI, mockAuthz, mockTracer, mockMonitor, mockLogger).ListIdentities(ctx, 10, "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ", "")
 
 	if !reflect.DeepEqual(ids.Identities, identities) {
 		t.Fatalf("expected identities to be %v not  %v", identities, ids.Identities)
@@ -95,6 +96,7 @@ func TestListIdentitiesFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
@@ -147,7 +149,7 @@ func TestListIdentitiesFails(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).ListIdentities(ctx, 10, "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ", "test")
+	ids, err := NewService(mockKratosIdentityAPI, mockAuthz, mockTracer, mockMonitor, mockLogger).ListIdentities(ctx, 10, "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ", "test")
 
 	if !reflect.DeepEqual(ids.Identities, identities) {
 		t.Fatalf("expected identities to be empty not  %v", ids.Identities)
@@ -173,6 +175,7 @@ func TestGetIdentitySuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
@@ -188,7 +191,7 @@ func TestGetIdentitySuccess(t *testing.T) {
 	mockKratosIdentityAPI.EXPECT().GetIdentity(ctx, credID).Times(1).Return(identityRequest)
 	mockKratosIdentityAPI.EXPECT().GetIdentityExecute(gomock.Any()).Times(1).Return(identity, new(http.Response), nil)
 
-	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).GetIdentity(ctx, credID)
+	ids, err := NewService(mockKratosIdentityAPI, mockAuthz, mockTracer, mockMonitor, mockLogger).GetIdentity(ctx, credID)
 
 	if !reflect.DeepEqual(ids.Identities, []kClient.Identity{*identity}) {
 		t.Fatalf("expected identities to be %v not  %v", *identity, ids.Identities)
@@ -205,6 +208,7 @@ func TestGetIdentityFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
@@ -242,7 +246,7 @@ func TestGetIdentityFails(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).GetIdentity(ctx, credID)
+	ids, err := NewService(mockKratosIdentityAPI, mockAuthz, mockTracer, mockMonitor, mockLogger).GetIdentity(ctx, credID)
 
 	if !reflect.DeepEqual(ids.Identities, make([]kClient.Identity, 0)) {
 		t.Fatalf("expected identities to be empty not  %v", ids.Identities)
@@ -268,6 +272,7 @@ func TestCreateIdentitySuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
@@ -282,6 +287,7 @@ func TestCreateIdentitySuccess(t *testing.T) {
 	identityBody.SetCredentials(*credentials)
 
 	mockTracer.EXPECT().Start(ctx, "kratos.IdentityAPI.CreateIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockAuthz.EXPECT().SetCreateIdentityEntitlements(gomock.Any(), identity.Id)
 	mockKratosIdentityAPI.EXPECT().CreateIdentity(ctx).Times(1).Return(identityRequest)
 	mockKratosIdentityAPI.EXPECT().CreateIdentityExecute(gomock.Any()).Times(1).DoAndReturn(
 		func(r kClient.IdentityAPICreateIdentityRequest) (*kClient.Identity, *http.Response, error) {
@@ -295,7 +301,7 @@ func TestCreateIdentitySuccess(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).CreateIdentity(ctx, identityBody)
+	ids, err := NewService(mockKratosIdentityAPI, mockAuthz, mockTracer, mockMonitor, mockLogger).CreateIdentity(ctx, identityBody)
 
 	if !reflect.DeepEqual(ids.Identities, []kClient.Identity{*identity}) {
 		t.Fatalf("expected identities to be %v not  %v", *identity, ids.Identities)
@@ -313,6 +319,7 @@ func TestCreateIdentityFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
@@ -353,7 +360,7 @@ func TestCreateIdentityFails(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).CreateIdentity(ctx, identityBody)
+	ids, err := NewService(mockKratosIdentityAPI, mockAuthz, mockTracer, mockMonitor, mockLogger).CreateIdentity(ctx, identityBody)
 
 	if !reflect.DeepEqual(ids.Identities, make([]kClient.Identity, 0)) {
 		t.Fatalf("expected identities to be empty not  %v", ids.Identities)
@@ -379,6 +386,7 @@ func TestUpdateIdentitySuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
@@ -407,7 +415,7 @@ func TestUpdateIdentitySuccess(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).UpdateIdentity(ctx, identity.Id, identityBody)
+	ids, err := NewService(mockKratosIdentityAPI, mockAuthz, mockTracer, mockMonitor, mockLogger).UpdateIdentity(ctx, identity.Id, identityBody)
 
 	if !reflect.DeepEqual(ids.Identities, []kClient.Identity{*identity}) {
 		t.Fatalf("expected identities to be %v not  %v", *identity, ids.Identities)
@@ -425,6 +433,7 @@ func TestUpdateIdentityFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
@@ -468,7 +477,7 @@ func TestUpdateIdentityFails(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).UpdateIdentity(ctx, credID, identityBody)
+	ids, err := NewService(mockKratosIdentityAPI, mockAuthz, mockTracer, mockMonitor, mockLogger).UpdateIdentity(ctx, credID, identityBody)
 
 	if !reflect.DeepEqual(ids.Identities, make([]kClient.Identity, 0)) {
 		t.Fatalf("expected identities to be empty not  %v", ids.Identities)
@@ -494,6 +503,7 @@ func TestDeleteIdentitySuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
@@ -504,10 +514,11 @@ func TestDeleteIdentitySuccess(t *testing.T) {
 	}
 
 	mockTracer.EXPECT().Start(ctx, "kratos.IdentityAPI.DeleteIdentity").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockAuthz.EXPECT().SetDeleteIdentityEntitlements(gomock.Any(), credID)
 	mockKratosIdentityAPI.EXPECT().DeleteIdentity(ctx, credID).Times(1).Return(identityRequest)
 	mockKratosIdentityAPI.EXPECT().DeleteIdentityExecute(gomock.Any()).Times(1).Return(new(http.Response), nil)
 
-	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).DeleteIdentity(ctx, credID)
+	ids, err := NewService(mockKratosIdentityAPI, mockAuthz, mockTracer, mockMonitor, mockLogger).DeleteIdentity(ctx, credID)
 
 	if len(ids.Identities) > 0 {
 		t.Fatalf("invalid result, expected no identities, got %v", ids.Identities)
@@ -525,6 +536,7 @@ func TestDeleteIdentityFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 
 	ctx := context.Background()
@@ -562,7 +574,7 @@ func TestDeleteIdentityFails(t *testing.T) {
 		},
 	)
 
-	ids, err := NewService(mockKratosIdentityAPI, mockTracer, mockMonitor, mockLogger).DeleteIdentity(ctx, credID)
+	ids, err := NewService(mockKratosIdentityAPI, mockAuthz, mockTracer, mockMonitor, mockLogger).DeleteIdentity(ctx, credID)
 
 	if !reflect.DeepEqual(ids.Identities, make([]kClient.Identity, 0)) {
 		t.Fatalf("expected identities to be empty not  %v", ids.Identities)

--- a/pkg/idp/handlers.go
+++ b/pkg/idp/handlers.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
 	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 )
 
@@ -22,7 +24,9 @@ type API struct {
 	service          ServiceInterface
 	payloadValidator validation.PayloadValidatorInterface
 
-	logger logging.LoggerInterface
+	logger  logging.LoggerInterface
+	tracer  tracing.TracingInterface
+	monitor monitoring.MonitorInterface
 }
 
 func (a *API) RegisterEndpoints(mux *chi.Mux) {
@@ -252,13 +256,16 @@ func (a *API) handleRemove(w http.ResponseWriter, r *http.Request) {
 	)
 }
 
-func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
+func NewAPI(service ServiceInterface, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *API {
 	a := new(API)
 	a.apiKey = "idps"
 
 	a.payloadValidator = NewIdPPayloadValidator(a.apiKey, logger)
 	a.service = service
+
 	a.logger = logger
+	a.tracer = tracer
+	a.monitor = monitor
 
 	return a
 }

--- a/pkg/idp/handlers_test.go
+++ b/pkg/idp/handlers_test.go
@@ -34,6 +34,8 @@ func TestHandleListSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	idps := []*Configuration{
@@ -70,7 +72,7 @@ func TestHandleListSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -112,6 +114,8 @@ func TestHandleListFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v0/idps", nil)
@@ -120,7 +124,7 @@ func TestHandleListFails(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -148,6 +152,8 @@ func TestHandleDetailSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	idps := []*Configuration{
@@ -184,7 +190,7 @@ func TestHandleDetailSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -224,6 +230,8 @@ func TestHandleDetailEmpty(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/idps/%s", "random"), nil)
@@ -232,7 +240,7 @@ func TestHandleDetailEmpty(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -268,6 +276,8 @@ func TestHandleDetailFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	ID := "test-1"
@@ -277,7 +287,7 @@ func TestHandleDetailFails(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -304,6 +314,8 @@ func TestHandleCreateSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	c := new(Configuration)
@@ -339,7 +351,7 @@ func TestHandleCreateSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -379,6 +391,8 @@ func TestHandleCreateFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	c := new(Configuration)
@@ -407,7 +421,7 @@ func TestHandleCreateFails(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -438,6 +452,8 @@ func TestHandleCreateFailsIfIDPassedIn(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	c := new(Configuration)
@@ -453,7 +469,7 @@ func TestHandleCreateFailsIfIDPassedIn(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -484,13 +500,15 @@ func TestHandleCreateFailBadRequest(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v0/idps", strings.NewReader("test"))
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -521,6 +539,8 @@ func TestHandlePartialUpdateSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	c := new(Configuration)
@@ -559,7 +579,7 @@ func TestHandlePartialUpdateSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -599,6 +619,8 @@ func TestHandlePartialUpdateFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	c := new(Configuration)
@@ -637,7 +659,7 @@ func TestHandlePartialUpdateFails(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -668,13 +690,15 @@ func TestHandlePartialUpdateFailBadRequest(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodPatch, "/api/v0/idps/fake", strings.NewReader("test"))
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -705,6 +729,8 @@ func TestHandleRemoveSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	credID := "test-1"
@@ -715,7 +741,7 @@ func TestHandleRemoveSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -749,6 +775,8 @@ func TestHandleRemoveFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	credID := "test-1"
@@ -758,7 +786,7 @@ func TestHandleRemoveFails(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -789,6 +817,8 @@ func TestRegisterValidation(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 	mockValidationRegistry := NewMockValidationRegistryInterface(ctrl)
 
@@ -801,10 +831,10 @@ func TestRegisterValidation(t *testing.T) {
 		Return(fmt.Errorf("key is already registered"))
 
 	// first registration of `apiKey` is successful
-	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)
 
 	mockLogger.EXPECT().Fatalf(gomock.Any(), gomock.Any()).Times(1)
 
 	// second registration of `apiKey` causes logger.Fatal invocation
-	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)
 }

--- a/pkg/idp/interfaces.go
+++ b/pkg/idp/interfaces.go
@@ -7,6 +7,11 @@ import (
 	"context"
 )
 
+type AuthorizerInterface interface {
+	SetCreateProviderEntitlements(context.Context, string) error
+	SetDeleteProviderEntitlements(context.Context, string) error
+}
+
 type ServiceInterface interface {
 	ListResources(context.Context) ([]*Configuration, error)
 	GetResource(context.Context, string) ([]*Configuration, error)

--- a/pkg/idp/service_test.go
+++ b/pkg/idp/service_test.go
@@ -30,6 +30,7 @@ func TestListResourcesSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -77,7 +78,7 @@ func TestListResourcesSuccess(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).ListResources(ctx)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).ListResources(ctx)
 
 	if !reflect.DeepEqual(is, idps) {
 		t.Fatalf("expected providers to be %v not  %v", idps, is)
@@ -96,6 +97,7 @@ func TestListResourcesSuccessButEmpty(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -114,7 +116,7 @@ func TestListResourcesSuccessButEmpty(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).ListResources(ctx)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).ListResources(ctx)
 
 	if len(is) != 0 {
 		t.Fatalf("expected providers to be empty not  %v", is)
@@ -132,6 +134,7 @@ func TestListResourcesFailsOnConfigMap(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -146,7 +149,7 @@ func TestListResourcesFailsOnConfigMap(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(nil, fmt.Errorf("broken"))
 	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).ListResources(ctx)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).ListResources(ctx)
 
 	if is != nil {
 		t.Fatalf("expected result to be nil not  %v", is)
@@ -165,6 +168,7 @@ func TestListResourcesFailsOnMissingKey(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -212,7 +216,7 @@ func TestListResourcesFailsOnMissingKey(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(1)
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).ListResources(ctx)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).ListResources(ctx)
 
 	if is != nil {
 		t.Fatalf("expected result to be nil not  %v", is)
@@ -231,6 +235,7 @@ func TestGetResourceSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -278,7 +283,7 @@ func TestGetResourceSuccess(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).GetResource(ctx, idps[0].ID)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).GetResource(ctx, idps[0].ID)
 
 	if !reflect.DeepEqual(is[0], idps[0]) {
 		t.Fatalf("expected providers to be %v not  %v", idps[0], is)
@@ -296,6 +301,7 @@ func TestGetResourceNotfound(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -343,7 +349,7 @@ func TestGetResourceNotfound(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).GetResource(ctx, "fake")
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).GetResource(ctx, "fake")
 
 	if len(is) != 0 {
 		t.Fatalf("expected providers to be empty not  %v", is)
@@ -361,6 +367,7 @@ func TestGetResourceSuccessButEmpty(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -379,7 +386,7 @@ func TestGetResourceSuccessButEmpty(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).GetResource(ctx, "fake")
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).GetResource(ctx, "fake")
 
 	if len(is) != 0 {
 		t.Fatalf("expected providers to be empty not  %v", is)
@@ -397,6 +404,7 @@ func TestGetResourceFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -415,7 +423,7 @@ func TestGetResourceFails(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).GetResource(ctx, "fake")
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).GetResource(ctx, "fake")
 
 	if len(is) != 0 {
 		t.Fatalf("expected providers to be empty not  %v", is)
@@ -433,6 +441,7 @@ func TestEditResourceSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -484,7 +493,7 @@ func TestEditResourceSuccess(t *testing.T) {
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).Return(cm, nil)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).EditResource(ctx, idps[0].ID, c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).EditResource(ctx, idps[0].ID, c)
 
 	if is[0].ClientSecret != c.ClientSecret {
 		t.Fatalf("expected provider secret to be %v not  %v", c.ClientSecret, is[0].ClientSecret)
@@ -503,6 +512,7 @@ func TestEditResourceNotfound(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -553,7 +563,7 @@ func TestEditResourceNotfound(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).EditResource(ctx, "fake", c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).EditResource(ctx, "fake", c)
 
 	if len(is) != 0 {
 		t.Fatalf("expected providers to be empty not  %v", is)
@@ -571,6 +581,7 @@ func TestEditResourceFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -622,7 +633,7 @@ func TestEditResourceFails(t *testing.T) {
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).Return(cm, fmt.Errorf("error"))
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).EditResource(ctx, idps[0].ID, c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).EditResource(ctx, idps[0].ID, c)
 
 	if is != nil {
 		t.Fatalf("expected providers to be nil, not %v", is)
@@ -640,6 +651,7 @@ func TestCreateResourceSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -692,6 +704,7 @@ func TestCreateResourceSuccess(t *testing.T) {
 	c.Scope = []string{"email"}
 
 	mockTracer.EXPECT().Start(ctx, "idp.Service.CreateResource").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockAuthz.EXPECT().SetCreateProviderEntitlements(gomock.Any(), gomock.Any())
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(2).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).DoAndReturn(
@@ -709,7 +722,7 @@ func TestCreateResourceSuccess(t *testing.T) {
 		},
 	)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).CreateResource(ctx, c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).CreateResource(ctx, c)
 
 	if is == nil {
 		t.Fatalf("expected provider to be not nil %v", is)
@@ -727,6 +740,7 @@ func TestCreateResourceSuccessSetsIDIfMissing(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -749,6 +763,7 @@ func TestCreateResourceSuccessSetsIDIfMissing(t *testing.T) {
 	c.Scope = []string{"email"}
 
 	mockTracer.EXPECT().Start(ctx, "idp.Service.CreateResource").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockAuthz.EXPECT().SetCreateProviderEntitlements(gomock.Any(), gomock.Any())
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(2).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).DoAndReturn(
@@ -775,7 +790,7 @@ func TestCreateResourceSuccessSetsIDIfMissing(t *testing.T) {
 		},
 	)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).CreateResource(ctx, c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).CreateResource(ctx, c)
 
 	if is == nil {
 		t.Fatalf("expected provider to be not nil %v", is)
@@ -793,6 +808,7 @@ func TestCreateResourceFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -862,7 +878,7 @@ func TestCreateResourceFails(t *testing.T) {
 		},
 	)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).CreateResource(ctx, c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).CreateResource(ctx, c)
 
 	if is != nil {
 		t.Fatalf("expected provider to be nil not %v", is)
@@ -880,6 +896,7 @@ func TestDeleteResourceSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -924,6 +941,7 @@ func TestDeleteResourceSuccess(t *testing.T) {
 	cm.Data[cfg.KeyName] = string(rawIdps)
 
 	mockTracer.EXPECT().Start(ctx, "idp.Service.DeleteResource").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockAuthz.EXPECT().SetDeleteProviderEntitlements(gomock.Any(), idps[0].ID)
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(2).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).DoAndReturn(
@@ -941,7 +959,7 @@ func TestDeleteResourceSuccess(t *testing.T) {
 		},
 	)
 
-	err := NewService(cfg, mockTracer, mockMonitor, mockLogger).DeleteResource(ctx, idps[0].ID)
+	err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).DeleteResource(ctx, idps[0].ID)
 
 	if err != nil {
 		t.Fatalf("expected error to be nil not  %v", err)
@@ -955,6 +973,7 @@ func TestDeleteResourceFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	ctx := context.Background()
@@ -1002,7 +1021,7 @@ func TestDeleteResourceFails(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	err := NewService(cfg, mockTracer, mockMonitor, mockLogger).DeleteResource(ctx, "fake")
+	err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).DeleteResource(ctx, "fake")
 
 	if err == nil {
 		t.Fatalf("expected error not to be nil")

--- a/pkg/rules/handlers.go
+++ b/pkg/rules/handlers.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
 	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 
 	"github.com/go-chi/chi/v5"
@@ -25,7 +27,9 @@ type API struct {
 	service          ServiceInterface
 	payloadValidator validation.PayloadValidatorInterface
 
-	logger logging.LoggerInterface
+	tracer  tracing.TracingInterface
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
 }
 
 type PageToken struct {
@@ -302,11 +306,14 @@ func (a *API) handleRemove(w http.ResponseWriter, r *http.Request) {
 	)
 }
 
-func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
+func NewAPI(service ServiceInterface, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *API {
 	a := new(API)
 	a.apiKey = "rules"
 	a.payloadValidator = NewRulesPayloadValidator(a.apiKey, logger)
 	a.service = service
+
+	a.tracer = tracer
+	a.monitor = monitor
 	a.logger = logger
 
 	return a

--- a/pkg/rules/handlers_test.go
+++ b/pkg/rules/handlers_test.go
@@ -32,6 +32,8 @@ func TestHandleListSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	string_athenticator_handler := "cookie_session"
@@ -90,7 +92,7 @@ func TestHandleListSuccess(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v0/rules?page_token=eyJvZmZzZXQiOjB9&size=100", nil)
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -128,6 +130,8 @@ func TestHandleListFailed(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	var offset int64 = 0
@@ -138,7 +142,7 @@ func TestHandleListFailed(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v0/rules?pageToken=0&offset=100", nil)
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -173,6 +177,8 @@ func TestHandleDetailSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	string_athenticator_handler := "cookie_session"
@@ -207,7 +213,7 @@ func TestHandleDetailSuccess(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v0/rules/mocked_rule1:allow", nil)
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -245,6 +251,8 @@ func TestHandleDetailFailed(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	mockService.EXPECT().GetRule(gomock.Any(), "mocked_rule1:allow").Return(nil, fmt.Errorf("mock_error"))
@@ -252,7 +260,7 @@ func TestHandleDetailFailed(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v0/rules/mocked_rule1:allow", nil)
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -287,6 +295,8 @@ func TestHandleUpdateSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	string_athenticator_handler := "cookie_session"
@@ -321,7 +331,7 @@ func TestHandleUpdateSuccess(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "/api/v0/rules/mocked_rule1:allow", bytes.NewReader(payload))
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -353,6 +363,8 @@ func TestHandleUpdateFailed(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	string_athenticator_handler := "cookie_session"
@@ -387,7 +399,7 @@ func TestHandleUpdateFailed(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "/api/v0/rules/mocked_rule1:allow", bytes.NewReader(payload))
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -422,6 +434,8 @@ func TestHandleCreateSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	string_athenticator_handler := "cookie_session"
@@ -456,7 +470,7 @@ func TestHandleCreateSuccess(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v0/rules", bytes.NewReader(payload))
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -488,6 +502,8 @@ func TestHandleCreateFailed(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	string_athenticator_handler := "cookie_session"
@@ -522,7 +538,7 @@ func TestHandleCreateFailed(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v0/rules", bytes.NewReader(payload))
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -557,6 +573,8 @@ func TestHandleRemoveSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	mockService.EXPECT().DeleteRule(gomock.Any(), "mocked_rule1:allow").Return(nil)
@@ -564,7 +582,7 @@ func TestHandleRemoveSuccess(t *testing.T) {
 	req := httptest.NewRequest(http.MethodDelete, "/api/v0/rules/mocked_rule1:allow", nil)
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -596,6 +614,8 @@ func TestHandleRemoveFailed(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	mockService.EXPECT().DeleteRule(gomock.Any(), "mocked_rule1:allow").Return(fmt.Errorf("mock_error"))
@@ -603,7 +623,7 @@ func TestHandleRemoveFailed(t *testing.T) {
 	req := httptest.NewRequest(http.MethodDelete, "/api/v0/rules/mocked_rule1:allow", nil)
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -638,6 +658,8 @@ func TestRegisterValidation(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 	mockValidationRegistry := NewMockValidationRegistryInterface(ctrl)
 
@@ -650,10 +672,10 @@ func TestRegisterValidation(t *testing.T) {
 		Return(fmt.Errorf("key is already registered"))
 
 	// first registration of `apiKey` is successful
-	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)
 
 	mockLogger.EXPECT().Fatalf(gomock.Any(), gomock.Any()).Times(1)
 
 	// second registration of `apiKey` causes logger.Fatal invocation
-	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)
 }

--- a/pkg/rules/interfaces.go
+++ b/pkg/rules/interfaces.go
@@ -9,6 +9,11 @@ import (
 	oathkeeper "github.com/ory/oathkeeper-client-go"
 )
 
+type AuthorizerInterface interface {
+	SetCreateRuleEntitlements(context.Context, string) error
+	SetDeleteRuleEntitlements(context.Context, string) error
+}
+
 type ServiceInterface interface {
 	ListRules(context.Context, int64, int64) ([]oathkeeper.Rule, error)
 	GetRule(context.Context, string) ([]oathkeeper.Rule, error)

--- a/pkg/rules/service_test.go
+++ b/pkg/rules/service_test.go
@@ -33,6 +33,7 @@ func TestListRulesSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockOathkeeperApiApi := NewMockApiApi(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 
@@ -83,7 +84,7 @@ func TestListRulesSuccess(t *testing.T) {
 	mockOathkeeperApiApi.EXPECT().ListRules(ctx).Times(1).Return(listRulesRequest)
 	mockOathkeeperApiApi.EXPECT().ListRulesExecute(gomock.Any()).Times(1).Return(mock_rules, new(http.Response), nil)
 
-	rules, err := NewService(&config, mockTracer, mockMonitor, mockLogger).ListRules(ctx, 1, 100)
+	rules, err := NewService(&config, mockAuthz, mockTracer, mockMonitor, mockLogger).ListRules(ctx, 1, 100)
 
 	if !reflect.DeepEqual(rules, mock_rules) {
 		t.Fatalf("expected identities to be %v not  %v", mock_rules, rules)
@@ -100,6 +101,7 @@ func TestListRulesFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockOathkeeperApiApi := NewMockApiApi(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 
@@ -144,7 +146,7 @@ func TestListRulesFails(t *testing.T) {
 	)
 	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
 
-	rules, err := NewService(&config, mockTracer, mockMonitor, mockLogger).ListRules(ctx, 1, 100)
+	rules, err := NewService(&config, mockAuthz, mockTracer, mockMonitor, mockLogger).ListRules(ctx, 1, 100)
 
 	if len(rules) != 0 {
 		t.Fatalf("expected rules to be empty list")
@@ -162,6 +164,7 @@ func TestGetRuleSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockOathkeeperApiApi := NewMockApiApi(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 
@@ -212,7 +215,7 @@ func TestGetRuleSuccess(t *testing.T) {
 	mockOathkeeperApiApi.EXPECT().GetRule(ctx, string_id).Times(1).Return(getRulesRequest)
 	mockOathkeeperApiApi.EXPECT().GetRuleExecute(gomock.Any()).Times(1).Return(&mock_rule, new(http.Response), nil)
 
-	rules, err := NewService(&config, mockTracer, mockMonitor, mockLogger).GetRule(ctx, string_id)
+	rules, err := NewService(&config, mockAuthz, mockTracer, mockMonitor, mockLogger).GetRule(ctx, string_id)
 
 	if !reflect.DeepEqual(rules, mock_rule_list) {
 		t.Fatalf("expected identities to be %v not  %v", mock_rule_list, rules)
@@ -229,6 +232,7 @@ func TestGetRuleFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockOathkeeperApiApi := NewMockApiApi(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 
@@ -275,7 +279,7 @@ func TestGetRuleFails(t *testing.T) {
 	)
 	mockLogger.EXPECT().Error(gomock.Any()).Times(1)
 
-	_, err := NewService(&config, mockTracer, mockMonitor, mockLogger).GetRule(ctx, string_id)
+	_, err := NewService(&config, mockAuthz, mockTracer, mockMonitor, mockLogger).GetRule(ctx, string_id)
 
 	if err == nil {
 		t.Fatal("expected error to be not nil")
@@ -289,6 +293,7 @@ func TestUpdateRuleSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockOathkeeperApiApi := NewMockApiApi(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
@@ -396,7 +401,7 @@ func TestUpdateRuleSuccess(t *testing.T) {
 		},
 	)
 
-	err := NewService(&config, mockTracer, mockMonitor, mockLogger).UpdateRule(ctx, rules2_id, ruleUpdate)
+	err := NewService(&config, mockAuthz, mockTracer, mockMonitor, mockLogger).UpdateRule(ctx, rules2_id, ruleUpdate)
 
 	if err != nil {
 		t.Fatalf("expected error to be nil not  %v", err)
@@ -411,6 +416,7 @@ func TestUpdateRuleNotFound(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockOathkeeperApiApi := NewMockApiApi(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
@@ -503,7 +509,7 @@ func TestUpdateRuleNotFound(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(config.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, "mock_config", gomock.Any()).Times(1).Return(cm, nil)
 
-	err := NewService(&config, mockTracer, mockMonitor, mockLogger).UpdateRule(ctx, rules3_id, ruleUpdate)
+	err := NewService(&config, mockAuthz, mockTracer, mockMonitor, mockLogger).UpdateRule(ctx, rules3_id, ruleUpdate)
 
 	expectedError := fmt.Sprintf("rule with ID %s not found", *ruleUpdate.Id)
 	if err.Error() != expectedError {
@@ -518,6 +524,7 @@ func TestUpdateRuleIdMismatch(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockOathkeeperApiApi := NewMockApiApi(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 
@@ -607,7 +614,7 @@ func TestUpdateRuleIdMismatch(t *testing.T) {
 
 	mockTracer.EXPECT().Start(ctx, "rules.Service.UpdateRule").Times(1).Return(ctx, trace.SpanFromContext(ctx))
 
-	err := NewService(&config, mockTracer, mockMonitor, mockLogger).UpdateRule(ctx, rules1_id, rule_update)
+	err := NewService(&config, mockAuthz, mockTracer, mockMonitor, mockLogger).UpdateRule(ctx, rules1_id, rule_update)
 
 	expectedError := fmt.Sprintf("The URL parameter id %s is different from payload rule id %s", rules1_id, *rule_update.Id)
 	if err.Error() != expectedError {
@@ -622,6 +629,7 @@ func TestCreateRuleSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockOathkeeperApiApi := NewMockApiApi(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
@@ -715,6 +723,7 @@ func TestCreateRuleSuccess(t *testing.T) {
 	ruleCreatedRaw, _ := json.Marshal(ruleCreateList)
 
 	mockTracer.EXPECT().Start(ctx, "rules.Service.CreateRule").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockAuthz.EXPECT().SetCreateRuleEntitlements(gomock.Any(), *ruleCreate.Id)
 	mockCoreV1.EXPECT().ConfigMaps(config.Namespace).Times(2).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, "mock_config", gomock.Any()).Times(1).Return(cm, nil)
 	mockConfigMapV1.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
@@ -728,7 +737,7 @@ func TestCreateRuleSuccess(t *testing.T) {
 		},
 	)
 
-	err := NewService(&config, mockTracer, mockMonitor, mockLogger).CreateRule(ctx, ruleCreate)
+	err := NewService(&config, mockAuthz, mockTracer, mockMonitor, mockLogger).CreateRule(ctx, ruleCreate)
 
 	if err != nil {
 		t.Fatalf("expected error to be nil not  %v", err)
@@ -742,6 +751,7 @@ func TestCreateRuleAlreadyExists(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockOathkeeperApiApi := NewMockApiApi(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
@@ -833,7 +843,7 @@ func TestCreateRuleAlreadyExists(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(config.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, "mock_config", gomock.Any()).Times(1).Return(cm, nil)
 
-	err := NewService(&config, mockTracer, mockMonitor, mockLogger).CreateRule(ctx, ruleCreate)
+	err := NewService(&config, mockAuthz, mockTracer, mockMonitor, mockLogger).CreateRule(ctx, ruleCreate)
 
 	expected_error := fmt.Sprintf("rule with ID %s already exists", *ruleCreate.Id)
 	if err.Error() != expected_error {
@@ -848,6 +858,7 @@ func TestDeleteRuleSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockOathkeeperApiApi := NewMockApiApi(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
@@ -895,6 +906,7 @@ func TestDeleteRuleSuccess(t *testing.T) {
 	cm.Data[config.File] = string(rawRuleList)
 
 	mockTracer.EXPECT().Start(ctx, "rules.Service.DeleteRule").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockAuthz.EXPECT().SetDeleteRuleEntitlements(gomock.Any(), rules1_id)
 	mockCoreV1.EXPECT().ConfigMaps(config.Namespace).Times(2).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, "mock_config", gomock.Any()).Times(1).Return(cm, nil)
 	mockConfigMapV1.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
@@ -908,7 +920,7 @@ func TestDeleteRuleSuccess(t *testing.T) {
 		},
 	)
 
-	err := NewService(&config, mockTracer, mockMonitor, mockLogger).DeleteRule(ctx, rules1_id)
+	err := NewService(&config, mockAuthz, mockTracer, mockMonitor, mockLogger).DeleteRule(ctx, rules1_id)
 
 	if err != nil {
 		t.Fatalf("expected error to be nil not  %v", err)
@@ -922,6 +934,7 @@ func TestDeleteRuleFailure(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockOathkeeperApiApi := NewMockApiApi(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
@@ -974,7 +987,7 @@ func TestDeleteRuleFailure(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(config.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, "mock_config", gomock.Any()).Times(1).Return(cm, nil)
 
-	err := NewService(&config, mockTracer, mockMonitor, mockLogger).DeleteRule(ctx, ruleForDeletion)
+	err := NewService(&config, mockAuthz, mockTracer, mockMonitor, mockLogger).DeleteRule(ctx, ruleForDeletion)
 
 	expected_error := fmt.Sprintf("rule with ID %s not found", ruleForDeletion)
 	if err.Error() != expected_error {

--- a/pkg/schemas/handlers.go
+++ b/pkg/schemas/handlers.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
 	"github.com/canonical/identity-platform-admin-ui/internal/validation"
 )
 
@@ -21,7 +23,9 @@ type API struct {
 	service          ServiceInterface
 	payloadValidator validation.PayloadValidatorInterface
 
-	logger logging.LoggerInterface
+	tracer  tracing.TracingInterface
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
 }
 
 func (a *API) RegisterEndpoints(mux *chi.Mux) {
@@ -356,12 +360,15 @@ func (a *API) error(e *kClient.GenericError) types.Response {
 
 }
 
-func NewAPI(service ServiceInterface, logger logging.LoggerInterface) *API {
+func NewAPI(service ServiceInterface, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *API {
 	a := new(API)
 
 	a.apiKey = "schemas"
 	a.service = service
 	a.payloadValidator = NewSchemasPayloadValidator(a.apiKey, logger)
+
+	a.tracer = tracer
+	a.monitor = monitor
 	a.logger = logger
 
 	return a

--- a/pkg/schemas/handlers_test.go
+++ b/pkg/schemas/handlers_test.go
@@ -36,6 +36,8 @@ func TestHandleListSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	v0Schema := map[string]interface{}{
@@ -115,7 +117,7 @@ func TestHandleListSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -162,6 +164,8 @@ func TestHandleListFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v0/schemas", nil)
@@ -175,7 +179,7 @@ func TestHandleListFails(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -203,6 +207,8 @@ func TestHandleDetailSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	v0Schema := map[string]interface{}{
@@ -249,7 +255,7 @@ func TestHandleDetailSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -289,6 +295,8 @@ func TestHandleDetailEmpty(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/schemas/%s", "random"), nil)
@@ -301,7 +309,7 @@ func TestHandleDetailEmpty(t *testing.T) {
 	)
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -337,6 +345,8 @@ func TestHandleDetailFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	ID := "test-1"
@@ -351,7 +361,7 @@ func TestHandleDetailFails(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -378,6 +388,8 @@ func TestHandleCreateSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	v0Schema := map[string]interface{}{
@@ -431,7 +443,7 @@ func TestHandleCreateSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -471,6 +483,8 @@ func TestHandleCreateFailsIfIDPassedIn(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	v0Schema := map[string]interface{}{
@@ -510,7 +524,7 @@ func TestHandleCreateFailsIfIDPassedIn(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -547,6 +561,8 @@ func TestHandleCreateFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	v0Schema := map[string]interface{}{
@@ -598,7 +614,7 @@ func TestHandleCreateFails(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -629,13 +645,15 @@ func TestHandleCreateFailBadRequest(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v0/schemas", strings.NewReader("test"))
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -666,6 +684,8 @@ func TestHandlePartialUpdateSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	v0Schema := map[string]interface{}{
@@ -723,7 +743,7 @@ func TestHandlePartialUpdateSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -763,6 +783,8 @@ func TestHandlePartialUpdateFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	v0Schema := map[string]interface{}{
@@ -820,7 +842,7 @@ func TestHandlePartialUpdateFails(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -851,13 +873,15 @@ func TestHandlePartialUpdateFailBadRequest(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodPatch, "/api/v0/schemas/fake", strings.NewReader("test"))
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -888,6 +912,8 @@ func TestHandleRemoveSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	credID := "test-1"
@@ -898,7 +924,7 @@ func TestHandleRemoveSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -932,6 +958,8 @@ func TestHandleRemoveFails(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	credID := "test-1"
@@ -941,7 +969,7 @@ func TestHandleRemoveFails(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -972,6 +1000,8 @@ func TestHandleDetailDefaultSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	defaultSchemaID := "mock_default"
@@ -984,7 +1014,7 @@ func TestHandleDetailDefaultSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1020,6 +1050,8 @@ func TestHandleDetailDefaultFail(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v0/schemas/default", nil)
@@ -1028,7 +1060,7 @@ func TestHandleDetailDefaultFail(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1064,6 +1096,8 @@ func TestHandleUpdateDefaultSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	defaultSchemaID := "mock_default"
@@ -1078,7 +1112,7 @@ func TestHandleUpdateDefaultSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1114,13 +1148,15 @@ func TestHandleUpdateDefaultBadRequest(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	req := httptest.NewRequest(http.MethodPut, "/api/v0/schemas/default", strings.NewReader("test"))
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1151,6 +1187,8 @@ func TestHandleUpdateDefaultFail(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 
 	defaultSchemaID := "mock_default"
@@ -1174,7 +1212,7 @@ func TestHandleUpdateDefaultFail(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()
-	NewAPI(mockService, mockLogger).RegisterEndpoints(mux)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterEndpoints(mux)
 
 	mux.ServeHTTP(w, req)
 
@@ -1205,6 +1243,8 @@ func TestRegisterValidation(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockLogger := NewMockLoggerInterface(ctrl)
+	mockTracer := NewMockTracer(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
 	mockService := NewMockServiceInterface(ctrl)
 	mockValidationRegistry := NewMockValidationRegistryInterface(ctrl)
 
@@ -1217,10 +1257,10 @@ func TestRegisterValidation(t *testing.T) {
 		Return(fmt.Errorf("key is already registered"))
 
 	// first registration of `apiKey` is successful
-	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)
 
 	mockLogger.EXPECT().Fatalf(gomock.Any(), gomock.Any()).Times(1)
 
 	// second registration of `apiKey` causes logger.Fatal invocation
-	NewAPI(mockService, mockLogger).RegisterValidation(mockValidationRegistry)
+	NewAPI(mockService, mockTracer, mockMonitor, mockLogger).RegisterValidation(mockValidationRegistry)
 }

--- a/pkg/schemas/interfaces.go
+++ b/pkg/schemas/interfaces.go
@@ -9,6 +9,11 @@ import (
 	kClient "github.com/ory/kratos-client-go"
 )
 
+type AuthorizerInterface interface {
+	SetCreateSchemaEntitlements(context.Context, string) error
+	SetDeleteSchemaEntitlements(context.Context, string) error
+}
+
 type ServiceInterface interface {
 	ListSchemas(context.Context, int64, string) (*IdentitySchemaData, error)
 	GetSchema(context.Context, string) (*IdentitySchemaData, error)

--- a/pkg/schemas/service_test.go
+++ b/pkg/schemas/service_test.go
@@ -33,6 +33,7 @@ func TestListSchemasSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 	ctx := context.Background()
@@ -133,7 +134,7 @@ func TestListSchemasSuccess(t *testing.T) {
 			return schemas, rr, nil
 		},
 	)
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).ListSchemas(ctx, 10, "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ")
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).ListSchemas(ctx, 10, "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ")
 
 	if !reflect.DeepEqual(is.IdentitySchemas, schemas) {
 		t.Fatalf("expected schemas to be %v not  %v", schemas, is.IdentitySchemas)
@@ -152,6 +153,7 @@ func TestListSchemasFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 	ctx := context.Background()
@@ -206,7 +208,7 @@ func TestListSchemasFails(t *testing.T) {
 			return schemas, rr.Result(), fmt.Errorf("error")
 		},
 	)
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).ListSchemas(ctx, 10, "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ")
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).ListSchemas(ctx, 10, "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ")
 
 	if is.Error == nil {
 		t.Fatal("expected ids.Error to be not nil")
@@ -228,6 +230,7 @@ func TestListSchemasSuccessButEmpty(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 	ctx := context.Background()
@@ -261,7 +264,7 @@ func TestListSchemasSuccessButEmpty(t *testing.T) {
 			return schemas, new(http.Response), nil
 		},
 	)
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).ListSchemas(ctx, 10, "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ")
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).ListSchemas(ctx, 10, "eyJvZmZzZXQiOiIyNTAiLCJ2IjoyfQ")
 
 	if !reflect.DeepEqual(is.IdentitySchemas, schemas) {
 		t.Fatalf("expected schemas to be %v not  %v", schemas, is.IdentitySchemas)
@@ -280,6 +283,7 @@ func TestGetSchemaSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 	ctx := context.Background()
@@ -330,7 +334,7 @@ func TestGetSchemaSuccess(t *testing.T) {
 	mockKratosIdentityAPI.EXPECT().GetIdentitySchema(ctx, v0ID).Times(1).Return(identitySchemaRequest)
 	mockKratosIdentityAPI.EXPECT().GetIdentitySchemaExecute(gomock.Any()).Times(1).Return(schema.Schema, new(http.Response), nil)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).GetSchema(ctx, v0ID)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).GetSchema(ctx, v0ID)
 
 	if !reflect.DeepEqual(is.IdentitySchemas, []kClient.IdentitySchemaContainer{schema}) {
 		t.Fatalf("expected schemas to be %v not  %v", schema, is.IdentitySchemas)
@@ -347,6 +351,7 @@ func TestGetSchemaSuccessButEmpty(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 	ctx := context.Background()
@@ -365,7 +370,7 @@ func TestGetSchemaSuccessButEmpty(t *testing.T) {
 	mockKratosIdentityAPI.EXPECT().GetIdentitySchema(ctx, "test").Times(1).Return(identitySchemaRequest)
 	mockKratosIdentityAPI.EXPECT().GetIdentitySchemaExecute(gomock.Any()).Times(1).Return(nil, new(http.Response), nil)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).GetSchema(ctx, "test")
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).GetSchema(ctx, "test")
 
 	if !reflect.DeepEqual(is.IdentitySchemas, []kClient.IdentitySchemaContainer{}) {
 		t.Fatalf("expected schemas to be empty not  %v", is.IdentitySchemas)
@@ -382,6 +387,7 @@ func TestGetSchemaFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
 	ctx := context.Background()
@@ -425,7 +431,7 @@ func TestGetSchemaFails(t *testing.T) {
 		},
 	)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).GetSchema(ctx, "fake")
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).GetSchema(ctx, "fake")
 
 	if !reflect.DeepEqual(is.IdentitySchemas, make([]kClient.IdentitySchemaContainer, 0)) {
 		t.Fatalf("expected schemas to be empty not  %v", is.IdentitySchemas)
@@ -451,6 +457,7 @@ func TestEdiSchemaSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -546,7 +553,7 @@ func TestEdiSchemaSuccess(t *testing.T) {
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).Return(cm, nil)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).EditSchema(ctx, v0ID, c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).EditSchema(ctx, v0ID, c)
 
 	if !reflect.DeepEqual(is.IdentitySchemas[0].Schema, c.Schema) {
 		t.Fatalf("expected schema secret to be %v not  %v", c.Schema, is.IdentitySchemas[0].Schema)
@@ -565,6 +572,7 @@ func TestEditSchemaNotfound(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -661,7 +669,7 @@ func TestEditSchemaNotfound(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).EditSchema(ctx, "fake", c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).EditSchema(ctx, "fake", c)
 
 	if len(is.IdentitySchemas) != 0 {
 		t.Fatalf("expected schemas to be empty not  %v", is.IdentitySchemas)
@@ -679,6 +687,7 @@ func TestEditSchemaFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -734,7 +743,7 @@ func TestEditSchemaFails(t *testing.T) {
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).Return(cm, fmt.Errorf("error"))
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).EditSchema(ctx, v0ID, c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).EditSchema(ctx, v0ID, c)
 
 	if is != nil {
 		t.Fatalf("expected schemas to be nil, not %v", is)
@@ -752,6 +761,7 @@ func TestCreateSchemaSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -799,6 +809,7 @@ func TestCreateSchemaSuccess(t *testing.T) {
 	c.Schema = v0Schema
 
 	mockTracer.EXPECT().Start(ctx, "schemas.Service.CreateSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockAuthz.EXPECT().SetCreateSchemaEntitlements(gomock.Any(), *c.Id)
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(2).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).DoAndReturn(
@@ -821,7 +832,7 @@ func TestCreateSchemaSuccess(t *testing.T) {
 		},
 	)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).CreateSchema(ctx, c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).CreateSchema(ctx, c)
 
 	if err != nil {
 		t.Fatalf("expected error to be nil not  %v", err)
@@ -844,6 +855,7 @@ func TestCreateSchemaSuccessWithEmptyConfigmap(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -890,6 +902,7 @@ func TestCreateSchemaSuccessWithEmptyConfigmap(t *testing.T) {
 	c.Schema = v0Schema
 
 	mockTracer.EXPECT().Start(ctx, "schemas.Service.CreateSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockAuthz.EXPECT().SetCreateSchemaEntitlements(gomock.Any(), *c.Id)
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(2).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).DoAndReturn(
@@ -912,7 +925,7 @@ func TestCreateSchemaSuccessWithEmptyConfigmap(t *testing.T) {
 		},
 	)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).CreateSchema(ctx, c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).CreateSchema(ctx, c)
 
 	if err != nil {
 		t.Fatalf("expected error to be nil not  %v", err)
@@ -935,6 +948,7 @@ func TestCreateSchemaSuccessIfIDIsMissing(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -975,10 +989,14 @@ func TestCreateSchemaSuccessIfIDIsMissing(t *testing.T) {
 	cm := new(v1.ConfigMap)
 	cm.Data = make(map[string]string)
 
+	v0ID := "test_v0"
+
 	c := new(kClient.IdentitySchemaContainer)
+	c.Id = &v0ID
 	c.Schema = v0Schema
 
 	mockTracer.EXPECT().Start(ctx, "schemas.Service.CreateSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockAuthz.EXPECT().SetCreateSchemaEntitlements(gomock.Any(), *c.Id)
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(2).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).DoAndReturn(
@@ -1005,7 +1023,7 @@ func TestCreateSchemaSuccessIfIDIsMissing(t *testing.T) {
 		},
 	)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).CreateSchema(ctx, c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).CreateSchema(ctx, c)
 
 	if err != nil {
 		t.Fatalf("expected error to be nil not  %v", err)
@@ -1027,6 +1045,7 @@ func TestCreateSchemaFailsConflict(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -1079,7 +1098,7 @@ func TestCreateSchemaFailsConflict(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).CreateSchema(ctx, c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).CreateSchema(ctx, c)
 
 	if err == nil {
 		t.Fatalf("expected error not to be nil")
@@ -1098,6 +1117,7 @@ func TestCreateSchemaFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -1167,7 +1187,7 @@ func TestCreateSchemaFails(t *testing.T) {
 		},
 	)
 
-	is, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).CreateSchema(ctx, c)
+	is, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).CreateSchema(ctx, c)
 
 	if is != nil {
 		t.Fatalf("expected schema to be empty not %v", is.IdentitySchemas)
@@ -1185,6 +1205,7 @@ func TestDeleteSchemaSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -1270,6 +1291,7 @@ func TestDeleteSchemaSuccess(t *testing.T) {
 	}
 
 	mockTracer.EXPECT().Start(ctx, "schemas.Service.DeleteSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
+	mockAuthz.EXPECT().SetDeleteSchemaEntitlements(gomock.Any(), v0ID)
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(2).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 	mockConfigMapV1.EXPECT().Update(gomock.Any(), cm, gomock.Any()).Times(1).DoAndReturn(
@@ -1282,7 +1304,7 @@ func TestDeleteSchemaSuccess(t *testing.T) {
 		},
 	)
 
-	err := NewService(cfg, mockTracer, mockMonitor, mockLogger).DeleteSchema(ctx, v0ID)
+	err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).DeleteSchema(ctx, v0ID)
 
 	if err != nil {
 		t.Fatalf("expected error to be nil not  %v", err)
@@ -1296,6 +1318,7 @@ func TestDeleteSchemaNotFound(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -1383,7 +1406,7 @@ func TestDeleteSchemaNotFound(t *testing.T) {
 	mockTracer.EXPECT().Start(ctx, "schemas.Service.DeleteSchema").Times(1).Return(ctx, trace.SpanFromContext(ctx))
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
-	err := NewService(cfg, mockTracer, mockMonitor, mockLogger).DeleteSchema(ctx, "fake")
+	err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).DeleteSchema(ctx, "fake")
 
 	if err == nil {
 		t.Fatalf("expected error not to be nil")
@@ -1397,6 +1420,7 @@ func TestDeleteSchemaFailsIfDefault(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -1486,7 +1510,7 @@ func TestDeleteSchemaFailsIfDefault(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	err := NewService(cfg, mockTracer, mockMonitor, mockLogger).DeleteSchema(ctx, DEFAULT_SCHEMA)
+	err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).DeleteSchema(ctx, DEFAULT_SCHEMA)
 
 	if err == nil {
 		t.Fatalf("expected error not to be nil")
@@ -1500,6 +1524,7 @@ func TestDeleteSchemaFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -1592,7 +1617,7 @@ func TestDeleteSchemaFails(t *testing.T) {
 			return nil, fmt.Errorf("error")
 		},
 	)
-	err := NewService(cfg, mockTracer, mockMonitor, mockLogger).DeleteSchema(ctx, v0ID)
+	err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).DeleteSchema(ctx, v0ID)
 
 	if err == nil {
 		t.Fatalf("expected error not to be nil")
@@ -1606,6 +1631,7 @@ func TestGetDefaultSchemaSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -1629,7 +1655,7 @@ func TestGetDefaultSchemaSuccess(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	ds, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).GetDefaultSchema(ctx)
+	ds, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).GetDefaultSchema(ctx)
 
 	if ds.ID != defaultSchemaID {
 		t.Fatalf("expected default schema id to be %s not %s", defaultSchemaID, ds.ID)
@@ -1647,6 +1673,7 @@ func TestGetDefaultSchemaNoDefaultSchema(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -1672,7 +1699,7 @@ func TestGetDefaultSchemaNoDefaultSchema(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	ds, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).GetDefaultSchema(ctx)
+	ds, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).GetDefaultSchema(ctx)
 
 	if ds != nil {
 		t.Fatalf("expected returned value to be nil not %s", ds)
@@ -1690,6 +1717,7 @@ func TestGetDefaultSchemaFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -1706,7 +1734,7 @@ func TestGetDefaultSchemaFails(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(nil, fmt.Errorf("mock_error"))
 
-	ds, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).GetDefaultSchema(ctx)
+	ds, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).GetDefaultSchema(ctx)
 
 	if ds != nil {
 		t.Fatalf("expected returned value to be nil not %s", ds)
@@ -1724,6 +1752,7 @@ func TestUpdateDefaultSchemaSuccess(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -1782,7 +1811,7 @@ func TestUpdateDefaultSchemaSuccess(t *testing.T) {
 		},
 	)
 
-	ds, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).UpdateDefaultSchema(ctx, defaultSchemaUpdate)
+	ds, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).UpdateDefaultSchema(ctx, defaultSchemaUpdate)
 
 	if ds.ID != defaultSchemaUpdateID {
 		t.Fatalf("expected default schema id to be %s not %s", defaultSchemaID, ds.ID)
@@ -1800,6 +1829,7 @@ func TestUpdateDefaultSchemaIdNotFound(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -1824,7 +1854,7 @@ func TestUpdateDefaultSchemaIdNotFound(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	ds, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).UpdateDefaultSchema(ctx, defaultSchemaUpdate)
+	ds, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).UpdateDefaultSchema(ctx, defaultSchemaUpdate)
 
 	if ds != nil {
 		t.Fatalf("expected default schema id to be nil not %s", ds.ID)
@@ -1843,6 +1873,7 @@ func TestUpdateDefaultSchemaIdIsDefaultKey(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -1867,7 +1898,7 @@ func TestUpdateDefaultSchemaIdIsDefaultKey(t *testing.T) {
 	mockCoreV1.EXPECT().ConfigMaps(cfg.Namespace).Times(1).Return(mockConfigMapV1)
 	mockConfigMapV1.EXPECT().Get(ctx, cfg.Name, gomock.Any()).Times(1).Return(cm, nil)
 
-	ds, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).UpdateDefaultSchema(ctx, defaultSchemaUpdate)
+	ds, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).UpdateDefaultSchema(ctx, defaultSchemaUpdate)
 
 	if ds != nil {
 		t.Fatalf("expected default schema id to be nil not %s", ds.ID)
@@ -1886,6 +1917,7 @@ func TestUpdateDefaultSchemaFails(t *testing.T) {
 	mockLogger := NewMockLoggerInterface(ctrl)
 	mockTracer := NewMockTracer(ctrl)
 	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
 	mockCoreV1 := NewMockCoreV1Interface(ctrl)
 	mockConfigMapV1 := NewMockConfigMapInterface(ctrl)
 	mockKratosIdentityAPI := NewMockIdentityAPI(ctrl)
@@ -1944,7 +1976,7 @@ func TestUpdateDefaultSchemaFails(t *testing.T) {
 		},
 	)
 
-	_, err := NewService(cfg, mockTracer, mockMonitor, mockLogger).UpdateDefaultSchema(ctx, defaultSchemaUpdate)
+	_, err := NewService(cfg, mockAuthz, mockTracer, mockMonitor, mockLogger).UpdateDefaultSchema(ctx, defaultSchemaUpdate)
 
 	if err.Error() != "mock_error" {
 		t.Fatalf("expected error message to be mock_error not  %s", err.Error())

--- a/pkg/web/config.go
+++ b/pkg/web/config.go
@@ -53,7 +53,7 @@ type ExternalClientsConfig struct {
 	kratosPublic     *ik.Client
 	oathkeeperPublic *io.Client
 	ofga             OpenFGAClientInterface
-	authorizer       OpenFGAClientInterface
+	authorizer       AuthorizerClientInterface
 }
 
 // HydraAdmin returns an hydra client to interact with the admin API
@@ -82,17 +82,17 @@ func (c *ExternalClientsConfig) OpenFGA() OpenFGAClientInterface {
 }
 
 // Authorizer returns an openfga client used for the authorization middleware
-func (c *ExternalClientsConfig) Authorizer() OpenFGAClientInterface {
+func (c *ExternalClientsConfig) Authorizer() AuthorizerClientInterface {
 	return c.authorizer
 }
 
 // SetAuthorizer sets the authorization middleware
-func (c *ExternalClientsConfig) SetAuthorizer(o OpenFGAClientInterface) {
+func (c *ExternalClientsConfig) SetAuthorizer(o AuthorizerClientInterface) {
 	c.authorizer = o
 }
 
 // NewExternalClientsConfig create a third party config object for all the external clients needed
-func NewExternalClientsConfig(hydra *ih.Client, kratosAdmin *ik.Client, kratosPublic *ik.Client, oathkeeper *io.Client, ofga OpenFGAClientInterface, authorizer OpenFGAClientInterface) *ExternalClientsConfig {
+func NewExternalClientsConfig(hydra *ih.Client, kratosAdmin *ik.Client, kratosPublic *ik.Client, oathkeeper *io.Client, ofga OpenFGAClientInterface, authorizer AuthorizerClientInterface) *ExternalClientsConfig {
 	c := new(ExternalClientsConfig)
 
 	c.hydraAdmin = hydra

--- a/pkg/web/interfaces.go
+++ b/pkg/web/interfaces.go
@@ -33,7 +33,6 @@ type OpenFGAClientInterface interface {
 type AuthorizerClientInterface interface {
 	ListObjects(context.Context, string, string, string) ([]string, error)
 	Check(context.Context, string, string, string, ...ofga.Tuple) (bool, error)
-	WriteTuple(ctx context.Context, user, relation, object string) error
 }
 
 type O11yConfigInterface interface {

--- a/pkg/web/interfaces.go
+++ b/pkg/web/interfaces.go
@@ -10,6 +10,7 @@ import (
 	openfga "github.com/openfga/go-sdk"
 	trace "go.opentelemetry.io/otel/trace"
 
+	"github.com/canonical/identity-platform-admin-ui/internal/authorization"
 	ih "github.com/canonical/identity-platform-admin-ui/internal/hydra"
 	ik "github.com/canonical/identity-platform-admin-ui/internal/kratos"
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
@@ -30,10 +31,7 @@ type OpenFGAClientInterface interface {
 	ReadTuples(context.Context, string, string, string, string) (*openfga.ReadResponse, error)
 }
 
-type AuthorizerClientInterface interface {
-	ListObjects(context.Context, string, string, string) ([]string, error)
-	Check(context.Context, string, string, string, ...ofga.Tuple) (bool, error)
-}
+type AuthorizerClientInterface = *authorization.Authorizer
 
 type O11yConfigInterface interface {
 	Tracer() trace.Tracer

--- a/pkg/web/interfaces.go
+++ b/pkg/web/interfaces.go
@@ -30,6 +30,12 @@ type OpenFGAClientInterface interface {
 	ReadTuples(context.Context, string, string, string, string) (*openfga.ReadResponse, error)
 }
 
+type AuthorizerClientInterface interface {
+	ListObjects(context.Context, string, string, string) ([]string, error)
+	Check(context.Context, string, string, string, ...ofga.Tuple) (bool, error)
+	WriteTuple(ctx context.Context, user, relation, object string) error
+}
+
 type O11yConfigInterface interface {
 	Tracer() trace.Tracer
 	Monitor() monitoring.MonitorInterface
@@ -40,5 +46,5 @@ type ExternalClientsConfigInterface interface {
 	HydraAdmin() *ih.Client
 	KratosAdmin() *ik.Client
 	OpenFGA() OpenFGAClientInterface
-	Authorizer() OpenFGAClientInterface
+	Authorizer() AuthorizerClientInterface
 }

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -77,7 +77,7 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 		middlewareCORS([]string{"*"}),
 	)
 	authorizationMiddleware := authorization.NewMiddleware(
-		authorization.NewAuthorizer(externalConfig.Authorizer(), tracer, monitor, logger), monitor, logger,
+		authorization.NewAuthorizer(externalConfig.OpenFGA(), tracer, monitor, logger), monitor, logger,
 	).Authorize()
 
 	// TODO @shipperizer add a proper configuration to enable http logger middleware as it's expensive

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -95,26 +95,36 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 
 	identitiesAPI := identities.NewAPI(
 		identities.NewService(externalConfig.KratosAdmin().IdentityAPI(), tracer, monitor, logger),
+		tracer,
+		monitor,
 		logger,
 	)
 
 	clientsAPI := clients.NewAPI(
 		clients.NewService(externalConfig.HydraAdmin(), tracer, monitor, logger),
+		tracer,
+		monitor,
 		logger,
 	)
 
 	idpAPI := idp.NewAPI(
 		idp.NewService(idpConfig, tracer, monitor, logger),
+		tracer,
+		monitor,
 		logger,
 	)
 
 	schemasAPI := schemas.NewAPI(
 		schemas.NewService(schemasConfig, tracer, monitor, logger),
+		tracer,
+		monitor,
 		logger,
 	)
 
 	rulesAPI := rules.NewAPI(
 		rules.NewService(rulesConfig, tracer, monitor, logger),
+		tracer,
+		monitor,
 		logger,
 	)
 

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -76,9 +76,7 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 		monitoring.NewMiddleware(monitor, logger).ResponseTime(),
 		middlewareCORS([]string{"*"}),
 	)
-	authorizationMiddleware := authorization.NewMiddleware(
-		authorization.NewAuthorizer(externalConfig.OpenFGA(), tracer, monitor, logger), monitor, logger,
-	).Authorize()
+	authorizationMiddleware := authorization.NewMiddleware(config.external.Authorizer(), monitor, logger).Authorize()
 
 	// TODO @shipperizer add a proper configuration to enable http logger middleware as it's expensive
 	if true {
@@ -94,35 +92,35 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 	metricsAPI := metrics.NewAPI(logger)
 
 	identitiesAPI := identities.NewAPI(
-		identities.NewService(externalConfig.KratosAdmin().IdentityAPI(), tracer, monitor, logger),
+		identities.NewService(externalConfig.KratosAdmin().IdentityAPI(), externalConfig.Authorizer(), tracer, monitor, logger),
 		tracer,
 		monitor,
 		logger,
 	)
 
 	clientsAPI := clients.NewAPI(
-		clients.NewService(externalConfig.HydraAdmin(), tracer, monitor, logger),
+		clients.NewService(externalConfig.HydraAdmin(), externalConfig.Authorizer(), tracer, monitor, logger),
 		tracer,
 		monitor,
 		logger,
 	)
 
 	idpAPI := idp.NewAPI(
-		idp.NewService(idpConfig, tracer, monitor, logger),
+		idp.NewService(idpConfig, externalConfig.Authorizer(), tracer, monitor, logger),
 		tracer,
 		monitor,
 		logger,
 	)
 
 	schemasAPI := schemas.NewAPI(
-		schemas.NewService(schemasConfig, tracer, monitor, logger),
+		schemas.NewService(schemasConfig, externalConfig.Authorizer(), tracer, monitor, logger),
 		tracer,
 		monitor,
 		logger,
 	)
 
 	rulesAPI := rules.NewAPI(
-		rules.NewService(rulesConfig, tracer, monitor, logger),
+		rules.NewService(rulesConfig, externalConfig.Authorizer(), tracer, monitor, logger),
 		tracer,
 		monitor,
 		logger,


### PR DESCRIPTION
IAM-866

If we agree with this I will refactor all APIs. My main purpose with this approach is to keep the authz logic away from each API and to contain it in the `authorization` package.

Also fixes some of the logic for initializing the authorizer (@shipperizer @BarcoMasile please have a look that I don't break something in `serve.go` and `router.go`.

Closes #298