### PR TITLE
WD-13665 - fix: allow UI port to be set

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -18,7 +18,7 @@
     "hooks-remove": "husky uninstall",
     "start": "concurrently --kill-others --raw 'yarn dev-serve' 'yarn proxy-serve'",
     "test-js": "vitest --run",
-    "dev-serve": "vite --host | grep -v localhost",
+    "dev-serve": "vite --host",
     "proxy-serve": "./entrypoint"
   },
   "dependencies": {


### PR DESCRIPTION
This removes the grep that prevents extra arguments being passed to the `yarn dev-serve command`. Specifically, we need to be able to pass the port for some dev setups: `yarn dev-serve --port 8000`. In those cases `localhost:8000` is a valid address so don't want to remove it from the output.

https://warthogs.atlassian.net/browse/WD-13665