### PR TITLE
IAM-891 link authenticated users to authorization model

### DIFF
--- a/internal/authorization/authorization.go
+++ b/internal/authorization/authorization.go
@@ -1,5 +1,5 @@
-// Copyright 2024 Canonical Ltd
-// SPDX-License-Identifier: AGPL
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package authorization
 
@@ -13,6 +13,10 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/internal/pool"
 	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
 )
+
+type AdminContextKey string
+
+var adminContextKey AdminContextKey
 
 var ErrInvalidAuthModel = fmt.Errorf("Invalid authorization model schema")
 
@@ -92,5 +96,26 @@ func contains(s []string, e string) bool {
 			return true
 		}
 	}
+	return false
+}
+
+func IsAdminContext(ctx context.Context, isAdmin bool) context.Context {
+	parent := ctx
+	if ctx == nil {
+		parent = context.Background()
+	}
+
+	return context.WithValue(parent, adminContextKey, isAdmin)
+}
+
+func IsAdminFromContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+
+	if value, ok := ctx.Value(adminContextKey).(bool); ok {
+		return value
+	}
+
 	return false
 }

--- a/internal/authorization/authorization.go
+++ b/internal/authorization/authorization.go
@@ -78,6 +78,10 @@ func (a *Authorizer) ValidateModel(ctx context.Context) error {
 	return nil
 }
 
+func (a *Authorizer) Admin() AdminAuthorizerInterface {
+	return &a.AdminAuthorizer
+}
+
 func NewAuthorizer(client AuthzClientInterface, wpool pool.WorkerPoolInterface, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *Authorizer {
 	authorizer := new(Authorizer)
 	authorizer.client = client

--- a/internal/authorization/interfaces.go
+++ b/internal/authorization/interfaces.go
@@ -1,13 +1,14 @@
-// Copyright 2024 Canonical Ltd
-// SPDX-License-Identifier: AGPL
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package authorization
 
 import (
 	"context"
 
-	"github.com/canonical/identity-platform-admin-ui/internal/openfga"
 	fga "github.com/openfga/go-sdk"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/openfga"
 )
 
 type AuthorizerInterface interface {
@@ -15,6 +16,7 @@ type AuthorizerInterface interface {
 	Check(context.Context, string, string, string, ...openfga.Tuple) (bool, error)
 	FilterObjects(context.Context, string, string, string, []string) ([]string, error)
 	ValidateModel(context.Context) error
+	Admin() AdminAuthorizerInterface
 }
 
 type AuthzClientInterface interface {
@@ -24,4 +26,9 @@ type AuthzClientInterface interface {
 	CompareModel(context.Context, fga.AuthorizationModel) (bool, error)
 	WriteTuple(ctx context.Context, user, relation, object string) error
 	DeleteTuple(ctx context.Context, user, relation, object string) error
+}
+type AdminAuthorizerInterface interface {
+	CreateAdmin(ctx context.Context, username string) error
+	RemoveAdmin(ctx context.Context, username string) error
+	CheckAdmin(ctx context.Context, username string) (bool, error)
 }

--- a/internal/authorization/middlewares_test.go
+++ b/internal/authorization/middlewares_test.go
@@ -171,7 +171,11 @@ func TestMiddlewareAuthorize(t *testing.T) {
 
 			mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
-			calls = append(calls, mockAuthorizer.EXPECT().Check(gomock.Any(), "user:admin", "admin", ADMIN_PRIVILEGE).Times(1).Return(false, nil))
+			adminAuth := NewMockAdminAuthorizerInterface(ctrl)
+			adminAuth.EXPECT().CheckAdmin(gomock.Any(), gomock.Any()).Return(true, nil)
+
+			calls = append(calls, mockAuthorizer.EXPECT().Admin().Times(1).Return(adminAuth))
+			//calls = append(calls, mockAuthorizer.EXPECT().Check(gomock.Any(), "user:admin", "admin", ADMIN_PRIVILEGE).Times(1).Return(false, nil))
 			for _, check := range test.expect {
 				var call *gomock.Call
 				if !test.isGlobal {
@@ -231,9 +235,12 @@ func TestMiddlewareAuthorizeUseTokenHeader(t *testing.T) {
 
 	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
+	adminAuth := NewMockAdminAuthorizerInterface(ctrl)
+	adminAuth.EXPECT().CheckAdmin(gomock.Any(), gomock.Any()).Return(true, nil)
+
 	calls = append(
 		calls,
-		mockAuthorizer.EXPECT().Check(gomock.Any(), fmt.Sprintf("user:%s", testPrincipal.Identifier()), "admin", ADMIN_PRIVILEGE).Times(1).Return(false, nil),
+		mockAuthorizer.EXPECT().Admin().Times(1).Return(adminAuth),
 		mockAuthorizer.EXPECT().Check(gomock.Any(), gomock.Any(), CAN_VIEW, fmt.Sprintf("%s:%s", IDENTITY_TYPE, "__system__global"), gomock.Any(), gomock.Any()).Times(1).Return(true, nil),
 	)
 

--- a/internal/authorization/resource_manager.go
+++ b/internal/authorization/resource_manager.go
@@ -1,21 +1,26 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
 package authorization
 
 import (
 	"context"
 	"fmt"
+
+	"github.com/canonical/identity-platform-admin-ui/pkg/authentication"
 )
 
 var ErrNoUserInContext = fmt.Errorf("user not authenticated or requests context broken, cannot perform operation")
 
 func (a *Authorizer) createTuple(ctx context.Context, resourceID string) error {
-	user, ok := ctx.Value(USER_CTX).(*User)
-	if !ok {
+	principal := authentication.PrincipalFromContext(ctx)
+	if principal == nil {
 		return ErrNoUserInContext
 	}
 
 	_, err := a.wpool.Submit(
 		func() any {
-			if err := a.client.WriteTuple(context.Background(), "user:"+user.ID, CAN_VIEW, resourceID); err != nil {
+			if err := a.client.WriteTuple(context.Background(), "user:"+principal.Identifier(), CAN_VIEW, resourceID); err != nil {
 				a.logger.Error("Async write failed: ", err.Error())
 				return err
 			}
@@ -31,14 +36,14 @@ func (a *Authorizer) createTuple(ctx context.Context, resourceID string) error {
 }
 
 func (a *Authorizer) deleteTuple(ctx context.Context, resourceID string) error {
-	user, ok := ctx.Value(USER_CTX).(*User)
-	if !ok {
+	principal := authentication.PrincipalFromContext(ctx)
+	if principal == nil {
 		return ErrNoUserInContext
 	}
 
 	_, err := a.wpool.Submit(
 		func() any {
-			if err := a.client.DeleteTuple(context.Background(), "user:"+user.ID, CAN_VIEW, resourceID); err != nil {
+			if err := a.client.DeleteTuple(context.Background(), "user:"+principal.Identifier(), CAN_VIEW, resourceID); err != nil {
 				a.logger.Error("Async delete failed: ", err.Error())
 				return err
 			}

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -30,7 +30,7 @@ type EnvSpec struct {
 	OAuth2ClientId              string   `envconfig:"oauth2_client_id" validate:"required"`
 	OAuth2ClientSecret          string   `envconfig:"oauth2_client_secret" validate:"required"`
 	OAuth2RedirectURI           string   `envconfig:"oauth2_redirect_uri" validate:"required"`
-	OAuth2CodeGrantScopes       []string `envconfig:"oauth2_codegrant_scopes" default:"openid,offline_access" validate:"required"`
+	OAuth2CodeGrantScopes       []string `envconfig:"oauth2_codegrant_scopes" default:"openid,offline_access,profile,email" validate:"required"`
 	OAuth2AuthCookiesTTLSeconds int      `envconfig:"oauth2_auth_cookies_ttl_seconds" default:"300" validate:"required"`
 	OAuth2UserSessionTTLSeconds int      `envconfig:"oauth2_user_session_ttl_seconds" default:"21600" validate:"required"`
 

--- a/pkg/authentication/handlers.go
+++ b/pkg/authentication/handlers.go
@@ -258,7 +258,18 @@ func (a *API) handleLogout(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) uiRedirect(w http.ResponseWriter, r *http.Request, nextTo string) {
-	redirect := ui.UIPrefix
+	redirect, err := url.JoinPath("/", a.contextPath, ui.UIPrefix)
+	if err != nil {
+		a.logger.Errorf("unable to build ui redirect path, possible misconfiguration, err: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(
+			types.Response{
+				Status:  http.StatusInternalServerError,
+				Message: err.Error(),
+			},
+		)
+		return
+	}
 
 	if nextTo != "" {
 		redirectURL, _ := url.Parse(redirect)
@@ -267,9 +278,6 @@ func (a *API) uiRedirect(w http.ResponseWriter, r *http.Request, nextTo string) 
 		redirectURL.RawQuery = query.Encode()
 		redirect = redirectURL.String()
 	}
-
-	// handle context path in redirection response
-	r.URL.Path = a.contextPath
 
 	http.Redirect(w, r, redirect, http.StatusFound)
 }

--- a/pkg/authentication/handlers.go
+++ b/pkg/authentication/handlers.go
@@ -146,14 +146,14 @@ func (a *API) handleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	idToken, err := a.oauth2.Verifier().VerifyIDToken(ctx, rawIDToken)
+	principal, err := a.oauth2.Verifier().VerifyIDToken(ctx, rawIDToken)
 	if err != nil {
 		a.logger.Errorf("unable to verify ID token, error: %v", err)
 		a.badRequest(w, err)
 		return
 	}
 
-	err = a.checkNonce(r, idToken)
+	err = a.checkNonce(r, principal)
 	a.cookieManager.ClearNonceCookie(w)
 	if err != nil {
 		a.badRequest(w, err)
@@ -169,14 +169,14 @@ func (a *API) handleCallback(w http.ResponseWriter, r *http.Request) {
 	a.uiRedirect(w, r, nextTo)
 }
 
-func (a *API) checkNonce(r *http.Request, idToken *Principal) error {
+func (a *API) checkNonce(r *http.Request, principal *UserPrincipal) error {
 	nonce := a.cookieManager.GetNonceCookie(r)
 	if nonce == "" {
 		a.logger.Error("nonce cookie not found")
 		return fmt.Errorf("nonce cookie not found")
 	}
 
-	if idToken.Nonce != nonce {
+	if principal.Nonce != nonce {
 		a.logger.Error("id token nonce does not match nonce cookie")
 		return fmt.Errorf("id token nonce does not match nonce cookie")
 	}

--- a/pkg/authentication/handlers_test.go
+++ b/pkg/authentication/handlers_test.go
@@ -117,7 +117,7 @@ func TestHandleLoginCallback(t *testing.T) {
 		DoAndReturn(func(data string) (string, error) { return data, nil })
 
 	mockVerifier := NewMockTokenVerifier(ctrl)
-	mockVerifier.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+	mockVerifier.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
 
 	mockOauth2Ctx := NewMockOAuth2ContextInterface(ctrl)
 	mockOauth2Ctx.EXPECT().Verifier().Times(1).Return(mockVerifier)
@@ -306,7 +306,7 @@ func TestHandleLoginCallbackFailures(t *testing.T) {
 				oauth2Ctx.EXPECT().RetrieveTokens(gomock.Any(), gomock.Eq("mock-code")).Return(mockToken, nil)
 
 				verifier.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).Times(1).
-					Return(&Principal{
+					Return(&UserPrincipal{
 						Subject: "mock-subject",
 						Nonce:   "mock-nonce",
 					}, nil)
@@ -326,7 +326,7 @@ func TestHandleLoginCallbackFailures(t *testing.T) {
 				oauth2Ctx.EXPECT().RetrieveTokens(gomock.Any(), gomock.Eq("mock-code")).Return(mockToken, nil)
 
 				verifier.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).Times(1).
-					Return(&Principal{
+					Return(&UserPrincipal{
 						Subject: "mock-subject",
 						Nonce:   "mock-nonce",
 					}, nil)
@@ -386,7 +386,7 @@ func TestHandleLoginCallbackFailures(t *testing.T) {
 
 func TestHandleMe(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	p := &Principal{
+	p := &UserPrincipal{
 		Subject:         "mock-subject",
 		Name:            "mock-name",
 		Email:           "mock-email",
@@ -424,10 +424,10 @@ func TestHandleMe(t *testing.T) {
 	response := mockResponse.Result()
 	defer response.Body.Close()
 
-	got := new(Principal)
+	got := new(UserPrincipal)
 	_ = json.NewDecoder(response.Body).Decode(got)
 
-	expectedPrincipal := Principal{
+	expectedPrincipal := UserPrincipal{
 		Subject:         "mock-subject",
 		Name:            "mock-name",
 		Email:           "mock-email",
@@ -483,7 +483,7 @@ func TestLogout(t *testing.T) {
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Principal{
+			p := &UserPrincipal{
 				Subject:         "mock-subject",
 				Name:            "mock-name",
 				Email:           "mock-email",

--- a/pkg/authentication/interfaces.go
+++ b/pkg/authentication/interfaces.go
@@ -18,9 +18,9 @@ type providerVerifierInterface interface {
 
 type TokenVerifier interface {
 	// VerifyAccessToken verifies a raw string representing a ory Hydra access token (either opaque or jwt)
-	VerifyAccessToken(context.Context, string) (*Principal, error)
+	VerifyAccessToken(context.Context, string) (*ServicePrincipal, error)
 	// VerifyIDToken verifies a raw string representing a ory Hydra JWT ID token
-	VerifyIDToken(context.Context, string) (*Principal, error)
+	VerifyIDToken(context.Context, string) (*UserPrincipal, error)
 }
 
 type ProviderInterface interface {
@@ -42,7 +42,7 @@ type OAuth2ContextInterface interface {
 	// RefreshToken performs the OAuth2 refresh_token grant
 	RefreshToken(context.Context, string) (*oauth2.Token, error)
 	// Logout performs session and tokens revocation against the Hydra Admin APIs
-	Logout(ctx context.Context, principal *Principal) error
+	Logout(ctx context.Context, principal PrincipalInterface) error
 }
 
 type ReadableClaims interface {
@@ -103,4 +103,12 @@ type EncryptInterface interface {
 
 type HTTPClientInterface interface {
 	Do(*http.Request) (*http.Response, error)
+}
+
+type PrincipalInterface interface {
+	Identifier() string
+	Session() string
+	AccessToken() string
+	RefreshToken() string
+	IDToken() string
 }

--- a/pkg/authentication/middlewares.go
+++ b/pkg/authentication/middlewares.go
@@ -79,7 +79,10 @@ func (m *Middleware) oAuth2BearerAuthentication(next http.Handler) http.Handler 
 			servicePrincipal.RawAccessToken = rawAccessToken
 		}
 
-		ctx = PrincipalContext(ctx, servicePrincipal)
+		if servicePrincipal != nil {
+			ctx = PrincipalContext(ctx, servicePrincipal)
+		}
+
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/pkg/authentication/middlewares.go
+++ b/pkg/authentication/middlewares.go
@@ -67,7 +67,7 @@ func (m *Middleware) oAuth2BearerAuthentication(next http.Handler) http.Handler 
 		)
 
 		// add the Otel HTTP Client
-		r.WithContext(OtelHTTPClientContext(r.Context()))
+		r = r.WithContext(OtelHTTPClientContext(r.Context()))
 
 		if rawAccessToken, found := m.getBearerToken(r.Header); found {
 			servicePrincipal, err = m.oauth2.Verifier().VerifyAccessToken(r.Context(), rawAccessToken)

--- a/pkg/authentication/middlewares_test.go
+++ b/pkg/authentication/middlewares_test.go
@@ -32,7 +32,7 @@ func TestMiddleware_OAuth2AuthenticationSuccess(t *testing.T) {
 
 	verifier := NewMockTokenVerifier(ctrl)
 	verifier.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).Return(nil, errors.New("mock-error"))
-	verifier.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+	verifier.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
 
 	oauth2 := NewMockOAuth2ContextInterface(ctrl)
 	oauth2.EXPECT().Verifier().Times(2).Return(verifier)
@@ -197,7 +197,7 @@ func TestMiddleware_OAuth2AuthenticationMiddlewareFailures(t *testing.T) {
 					Return(nil, errors.New("mock-error"))
 				v.EXPECT().VerifyAccessToken(gomock.Any(), "mock-access-token").
 					Times(1).
-					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+					Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
 
 				o.EXPECT().Verifier().Times(2).Return(v)
 
@@ -226,7 +226,7 @@ func TestMiddleware_OAuth2AuthenticationMiddlewareFailures(t *testing.T) {
 
 				v.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).
 					Times(1).
-					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+					Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
 				v.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).
 					Times(1).
 					Return(nil, errors.New("mock-error"))
@@ -261,7 +261,7 @@ func TestMiddleware_OAuth2AuthenticationMiddlewareFailures(t *testing.T) {
 					Return(nil, &oidc.TokenExpiredError{})
 				v.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).
 					Times(1).
-					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+					Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
 
 				o.EXPECT().Verifier().Times(2).Return(v)
 
@@ -354,7 +354,7 @@ func TestMiddleware_OAuth2AuthenticationMiddlewareSuccess(t *testing.T) {
 			setupMocks: func(c *MockAuthCookieManagerInterface, v *MockTokenVerifier, o *MockOAuth2ContextInterface, l *MockLoggerInterface, t *MockTracer) {
 				v.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).
 					Times(1).
-					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+					Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
 
 				o.EXPECT().Verifier().Times(1).Return(v)
 
@@ -374,10 +374,10 @@ func TestMiddleware_OAuth2AuthenticationMiddlewareSuccess(t *testing.T) {
 			setupMocks: func(c *MockAuthCookieManagerInterface, v *MockTokenVerifier, o *MockOAuth2ContextInterface, l *MockLoggerInterface, t *MockTracer) {
 				v.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).
 					Times(1).
-					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+					Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
 				v.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).
 					Times(1).
-					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+					Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
 
 				o.EXPECT().Verifier().Times(2).Return(v)
 
@@ -417,7 +417,7 @@ func TestMiddleware_OAuth2AuthenticationMiddlewareSuccess(t *testing.T) {
 					Return(token, nil)
 
 				v.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).
-					Return(&Principal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+					Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
 
 				c.EXPECT().GetIDTokenCookie(gomock.Any()).Return("mock-id-token")
 				c.EXPECT().GetAccessTokenCookie(gomock.Any()).Return("mock-access-token")

--- a/pkg/authentication/middlewares_test.go
+++ b/pkg/authentication/middlewares_test.go
@@ -32,7 +32,7 @@ func TestMiddleware_OAuth2AuthenticationSuccess(t *testing.T) {
 
 	verifier := NewMockTokenVerifier(ctrl)
 	verifier.EXPECT().VerifyIDToken(gomock.Any(), gomock.Any()).Return(nil, errors.New("mock-error"))
-	verifier.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+	verifier.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).Return(&ServicePrincipal{Subject: "mock-subject"}, nil)
 
 	oauth2 := NewMockOAuth2ContextInterface(ctrl)
 	oauth2.EXPECT().Verifier().Times(2).Return(verifier)
@@ -197,7 +197,7 @@ func TestMiddleware_OAuth2AuthenticationMiddlewareFailures(t *testing.T) {
 					Return(nil, errors.New("mock-error"))
 				v.EXPECT().VerifyAccessToken(gomock.Any(), "mock-access-token").
 					Times(1).
-					Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+					Return(&ServicePrincipal{Subject: "mock-subject"}, nil)
 
 				o.EXPECT().Verifier().Times(2).Return(v)
 
@@ -354,7 +354,7 @@ func TestMiddleware_OAuth2AuthenticationMiddlewareSuccess(t *testing.T) {
 			setupMocks: func(c *MockAuthCookieManagerInterface, v *MockTokenVerifier, o *MockOAuth2ContextInterface, l *MockLoggerInterface, t *MockTracer) {
 				v.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).
 					Times(1).
-					Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+					Return(&ServicePrincipal{Subject: "mock-subject"}, nil)
 
 				o.EXPECT().Verifier().Times(1).Return(v)
 
@@ -377,7 +377,7 @@ func TestMiddleware_OAuth2AuthenticationMiddlewareSuccess(t *testing.T) {
 					Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
 				v.EXPECT().VerifyAccessToken(gomock.Any(), gomock.Any()).
 					Times(1).
-					Return(&UserPrincipal{Subject: "mock-subject", Nonce: "mock-nonce"}, nil)
+					Return(&ServicePrincipal{Subject: "mock-subject"}, nil)
 
 				o.EXPECT().Verifier().Times(2).Return(v)
 

--- a/pkg/authentication/oidc.go
+++ b/pkg/authentication/oidc.go
@@ -20,53 +20,9 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/pkg/clients"
 )
 
-type principalContextKey int
-
 var (
-	PrincipalContextKey principalContextKey
-	otelHTTPClient      = http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	otelHTTPClient = http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 )
-
-type Principal struct {
-	Subject   string `json:"sub"`
-	Name      string `json:"name"`
-	Email     string `json:"email"`
-	SessionID string `json:"sid"`
-	Nonce     string `json:"nonce"`
-
-	RawAccessToken  string `json:"-"`
-	RawIdToken      string `json:"-"`
-	RawRefreshToken string `json:"-"`
-}
-
-func NewPrincipalFromClaims(c ReadableClaims) (*Principal, error) {
-	a := new(Principal)
-	if err := c.Claims(a); err != nil {
-		return nil, err
-	}
-	return a, nil
-}
-
-func PrincipalContext(ctx context.Context, principal *Principal) context.Context {
-	parent := ctx
-	if ctx == nil {
-		parent = context.Background()
-	}
-
-	return context.WithValue(parent, PrincipalContextKey, principal)
-}
-
-func PrincipalFromContext(ctx context.Context) *Principal {
-	if ctx == nil {
-		return nil
-	}
-
-	if value, ok := ctx.Value(PrincipalContextKey).(*Principal); ok {
-		return value
-	}
-
-	return nil
-}
 
 func OtelHTTPClientContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, oauth2.HTTPClient, otelHTTPClient)

--- a/pkg/authentication/oidc_test.go
+++ b/pkg/authentication/oidc_test.go
@@ -33,18 +33,18 @@ func TestNewPrincipalFromClaims(t *testing.T) {
 
 	mockClaims.EXPECT().Claims(gomock.Any()).Times(1).
 		DoAndReturn(
-			func(p *Principal) error {
+			func(p *UserPrincipal) error {
 				p.Subject = "mock-sub"
 				return nil
 			})
 
-	principal, err := NewPrincipalFromClaims(mockClaims)
+	principal, err := NewUserPrincipalFromClaims(mockClaims)
 
 	if err != nil {
 		t.Fatalf("returned error should be null, but it is not")
 	}
 
-	if principal.Subject != "mock-sub" {
+	if principal.Identifier() != "mock-sub" {
 		t.Fatalf("returned principal subject doesn't match expected")
 	}
 }
@@ -57,7 +57,7 @@ func TestNewPrincipalFromClaimsError(t *testing.T) {
 
 	mockClaims.EXPECT().Claims(gomock.Any()).Times(1).Return(fmt.Errorf("mock-error"))
 
-	principal, err := NewPrincipalFromClaims(mockClaims)
+	principal, err := NewUserPrincipalFromClaims(mockClaims)
 
 	if principal != nil {
 		t.Fatalf("returned principal should be null, but it is not")
@@ -74,11 +74,11 @@ func TestNewPrincipalFromClaimsError(t *testing.T) {
 
 func TestPrincipalContext(t *testing.T) {
 	mockCtx := context.TODO()
-	mockPrincipal := &Principal{Subject: "mock-sub"}
+	mockPrincipal := &UserPrincipal{Subject: "mock-sub"}
 
 	result := PrincipalContext(mockCtx, mockPrincipal)
 
-	returnedPrincipal := result.Value(PrincipalContextKey).(*Principal)
+	returnedPrincipal := result.Value(PrincipalContextKey).(*UserPrincipal)
 
 	if returnedPrincipal.Subject != "mock-sub" {
 		t.Fatalf("returned subject does not match expected")
@@ -86,7 +86,7 @@ func TestPrincipalContext(t *testing.T) {
 
 	result = PrincipalContext(nil, mockPrincipal)
 
-	returnedPrincipal = result.Value(PrincipalContextKey).(*Principal)
+	returnedPrincipal = result.Value(PrincipalContextKey).(*UserPrincipal)
 
 	if returnedPrincipal.Subject != "mock-sub" {
 		t.Fatalf("returned subject does not match expected")
@@ -95,13 +95,13 @@ func TestPrincipalContext(t *testing.T) {
 
 func TestPrincipalFromContext(t *testing.T) {
 	mockCtx := context.TODO()
-	mockPrincipal := &Principal{Subject: "mock-sub"}
+	mockPrincipal := &UserPrincipal{Subject: "mock-sub"}
 
 	ctx := context.WithValue(mockCtx, PrincipalContextKey, mockPrincipal)
 
 	principal := PrincipalFromContext(ctx)
 
-	if principal == nil || principal.Subject != "mock-sub" {
+	if principal == nil || principal.Identifier() != "mock-sub" {
 		t.Fatalf("returned subject does not match expected")
 	}
 }
@@ -219,7 +219,7 @@ func TestOAuth2Context_Logout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	p := &Principal{
+	p := &UserPrincipal{
 		Subject:         "mock-subject",
 		Name:            "mock-name",
 		Email:           "mock-email",
@@ -233,7 +233,7 @@ func TestOAuth2Context_Logout(t *testing.T) {
 	errorStructString := "{\"error\":\"mock-error\", \"error_description\":\"mock-error-descr\"}"
 	tests := []struct {
 		name          string
-		principal     *Principal
+		principal     *UserPrincipal
 		setupMock     func(*MockOAuth2Api, *MockOAuth2Api)
 		expectedError string
 	}{

--- a/pkg/authentication/oidc_test.go
+++ b/pkg/authentication/oidc_test.go
@@ -34,7 +34,7 @@ func TestNewPrincipalFromClaims(t *testing.T) {
 	mockClaims.EXPECT().Claims(gomock.Any()).Times(1).
 		DoAndReturn(
 			func(p *UserPrincipal) error {
-				p.Subject = "mock-sub"
+				p.Email = "mock-sub"
 				return nil
 			})
 
@@ -95,7 +95,7 @@ func TestPrincipalContext(t *testing.T) {
 
 func TestPrincipalFromContext(t *testing.T) {
 	mockCtx := context.TODO()
-	mockPrincipal := &UserPrincipal{Subject: "mock-sub"}
+	mockPrincipal := &UserPrincipal{Email: "mock-sub"}
 
 	ctx := context.WithValue(mockCtx, PrincipalContextKey, mockPrincipal)
 
@@ -233,7 +233,7 @@ func TestOAuth2Context_Logout(t *testing.T) {
 	errorStructString := "{\"error\":\"mock-error\", \"error_description\":\"mock-error-descr\"}"
 	tests := []struct {
 		name          string
-		principal     *UserPrincipal
+		principal     PrincipalInterface
 		setupMock     func(*MockOAuth2Api, *MockOAuth2Api)
 		expectedError string
 	}{

--- a/pkg/authentication/principal.go
+++ b/pkg/authentication/principal.go
@@ -89,10 +89,6 @@ func PrincipalContext(ctx context.Context, principal PrincipalInterface) context
 		parent = context.Background()
 	}
 
-	if principal == nil {
-		return parent
-	}
-
 	return context.WithValue(parent, PrincipalContextKey, principal)
 }
 

--- a/pkg/authentication/principal.go
+++ b/pkg/authentication/principal.go
@@ -1,0 +1,109 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package authentication
+
+import "context"
+
+type principalContextKey int
+
+var PrincipalContextKey principalContextKey
+
+type UserPrincipal struct {
+	Subject   string `json:"sub"`
+	Name      string `json:"name"`
+	Email     string `json:"email"`
+	SessionID string `json:"sid"`
+	Nonce     string `json:"nonce"`
+
+	RawAccessToken  string `json:"-"`
+	RawIdToken      string `json:"-"`
+	RawRefreshToken string `json:"-"`
+}
+
+func (u *UserPrincipal) Session() string {
+	return u.SessionID
+}
+
+func (u *UserPrincipal) AccessToken() string {
+	return u.RawAccessToken
+}
+
+func (u *UserPrincipal) RefreshToken() string {
+	return u.RawRefreshToken
+}
+
+func (u *UserPrincipal) IDToken() string {
+	return u.RawIdToken
+}
+
+func (u *UserPrincipal) Identifier() string {
+	return u.Email
+}
+
+type ServicePrincipal struct {
+	Subject        string `json:"sub"`
+	RawAccessToken string `json:"-"`
+}
+
+func (s *ServicePrincipal) Session() string {
+	return ""
+}
+
+func (s *ServicePrincipal) AccessToken() string {
+	return s.RawAccessToken
+}
+
+func (s *ServicePrincipal) RefreshToken() string {
+	return ""
+}
+
+func (s *ServicePrincipal) IDToken() string {
+	return ""
+}
+
+func (s *ServicePrincipal) Identifier() string {
+	return s.Subject
+}
+
+func NewUserPrincipalFromClaims(c ReadableClaims) (*UserPrincipal, error) {
+	a := new(UserPrincipal)
+	if err := c.Claims(a); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+func NewServicePrincipalFromClaims(c ReadableClaims) (*ServicePrincipal, error) {
+	a := new(ServicePrincipal)
+	if err := c.Claims(a); err != nil {
+		return nil, err
+	}
+
+	return a, nil
+}
+
+func PrincipalContext(ctx context.Context, principal PrincipalInterface) context.Context {
+	parent := ctx
+	if ctx == nil {
+		parent = context.Background()
+	}
+
+	if principal == nil {
+		return parent
+	}
+
+	return context.WithValue(parent, PrincipalContextKey, principal)
+}
+
+func PrincipalFromContext(ctx context.Context) PrincipalInterface {
+	if ctx == nil {
+		return nil
+	}
+
+	if value, ok := ctx.Value(PrincipalContextKey).(PrincipalInterface); ok {
+		return value
+	}
+
+	return nil
+}

--- a/pkg/authentication/tokens_test.go
+++ b/pkg/authentication/tokens_test.go
@@ -92,7 +92,7 @@ func TestJWKSTokenVerifier_VerifyIDToken(t *testing.T) {
 	}{
 		{
 			name:  "Success",
-			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJtb2NrLXN1YmplY3QiLCJhdWQiOiJtb2NrLWNsaWVudC1pZCIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.BdspASNsnxeXnqZXZnFnkvv-ClMq0U6X1gCIUrh9V7c",
+			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJtb2NrLXN1YmplY3QiLCJhdWQiOiJtb2NrLWNsaWVudC1pZCIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMiwiZW1haWwiOiJtb2NrLWVtYWlsIn0.-3clv5YJmk4EGM9l_yIfGQjGhKEjEnHvCjA-kNYUd0Y",
 		},
 		{
 			name:  "Fail",
@@ -118,7 +118,7 @@ func TestJWKSTokenVerifier_VerifyIDToken(t *testing.T) {
 				t.Fatalf("error is nil or error message does not match expected error")
 			}
 
-			if tt.name == "Success" && (err != nil || token.Identifier() != "mock-subject") {
+			if tt.name == "Success" && (err != nil || token.Identifier() != "mock-email") {
 				t.Fatalf("expected token does not match returned token")
 			}
 		})
@@ -186,16 +186,13 @@ func TestUserinfoTokenVerifier_VerifyIDToken(t *testing.T) {
 		Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 	mockMonitor := NewMockMonitorInterface(ctrl)
 
-	mockToken := new(oidc.IDToken)
-	mockToken.Subject = "mock-subject"
-
 	for _, tt := range []struct {
 		name  string
 		token string
 	}{
 		{
 			name:  "Success",
-			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJtb2NrLXN1YmplY3QiLCJhdWQiOiJtb2NrLWNsaWVudC1pZCIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.BdspASNsnxeXnqZXZnFnkvv-ClMq0U6X1gCIUrh9V7c",
+			token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJtb2NrLXN1YmplY3QiLCJhdWQiOiJtb2NrLWNsaWVudC1pZCIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMiwiZW1haWwiOiJtb2NrLWVtYWlsIn0.-3clv5YJmk4EGM9l_yIfGQjGhKEjEnHvCjA-kNYUd0Y",
 		},
 		{
 			name:  "Fail",
@@ -221,7 +218,7 @@ func TestUserinfoTokenVerifier_VerifyIDToken(t *testing.T) {
 				t.Fatalf("error is nil or error message does not match expected error")
 			}
 
-			if tt.name == "Success" && (err != nil || token.Identifier() != "mock-subject") {
+			if tt.name == "Success" && (err != nil || token.Identifier() != "mock-email") {
 				t.Fatalf("expected token does not match returned token")
 			}
 		})

--- a/pkg/authentication/tokens_test.go
+++ b/pkg/authentication/tokens_test.go
@@ -64,7 +64,7 @@ func TestJWKSTokenVerifier_VerifyAccessToken(t *testing.T) {
 				t.Fatalf("error is nil or error message does not match expected error")
 			}
 
-			if tt.name == "Success" && (err != nil || token.Subject != "mock-subject") {
+			if tt.name == "Success" && (err != nil || token.Identifier() != "mock-subject") {
 				t.Fatalf("expected token does not match returned token")
 			}
 		})
@@ -118,7 +118,7 @@ func TestJWKSTokenVerifier_VerifyIDToken(t *testing.T) {
 				t.Fatalf("error is nil or error message does not match expected error")
 			}
 
-			if tt.name == "Success" && (err != nil || token.Subject != "mock-subject") {
+			if tt.name == "Success" && (err != nil || token.Identifier() != "mock-subject") {
 				t.Fatalf("expected token does not match returned token")
 			}
 		})
@@ -221,7 +221,7 @@ func TestUserinfoTokenVerifier_VerifyIDToken(t *testing.T) {
 				t.Fatalf("error is nil or error message does not match expected error")
 			}
 
-			if tt.name == "Success" && (err != nil || token.Subject != "mock-subject") {
+			if tt.name == "Success" && (err != nil || token.Identifier() != "mock-subject") {
 				t.Fatalf("expected token does not match returned token")
 			}
 		})

--- a/pkg/groups/handlers.go
+++ b/pkg/groups/handlers.go
@@ -4,7 +4,6 @@
 package groups
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,6 +15,7 @@ import (
 	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
 	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
 	"github.com/canonical/identity-platform-admin-ui/internal/validation"
+	"github.com/canonical/identity-platform-admin-ui/pkg/authentication"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -86,37 +86,14 @@ func (a *API) RegisterValidation(v validation.ValidationRegistryInterface) {
 	}
 }
 
-func (a *API) userFromContext(ctx context.Context) *authorization.User {
-	// TODO @shipperizer implement the FromContext and NewContext in authorization package
-	// see snippet below copied from https://pkg.go.dev/context#Context
-	// NewContext returns a new Context that carries value u.
-	// func NewContext(ctx context.Context, u *User) context.Context {
-	//     return context.WithValue(ctx, userKey, u)
-	// }
-
-	// // FromContext returns the User value stored in ctx, if any.
-	// func FromContext(ctx context.Context) (*User, bool) {
-	//     u, ok := ctx.Value(userKey).(*User)
-	//     return u, ok
-	// }
-	if user := ctx.Value(authorization.USER_CTX); user != nil {
-		return user.(*authorization.User)
-	}
-
-	user := new(authorization.User)
-	user.ID = "anonymous"
-
-	return user
-}
-
 func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	user := a.userFromContext(r.Context())
+	principal := authentication.PrincipalFromContext(r.Context())
 
 	groups, err := a.service.ListGroups(
 		r.Context(),
-		user.ID,
+		principal.Identifier(),
 	)
 
 	if err != nil {
@@ -146,8 +123,8 @@ func (a *API) handleDetail(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	ID := chi.URLParam(r, "id")
-	user := a.userFromContext(r.Context())
-	group, err := a.service.GetGroup(r.Context(), user.ID, ID)
+	principal := authentication.PrincipalFromContext(r.Context())
+	group, err := a.service.GetGroup(r.Context(), principal.Identifier(), ID)
 
 	if err != nil {
 
@@ -227,8 +204,8 @@ func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user := a.userFromContext(r.Context())
-	group, err = a.service.CreateGroup(r.Context(), user.ID, group.Name)
+	principal := authentication.PrincipalFromContext(r.Context())
+	group, err = a.service.CreateGroup(r.Context(), principal.Identifier(), group.Name)
 
 	if err != nil {
 

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -143,9 +143,7 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 	uiAPI := ui.NewAPI(uiConfig, tracer, monitor, logger)
 
 	// Create a new router for the API so that we can add extra middlewares
-	apiRouter := router.Group(func(r chi.Router) {
-		r.Use(authorizationMiddleware)
-	}).(*chi.Mux)
+	apiRouter := router.Group(nil).(*chi.Mux)
 
 	var oauth2Context authentication.OAuth2ContextInterface
 	var cookieManager authentication.AuthCookieManagerInterface
@@ -169,6 +167,9 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 		)
 		apiRouter.Use(authenticationMiddleware.OAuth2AuthenticationChain()...)
 	}
+
+	// register authorizationMiddleware after authentication so Principal is available if necessary
+	apiRouter.Use(authorizationMiddleware)
 
 	if config.payloadValidationEnabled {
 		validationRegistry := validation.NewRegistry(tracer, monitor, logger)


### PR DESCRIPTION
## Description
This PR links authenticated principals to the authorization model in OpenFGA.
This means that either a ServicePrincipal (CLI use case) or a UserPrincipal (browser use case) will be "mapped" to a OpenFGA user of a tuple throught the new `Identifier()` method.
For `ServicePrincipal`s (representing an OAuth2 client authenticated through `client_credentials` grant against Hydra), the subject will match the client-id of that specific OAuth2 client that generated the token. So in this case the identifier will be the value of the client-id coming form the `sub`claim.

For `UserPrincipal`s (representing a "human" user authenticated through the `authorization_code` grant against Hydra), the `email` claim will be used as the principal identifier.
This way we will be able to have OpenFGA tuples with a non-changing `user:` since both client-id and email uniquely identify an entity inside of the platform.

## Changes
- uniformed the use of the `isAdmin` context attribute (although right now is not used) and moved under authorization.go
- removed references to authorization header and dummy authentication in place before this
- now OpenFGA tuples are built using the `Identifier()` method on the `PrincipalInterface` to make authorization work on both CLI users and actual users
- auhtorization middlewares are moved after authentication middleware so authentication can come into play before and the authorizaion middlewares can rely on the authenticated principal object
- many tests are adjusted to suppor the changes in both authorization and authentication

# Breaking change
Anonymous authentication is not supported anymore. We can bring it back but we need to talk about what to put in and what not.