### PR TITLE
fix: temporary fix to allow time for new solution on the frontend for UI redirect

### DIFF
--- a/pkg/ui/handlers.go
+++ b/pkg/ui/handlers.go
@@ -30,7 +30,10 @@ type API struct {
 }
 
 func (a *API) RegisterEndpoints(mux *chi.Mux) {
-	mux.Get(UIPrefix, a.uiFiles)
+	mux.Get(UIPrefix, func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, r.URL.Path+"/", http.StatusMovedPermanently)
+	})
+	mux.Get(UIPrefix+"/", a.uiFiles)
 	mux.Get(UIPrefix+"/*", a.uiFiles)
 }
 


### PR DESCRIPTION
## Description
This PR comes after a chat with @huwshimi to allow for time to consider better solutions to handle redirects to the frontend SPA.
See #353 .

This implements the redirect from `/ui` to `/ui/` to let the assets download work.
This will be improved in the near future to make the system less fragile.