### PR TITLE
Use contextPath to redirect to UI

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -116,7 +116,8 @@ func serve() {
 	rulesConfig := rules.NewConfig(specs.RulesConfigMapName, specs.RulesConfigFileName, specs.RulesConfigMapNamespace, k8sCoreV1, externalConfig.OathkeeperPublic().ApiApi())
 
 	uiConfig := &ui.Config{
-		DistFS: distFS,
+		DistFS:      distFS,
+		ContextPath: specs.ContextPath,
 	}
 
 	wpool := pool.NewWorkerPool(specs.OpenFGAWorkersTotal, tracer, monitor, logger)


### PR DESCRIPTION
The current logic is bugged, `r.URL.Path` does not always contain the full path (when running behind a reverse proxy, the proxy changes the path when forwarding the requests)