### PR TITLE
IAM 922

### DIFF
--- a/DEVSETUP.md
+++ b/DEVSETUP.md
@@ -142,3 +142,15 @@ SCHEMAS_CONFIGMAP_NAME=identity-schemas \
 SCHEMAS_CONFIGMAP_NAMESPACE=default \
 TRACING_ENABLED=false \
 ```
+
+
+## OIDC authentication
+
+For development purposes we are going to be targeting `iam.dev.canonical.com` and use it as our OIDC provider
+
+the credentials are available in the team LastPass account and need to be swapped in the [configmap.yaml](https://github.com/canonical/identity-platform-admin-ui/blob/main/deployments/kubectl/configMap.yaml#L29-L30) file
+
+dev setup will rely on the application being exposed on `localhost:8000` without any path rewrite, if that is not the case the OIDC flow won't work due to how the redirect uri don't match with the expectations of the OAUTH2 client created in `iam.dev.canonical.com` (and also the `OAUTH2_REDIRECT_URI` variable in the configmap)
+
+
+in the remote case we need to create a new client the process to issue it will be described in the wiki together with a stop gap solution using other components (namely Dex)

--- a/deployments/helm/hydra/values.yaml
+++ b/deployments/helm/hydra/values.yaml
@@ -14,3 +14,6 @@ hydra:
     enabled: true
 maester:
   enabled: false
+image:
+  repository: "ghcr.io/canonical/hydra"
+  tag: "2.3.0-canonical"

--- a/deployments/kubectl/configMap.yaml
+++ b/deployments/kubectl/configMap.yaml
@@ -24,12 +24,12 @@ data:
   OPENFGA_STORE_ID: "-----to-be-replaced----"
   OPENFGA_AUTHORIZATION_MODEL_ID: "-----to-be-replaced----"
   AUTHORIZATION_ENABLED: "true"
-  AUTHENTICATION_ENABLED: "false"
-  OIDC_ISSUER: "https://random.com"
-  OAUTH2_CLIENT_ID: random
-  OAUTH2_CLIENT_SECRET: random
+  AUTHENTICATION_ENABLED: "true"
+  OIDC_ISSUER: "https://iam.dev.canonical.com/stg-identity-jaas-dev-hydra"
+  OAUTH2_CLIENT_ID: "-----to-be-replaced----"
+  OAUTH2_CLIENT_SECRET: "-----to-be-replaced----"
   OAUTH2_REDIRECT_URI: "http://localhost:8000/api/v0/auth/callback"
-  OAUTH2_CODEGRANT_SCOPES: "openid,offline_access"
+  OAUTH2_CODEGRANT_SCOPES: "openid,offline_access,email,profile"
   OAUTH2_AUTH_COOKIES_ENCRYPTION_KEY: "WrfOcYmVBwyduEbKYTUhO4X7XVaOQ1wF"
   ACCESS_TOKEN_VERIFICATION_STRATEGY: "jwks"
 ---

--- a/deployments/kubectl/deployment.yaml
+++ b/deployments/kubectl/deployment.yaml
@@ -19,31 +19,45 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8000"
     spec:
+      volumes:
+        - name: certificates
+          persistentVolumeClaim:
+            claimName: certificates-volume-claim
+      initContainers:
+        - name: init-ca-certificates
+          image: ubuntu:22.04
+          command: ["sh", "-c", "apt update && apt install -y ca-certificates"]
+          volumeMounts:
+            - mountPath: /etc/ssl/certs
+              name: certificates
       containers:
-      - image: identity-platform-admin-ui
-        name: identity-platform-admin-ui
-        command:  ["/usr/bin/identity-platform-admin-ui", "serve"]
-        envFrom:
-          - configMapRef:
-              name: identity-platform-admin-ui
-        ports:
-        - name: http
-          containerPort: 8000
-        readinessProbe:
-          httpGet:
-            path: "/api/v0/status"
-            port: 8000
-          initialDelaySeconds: 1
-          failureThreshold: 10
-          timeoutSeconds: 5
-          periodSeconds: 30
-        livenessProbe:
-          httpGet:
-            path: "/api/v0/status"
-            port: 8000
-          initialDelaySeconds: 1
-          failureThreshold: 10
-          timeoutSeconds: 5
-          periodSeconds: 30
+        - image: identity-platform-admin-ui
+          name: identity-platform-admin-ui
+          command: ["/usr/bin/identity-platform-admin-ui", "serve"]
+          volumeMounts:
+            - mountPath: /etc/ssl/certs
+              name: certificates
+          envFrom:
+            - configMapRef:
+                name: identity-platform-admin-ui
+          ports:
+            - name: http
+              containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: "/api/v0/status"
+              port: 8000
+            initialDelaySeconds: 1
+            failureThreshold: 10
+            timeoutSeconds: 5
+            periodSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: "/api/v0/status"
+              port: 8000
+            initialDelaySeconds: 1
+            failureThreshold: 10
+            timeoutSeconds: 5
+            periodSeconds: 30
       imagePullSecrets:
-      - name: regcred-github
+        - name: regcred-github

--- a/deployments/kubectl/volumes.yaml
+++ b/deployments/kubectl/volumes.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: certificates-volume
+spec:
+  storageClassName: microk8s-hostpath
+  capacity:
+    storage: 100Mi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /tmp/certificates-k8s
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: certificates-volume-claim
+spec:
+  storageClassName: microk8s-hostpath
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -40,12 +40,6 @@ const App: FC = () => {
     >
       <Suspense fallback={<Loader />}>
         <Routes>
-          <Route
-            path="/"
-            element={
-              <Login isAuthenticated={!!authUser} setAuthUser={setAuthUser} />
-            }
-          >
             <Route
               path="/"
               element={<Navigate to="/provider" replace={true} />}
@@ -65,7 +59,6 @@ const App: FC = () => {
               }
             />
             <Route path="*" element={<NoMatch />} />
-          </Route>
         </Routes>
       </Suspense>
     </ApplicationLayout>


### PR DESCRIPTION
IAM-922: skaffold setup for oidc authentication

to be rebased on top of #360 once merged


- **ci: point oidc to iam.dev.canonical.com**
- **ci: use canonical hydra**
- **ci: add init container and pvc to support third party certificates inside the rock**
- **docs: add OIDC setup**
- **fix: remove login component from ui**


@huwshimi @vladimir-cucu please have a look at https://github.com/canonical/identity-platform-admin-ui/pull/361/commits/b08a9185b5f7bd3f4ae3e8fbe0666dbbe844406c (and commit message with extra description)
let me know if that's fine


![Screenshot from 2024-07-18 10-49-14](https://github.com/user-attachments/assets/133718e3-9f4c-49d0-a850-d7cd4503bdc5)
![Screenshot from 2024-07-18 10-49-50](https://github.com/user-attachments/assets/a34c0639-2093-4162-8f36-33fa3b6fe6cb)


