### PR TITLE
WD-13813 - refactor: migrate API calls to Axios

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -53,6 +53,7 @@
     "@typescript-eslint/parser": "7.3.1",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "10.4.19",
+    "axios-mock-adapter": "2.0.0",
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
     "concurrently": "8.2.2",
     "eslint": "8.57.0",
@@ -75,8 +76,7 @@
     "typescript": "5.4.3",
     "vite": "5.2.8",
     "vite-tsconfig-paths": "4.3.2",
-    "vitest": "1.2.1",
-    "vitest-fetch-mock": "0.3.0"
+    "vitest": "1.2.1"
   },
   "lint-staged": {
     "src/**/*.{json,jsx,ts,tsx}": [

--- a/ui/src/api/auth.test.ts
+++ b/ui/src/api/auth.test.ts
@@ -1,7 +1,12 @@
-import { fetchMe } from "./auth";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+
+import { fetchMe, authURLs } from "./auth";
+
+const mock = new MockAdapter(axios);
 
 beforeEach(() => {
-  fetchMock.resetMocks();
+  mock.reset();
 });
 
 test("fetches a user", async () => {
@@ -12,17 +17,17 @@ test("fetches a user", async () => {
     sid: "sid",
     sub: "sub",
   };
-  fetchMock.mockResponse(JSON.stringify(user), { status: 200 });
+  mock.onGet(authURLs.me).reply(200, user);
   await expect(fetchMe()).resolves.toStrictEqual(user);
 });
 
 test("handles a non-authenticated user", async () => {
-  fetchMock.mockResponseOnce(JSON.stringify({}), { status: 401 });
+  mock.onGet(authURLs.me).reply(401, {});
   await expect(fetchMe()).resolves.toBeNull();
 });
 
 test("catches errors", async () => {
   const error = "Uh oh!";
-  fetchMock.mockRejectedValue(error);
+  mock.onGet(authURLs.me).reply(500, { error });
   await expect(fetchMe()).rejects.toBe(error);
 });

--- a/ui/src/api/client.tsx
+++ b/ui/src/api/client.tsx
@@ -1,61 +1,32 @@
 import { Client } from "types/client";
-import { ApiResponse, PaginatedResponse } from "types/api";
-import { handleResponse, PAGE_SIZE } from "util/api";
-import { apiBasePath } from "util/basePaths";
+import { PaginatedResponse } from "types/api";
+import { handleRequest, PAGE_SIZE } from "util/api";
+import axios from "axios";
 
 export const fetchClients = (
   pageToken: string,
-): Promise<PaginatedResponse<Client[]>> => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}clients?page_token=${pageToken}&size=${PAGE_SIZE}`)
-      .then(handleResponse)
-      .then((result: PaginatedResponse<Client[]>) => resolve(result))
-      .catch(reject);
-  });
-};
+): Promise<PaginatedResponse<Client[]>> =>
+  handleRequest(() =>
+    axios.get<PaginatedResponse<Client[]>>(
+      `/clients?page_token=${pageToken}&size=${PAGE_SIZE}`,
+    ),
+  );
 
-export const fetchClient = (clientId: string): Promise<Client> => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}clients/${clientId}`)
-      .then(handleResponse)
-      .then((result: ApiResponse<Client>) => resolve(result.data))
-      .catch(reject);
-  });
-};
+export const fetchClient = (clientId: string): Promise<Client> =>
+  handleRequest(() => axios.get<Client>(`/clients/${clientId}`));
 
-export const createClient = (values: string): Promise<Client> => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}clients`, {
-      method: "POST",
-      body: values,
-    })
-      .then(handleResponse)
-      .then((result: ApiResponse<Client>) => resolve(result.data))
-      .catch(reject);
-  });
-};
+export const createClient = (values: string): Promise<Client> =>
+  handleRequest(() => axios.post<Client>("/clients", values));
 
 export const updateClient = (
   clientId: string,
   values: string,
-): Promise<Client> => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}clients/${clientId}`, {
-      method: "PUT",
-      body: values,
-    })
-      .then(handleResponse)
-      .then((result: ApiResponse<Client>) => resolve(result.data))
-      .catch(reject);
-  });
-};
+): Promise<Client> =>
+  handleRequest(() => axios.post<Client>(`/clients/${clientId}`, values));
 
-export const deleteClient = (client: string) => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}clients/${client}`, {
+export const deleteClient = (client: string) =>
+  handleRequest(() =>
+    axios.get<string>(`/clients/${client}`, {
       method: "DELETE",
-    })
-      .then(resolve)
-      .catch(reject);
-  });
-};
+    }),
+  );

--- a/ui/src/api/client.tsx
+++ b/ui/src/api/client.tsx
@@ -1,5 +1,5 @@
 import { Client } from "types/client";
-import { PaginatedResponse } from "types/api";
+import { PaginatedResponse, ApiResponse } from "types/api";
 import { handleRequest, PAGE_SIZE } from "util/api";
 import axios from "axios";
 
@@ -12,21 +12,23 @@ export const fetchClients = (
     ),
   );
 
-export const fetchClient = (clientId: string): Promise<Client> =>
-  handleRequest(() => axios.get<Client>(`/clients/${clientId}`));
+export const fetchClient = (clientId: string): Promise<ApiResponse<Client>> =>
+  handleRequest(() => axios.get<ApiResponse<Client>>(`/clients/${clientId}`));
 
-export const createClient = (values: string): Promise<Client> =>
-  handleRequest(() => axios.post<Client>("/clients", values));
+export const createClient = (values: string): Promise<ApiResponse<Client>> =>
+  handleRequest(() => axios.post<ApiResponse<Client>>("/clients", values));
 
 export const updateClient = (
   clientId: string,
   values: string,
-): Promise<Client> =>
-  handleRequest(() => axios.post<Client>(`/clients/${clientId}`, values));
+): Promise<ApiResponse<Client>> =>
+  handleRequest(() =>
+    axios.post<ApiResponse<Client>>(`/clients/${clientId}`, values),
+  );
 
 export const deleteClient = (client: string) =>
   handleRequest(() =>
-    axios.get<string>(`/clients/${client}`, {
+    axios.get<ApiResponse<string>>(`/clients/${client}`, {
       method: "DELETE",
     }),
   );

--- a/ui/src/api/identities.tsx
+++ b/ui/src/api/identities.tsx
@@ -1,4 +1,4 @@
-import { PaginatedResponse } from "types/api";
+import { ApiResponse, PaginatedResponse } from "types/api";
 import { handleRequest, PAGE_SIZE } from "util/api";
 import { Identity } from "types/identity";
 import axios from "axios";
@@ -12,19 +12,23 @@ export const fetchIdentities = (
     ),
   );
 
-export const fetchIdentity = (identityId: string): Promise<Identity> =>
-  handleRequest(() => axios.get<Identity>(`/identities/${identityId}`));
+export const fetchIdentity = (
+  identityId: string,
+): Promise<ApiResponse<Identity>> =>
+  handleRequest(() =>
+    axios.get<ApiResponse<Identity>>(`/identities/${identityId}`),
+  );
 
-export const createIdentity = (body: string): Promise<void> =>
+export const createIdentity = (body: string): Promise<unknown> =>
   handleRequest(() => axios.post("/identities", body));
 
 export const updateIdentity = (
   identityId: string,
   values: string,
-): Promise<Identity> =>
+): Promise<ApiResponse<Identity>> =>
   handleRequest(() =>
-    axios.patch<Identity>(`/identities/${identityId}`, values),
+    axios.patch<ApiResponse<Identity>>(`/identities/${identityId}`, values),
   );
 
-export const deleteIdentity = (identityId: string): Promise<void> =>
+export const deleteIdentity = (identityId: string): Promise<unknown> =>
   handleRequest(() => axios.delete(`/identities/${identityId}`));

--- a/ui/src/api/identities.tsx
+++ b/ui/src/api/identities.tsx
@@ -1,61 +1,30 @@
-import { ApiResponse, PaginatedResponse } from "types/api";
-import { handleResponse, PAGE_SIZE } from "util/api";
+import { PaginatedResponse } from "types/api";
+import { handleRequest, PAGE_SIZE } from "util/api";
 import { Identity } from "types/identity";
-import { apiBasePath } from "util/basePaths";
+import axios from "axios";
 
 export const fetchIdentities = (
   pageToken: string,
-): Promise<PaginatedResponse<Identity[]>> => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}identities?page_token=${pageToken}&size=${PAGE_SIZE}`)
-      .then(handleResponse)
-      .then((result: PaginatedResponse<Identity[]>) => resolve(result))
-      .catch(reject);
-  });
-};
+): Promise<PaginatedResponse<Identity[]>> =>
+  handleRequest(() =>
+    axios.get<PaginatedResponse<Identity[]>>(
+      `/identities?page_token=${pageToken}&size=${PAGE_SIZE}`,
+    ),
+  );
 
-export const fetchIdentity = (identityId: string): Promise<Identity> => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}identities/${identityId}`)
-      .then(handleResponse)
-      .then((result: ApiResponse<Identity[]>) => resolve(result.data[0]))
-      .catch(reject);
-  });
-};
+export const fetchIdentity = (identityId: string): Promise<Identity> =>
+  handleRequest(() => axios.get<Identity>(`/identities/${identityId}`));
 
-export const createIdentity = (body: string): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}identities`, {
-      method: "POST",
-      body: body,
-    })
-      .then(handleResponse)
-      .then(resolve)
-      .catch(reject);
-  });
-};
+export const createIdentity = (body: string): Promise<void> =>
+  handleRequest(() => axios.post("/identities", body));
 
 export const updateIdentity = (
   identityId: string,
   values: string,
-): Promise<Identity> => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}identities/${identityId}`, {
-      method: "PATCH",
-      body: values,
-    })
-      .then(handleResponse)
-      .then((result: ApiResponse<Identity>) => resolve(result.data))
-      .catch(reject);
-  });
-};
+): Promise<Identity> =>
+  handleRequest(() =>
+    axios.patch<Identity>(`/identities/${identityId}`, values),
+  );
 
-export const deleteIdentity = (identityId: string) => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}identities/${identityId}`, {
-      method: "DELETE",
-    })
-      .then(resolve)
-      .catch(reject);
-  });
-};
+export const deleteIdentity = (identityId: string): Promise<void> =>
+  handleRequest(() => axios.delete(`/identities/${identityId}`));

--- a/ui/src/api/provider.tsx
+++ b/ui/src/api/provider.tsx
@@ -1,63 +1,30 @@
-import { ApiResponse } from "types/api";
-import { handleResponse } from "util/api";
+import { handleRequest } from "util/api";
 import { IdentityProvider } from "types/provider";
-import { apiBasePath } from "util/basePaths";
+import axios from "axios";
 
-export const fetchProviders = (): Promise<IdentityProvider[]> => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}idps`)
-      .then(handleResponse)
-      .then((result: ApiResponse<IdentityProvider[]>) => resolve(result.data))
-      .catch(reject);
-  });
-};
+export const fetchProviders = (): Promise<IdentityProvider[]> =>
+  handleRequest(() => axios.get<IdentityProvider[]>(`/idps`));
 
 export const fetchProvider = (
   providerId: string,
 ): Promise<IdentityProvider> => {
   return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}idps/${providerId}`)
-      .then(handleResponse)
-      .then((result: ApiResponse<IdentityProvider[]>) =>
-        resolve(result.data[0]),
-      )
-      .catch(reject);
+    handleRequest(() => axios.get<IdentityProvider[]>(`/idps/${providerId}`))
+      .then((data) => resolve(data[0]))
+      .catch((error) => reject(error));
   });
 };
 
-export const createProvider = (body: string): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}idps`, {
-      method: "POST",
-      body: body,
-    })
-      .then(handleResponse)
-      .then(resolve)
-      .catch(reject);
-  });
-};
+export const createProvider = (body: string): Promise<void> =>
+  handleRequest(() => axios.post("/idps", body));
 
 export const updateProvider = (
   providerId: string,
   values: string,
-): Promise<IdentityProvider> => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}idps/${providerId}`, {
-      method: "PATCH",
-      body: values,
-    })
-      .then(handleResponse)
-      .then((result: ApiResponse<IdentityProvider>) => resolve(result.data))
-      .catch(reject);
-  });
-};
+): Promise<IdentityProvider> =>
+  handleRequest(() =>
+    axios.patch<IdentityProvider>(`/idps/${providerId}`, values),
+  );
 
-export const deleteProvider = (providerId: string) => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}idps/${providerId}`, {
-      method: "DELETE",
-    })
-      .then(resolve)
-      .catch(reject);
-  });
-};
+export const deleteProvider = (providerId: string): Promise<void> =>
+  handleRequest(() => axios.delete(`/idps/${providerId}`));

--- a/ui/src/api/provider.tsx
+++ b/ui/src/api/provider.tsx
@@ -1,30 +1,37 @@
 import { handleRequest } from "util/api";
 import { IdentityProvider } from "types/provider";
 import axios from "axios";
+import { PaginatedResponse, ApiResponse } from "types/api";
 
-export const fetchProviders = (): Promise<IdentityProvider[]> =>
-  handleRequest(() => axios.get<IdentityProvider[]>(`/idps`));
+export const fetchProviders = (): Promise<
+  PaginatedResponse<IdentityProvider[]>
+> =>
+  handleRequest(() =>
+    axios.get<PaginatedResponse<IdentityProvider[]>>(`/idps`),
+  );
 
 export const fetchProvider = (
   providerId: string,
 ): Promise<IdentityProvider> => {
   return new Promise((resolve, reject) => {
-    handleRequest(() => axios.get<IdentityProvider[]>(`/idps/${providerId}`))
-      .then((data) => resolve(data[0]))
+    handleRequest<IdentityProvider[], ApiResponse<IdentityProvider[]>>(() =>
+      axios.get<ApiResponse<IdentityProvider[]>>(`/idps/${providerId}`),
+    )
+      .then(({ data }) => resolve(data[0]))
       .catch((error) => reject(error));
   });
 };
 
-export const createProvider = (body: string): Promise<void> =>
+export const createProvider = (body: string): Promise<unknown> =>
   handleRequest(() => axios.post("/idps", body));
 
 export const updateProvider = (
   providerId: string,
   values: string,
-): Promise<IdentityProvider> =>
+): Promise<ApiResponse<IdentityProvider>> =>
   handleRequest(() =>
-    axios.patch<IdentityProvider>(`/idps/${providerId}`, values),
+    axios.patch<ApiResponse<IdentityProvider>>(`/idps/${providerId}`, values),
   );
 
-export const deleteProvider = (providerId: string): Promise<void> =>
+export const deleteProvider = (providerId: string): Promise<unknown> =>
   handleRequest(() => axios.delete(`/idps/${providerId}`));

--- a/ui/src/api/schema.tsx
+++ b/ui/src/api/schema.tsx
@@ -1,4 +1,4 @@
-import { PaginatedResponse } from "types/api";
+import { PaginatedResponse, ApiResponse } from "types/api";
 import { handleRequest, PAGE_SIZE } from "util/api";
 import { Schema } from "types/schema";
 import axios from "axios";
@@ -14,20 +14,24 @@ export const fetchSchemas = (
 
 export const fetchSchema = (schemaId: string): Promise<Schema> => {
   return new Promise((resolve, reject) => {
-    handleRequest(() => axios.get<Schema[]>(`/schemas/${schemaId}`))
-      .then((data) => resolve(data[0]))
+    handleRequest<Schema[], ApiResponse<Schema[]>>(() =>
+      axios.get<ApiResponse<Schema[]>>(`/schemas/${schemaId}`),
+    )
+      .then(({ data }) => resolve(data[0]))
       .catch((error) => reject(error));
   });
 };
 
-export const createSchema = (body: string): Promise<void> =>
+export const createSchema = (body: string): Promise<unknown> =>
   handleRequest(() => axios.post("/schemas", body));
 
 export const updateSchema = (
   schemaId: string,
   values: string,
-): Promise<Schema> =>
-  handleRequest(() => axios.patch<Schema>(`/schemas/${schemaId}`, values));
+): Promise<ApiResponse<Schema>> =>
+  handleRequest(() =>
+    axios.patch<ApiResponse<Schema>>(`/schemas/${schemaId}`, values),
+  );
 
-export const deleteSchema = (schemaId: string): Promise<void> =>
+export const deleteSchema = (schemaId: string): Promise<unknown> =>
   handleRequest(() => axios.delete(`/schemas/${schemaId}`));

--- a/ui/src/api/schema.tsx
+++ b/ui/src/api/schema.tsx
@@ -1,63 +1,33 @@
-import { ApiResponse, PaginatedResponse } from "types/api";
-import { handleResponse, PAGE_SIZE } from "util/api";
+import { PaginatedResponse } from "types/api";
+import { handleRequest, PAGE_SIZE } from "util/api";
 import { Schema } from "types/schema";
-import { apiBasePath } from "util/basePaths";
+import axios from "axios";
 
 export const fetchSchemas = (
   pageToken: string,
-): Promise<PaginatedResponse<Schema[]>> => {
-  return new Promise((resolve, reject) => {
-    fetch(
-      `${apiBasePath}schemas?page_token=${pageToken}&page_size=${PAGE_SIZE}`,
-    )
-      .then(handleResponse)
-      .then((result: PaginatedResponse<Schema[]>) => resolve(result))
-      .catch(reject);
-  });
-};
+): Promise<PaginatedResponse<Schema[]>> =>
+  handleRequest(() =>
+    axios.get<PaginatedResponse<Schema[]>>(
+      `/schemas?page_token=${pageToken}&page_size=${PAGE_SIZE}`,
+    ),
+  );
 
 export const fetchSchema = (schemaId: string): Promise<Schema> => {
   return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}schemas/${schemaId}`)
-      .then(handleResponse)
-      .then((result: ApiResponse<Schema[]>) => resolve(result.data[0]))
-      .catch(reject);
+    handleRequest(() => axios.get<Schema[]>(`/schemas/${schemaId}`))
+      .then((data) => resolve(data[0]))
+      .catch((error) => reject(error));
   });
 };
 
-export const createSchema = (body: string): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}schemas`, {
-      method: "POST",
-      body: body,
-    })
-      .then(handleResponse)
-      .then(resolve)
-      .catch(reject);
-  });
-};
+export const createSchema = (body: string): Promise<void> =>
+  handleRequest(() => axios.post("/schemas", body));
 
 export const updateSchema = (
   schemaId: string,
   values: string,
-): Promise<Schema> => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}schemas/${schemaId}`, {
-      method: "PATCH",
-      body: values,
-    })
-      .then(handleResponse)
-      .then((result: ApiResponse<Schema>) => resolve(result.data))
-      .catch(reject);
-  });
-};
+): Promise<Schema> =>
+  handleRequest(() => axios.patch<Schema>(`/schemas/${schemaId}`, values));
 
-export const deleteSchema = (schemaId: string) => {
-  return new Promise((resolve, reject) => {
-    fetch(`${apiBasePath}schemas/${schemaId}`, {
-      method: "DELETE",
-    })
-      .then(resolve)
-      .catch(reject);
-  });
-};
+export const deleteSchema = (schemaId: string): Promise<void> =>
+  handleRequest(() => axios.delete(`/schemas/${schemaId}`));

--- a/ui/src/components/Layout/Layout.test.tsx
+++ b/ui/src/components/Layout/Layout.test.tsx
@@ -1,14 +1,21 @@
-import { renderComponent } from "test/utils";
-import Layout from "./Layout";
 import { screen } from "@testing-library/dom";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+
+import { authURLs } from "api/auth";
 import { LoginLabel } from "components/Login";
+import { renderComponent } from "test/utils";
+
+import Layout from "./Layout";
+
+const mock = new MockAdapter(axios);
 
 beforeEach(() => {
-  fetchMock.resetMocks();
+  mock.reset();
 });
 
 test("displays the login screen if the user is not authenticated", async () => {
-  fetchMock.mockResponseOnce(JSON.stringify({}), { status: 403 });
+  mock.onGet(authURLs.me).reply(403, {});
   renderComponent(<Layout />);
   expect(
     await screen.findByRole("heading", { name: LoginLabel.TITLE }),
@@ -23,7 +30,7 @@ test("displays the layout and content if the user is authenticated", async () =>
     sid: "sid",
     sub: "sub",
   };
-  fetchMock.mockResponse(JSON.stringify(user), { status: 200 });
+  mock.onGet(authURLs.me).reply(200, { data: user });
   renderComponent(<Layout />, {
     path: "/",
     url: "/",

--- a/ui/src/components/Login/Login.tsx
+++ b/ui/src/components/Login/Login.tsx
@@ -9,6 +9,7 @@ import { authURLs } from "api/auth";
 import { FC, ReactNode } from "react";
 import { SITE_NAME } from "consts";
 import { Label } from "./types";
+import { appendAPIBasePath } from "util/basePaths";
 
 type Props = {
   isLoading?: boolean;
@@ -38,7 +39,7 @@ const Login: FC<Props> = ({ error, isLoading }) => {
         }
         disabled={isLoading}
         element="a"
-        href={authURLs.login}
+        href={appendAPIBasePath(authURLs.login)}
       >
         Sign in to {SITE_NAME}
       </Button>

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -4,7 +4,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import "./sass/styles.scss";
 import { NotificationProvider } from "@canonical/react-components";
-import { basePath } from "util/basePaths";
+import { apiBasePath, basePath } from "util/basePaths";
+import axios from "axios";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -16,6 +17,8 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+axios.defaults.baseURL = apiBasePath;
 
 const rootElement = document.getElementById("app");
 if (!rootElement) throw new Error("Failed to find the root element");

--- a/ui/src/pages/clients/ClientCreate.tsx
+++ b/ui/src/pages/clients/ClientCreate.tsx
@@ -38,7 +38,7 @@ const ClientCreate: FC = () => {
     validationSchema: ClientCreateSchema,
     onSubmit: (values) => {
       createClient(JSON.stringify(values))
-        .then((result) => {
+        .then(({ data: result }) => {
           void queryClient.invalidateQueries({
             queryKey: [queryKeys.clients],
           });

--- a/ui/src/pages/clients/ClientEdit.tsx
+++ b/ui/src/pages/clients/ClientEdit.tsx
@@ -28,10 +28,11 @@ const ClientEdit: FC = () => {
     return;
   }
 
-  const { data: client } = useQuery({
+  const { data } = useQuery({
     queryKey: [queryKeys.clients, clientId],
     queryFn: () => fetchClient(clientId),
   });
+  const client = data?.data;
 
   const ClientEditSchema = Yup.object().shape({
     client_name: Yup.string().required("This field is required"),

--- a/ui/src/pages/providers/DeleteProviderBtn.tsx
+++ b/ui/src/pages/providers/DeleteProviderBtn.tsx
@@ -28,6 +28,10 @@ const DeleteProviderBtn: FC<Props> = ({ provider }) => {
 
   const handleDelete = () => {
     setLoading(true);
+    if (!provider.id) {
+      console.error("Cannot delete provider without id", provider);
+      return;
+    }
     deleteProvider(provider.id)
       .then(() => {
         navigate(

--- a/ui/src/pages/providers/ProviderList.tsx
+++ b/ui/src/pages/providers/ProviderList.tsx
@@ -16,7 +16,7 @@ import DeleteProviderBtn from "pages/providers/DeleteProviderBtn";
 const ProviderList: FC = () => {
   const panelParams = usePanelParams();
 
-  const { data: providers = [] } = useQuery({
+  const { data: providers } = useQuery({
     queryKey: [queryKeys.providers],
     queryFn: fetchProviders,
   });
@@ -51,7 +51,7 @@ const ProviderList: FC = () => {
                 { content: "Provider", sortKey: "provider" },
                 { content: "Actions" },
               ]}
-              rows={providers.map((provider) => {
+              rows={providers?.data.map((provider) => {
                 return {
                   columns: [
                     {

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -1,12 +1,6 @@
 import "@testing-library/jest-dom/vitest";
-import { vi } from "vitest";
-import createFetchMock from "vitest-fetch-mock";
 import type { Window as HappyDOMWindow } from "happy-dom";
 
 declare global {
   interface Window extends HappyDOMWindow {}
 }
-
-const fetchMocker = createFetchMock(vi);
-// sets globalThis.fetch and globalThis.fetchMock to our mocked version
-fetchMocker.enableMocks();

--- a/ui/src/util/api.tsx
+++ b/ui/src/util/api.tsx
@@ -1,11 +1,17 @@
 import { ErrorResponse } from "types/api";
+import { AxiosResponse } from "axios";
+import { AxiosError } from "axios";
 
 export const PAGE_SIZE = 50;
 
-export const handleResponse = async (response: Response) => {
-  if (!response.ok) {
-    const result = (await response.json()) as ErrorResponse;
-    throw Error(result.error ?? result.message);
-  }
-  return response.json();
+export const handleRequest = <R,>(
+  request: () => Promise<AxiosResponse<R>>,
+): Promise<R> => {
+  return new Promise((resolve, reject) => {
+    request()
+      .then((result) => resolve(result.data))
+      .catch(({ response }: AxiosError<ErrorResponse>) =>
+        reject(response?.data?.error ?? response?.data?.message),
+      );
+  });
 };

--- a/ui/src/util/api.tsx
+++ b/ui/src/util/api.tsx
@@ -1,15 +1,15 @@
-import { ErrorResponse } from "types/api";
+import { ApiResponse, ErrorResponse } from "types/api";
 import { AxiosResponse } from "axios";
 import { AxiosError } from "axios";
 
 export const PAGE_SIZE = 50;
 
-export const handleRequest = <R,>(
+export const handleRequest = <T, R extends ApiResponse<T>>(
   request: () => Promise<AxiosResponse<R>>,
 ): Promise<R> => {
   return new Promise((resolve, reject) => {
     request()
-      .then((result) => resolve(result.data))
+      .then((response) => resolve(response.data))
       .catch(({ response }: AxiosError<ErrorResponse>) =>
         reject(response?.data?.error ?? response?.data?.message),
       );

--- a/ui/src/util/basePaths.spec.ts
+++ b/ui/src/util/basePaths.spec.ts
@@ -1,4 +1,18 @@
-import { calculateBasePath } from "./basePaths";
+import {
+  appendBasePath,
+  calculateBasePath,
+  appendAPIBasePath,
+} from "./basePaths";
+
+vi.mock("./basePaths", async () => {
+  vi.stubGlobal("location", { pathname: "/example/ui/" });
+  const actual = await vi.importActual("./basePaths");
+  return {
+    ...actual,
+    basePath: "/example/ui/",
+    apiBasePath: "/example/ui/../api/v0/",
+  };
+});
 
 describe("calculateBasePath", () => {
   it("resolves with ui path", () => {
@@ -29,5 +43,25 @@ describe("calculateBasePath", () => {
     vi.stubGlobal("location", { pathname: "/foo/bar/baz" });
     const result = calculateBasePath();
     expect(result).toBe("/");
+  });
+});
+
+describe("appendBasePath", () => {
+  it("handles paths with a leading slash", () => {
+    expect(appendBasePath("/test")).toBe("/example/ui/test");
+  });
+
+  it("handles paths without a leading slash", () => {
+    expect(appendBasePath("test")).toBe("/example/ui/test");
+  });
+});
+
+describe("appendAPIBasePath", () => {
+  it("handles paths with a leading slash", () => {
+    expect(appendAPIBasePath("/test")).toBe("/example/ui/../api/v0/test");
+  });
+
+  it("handles paths without a leading slash", () => {
+    expect(appendAPIBasePath("test")).toBe("/example/ui/../api/v0/test");
   });
 });

--- a/ui/src/util/basePaths.ts
+++ b/ui/src/util/basePaths.ts
@@ -12,3 +12,9 @@ export const calculateBasePath = (): BasePath => {
 
 export const basePath: BasePath = calculateBasePath();
 export const apiBasePath: BasePath = `${basePath}../api/v0/`;
+
+export const appendBasePath = (path: string) =>
+  `${basePath.replace(/\/$/, "")}/${path.replace(/^\//, "")}`;
+
+export const appendAPIBasePath = (path: string) =>
+  `${apiBasePath.replace(/\/$/, "")}/${path.replace(/^\//, "")}`;

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2511,6 +2511,14 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
+axios-mock-adapter@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-2.0.0.tgz#91920c06e2e5733dd118ba079e4a12c58f3a68aa"
+  integrity sha512-D/K0J5Zm6KvaMTnsWrBQZWLzKN9GxUFZEa0mx2qeEHXDeTugCoplWehy8y36dj5vuSjhe1u/Dol8cZ8lzzmDew==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    is-buffer "^2.0.5"
+
 axios@1.6.8:
   version "1.6.8"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
@@ -3022,13 +3030,6 @@ cosmiconfig@^9.0.0:
     import-fresh "^3.3.0"
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
-
-cross-fetch@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
-  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
-  dependencies:
-    node-fetch "^2.6.12"
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -4421,6 +4422,11 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-buffer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
+
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
@@ -5144,13 +5150,6 @@ negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
-
-node-fetch@^2.6.12:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
-  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
-  dependencies:
-    whatwg-url "^5.0.0"
 
 node-releases@^2.0.13:
   version "2.0.13"
@@ -6609,11 +6608,6 @@ tr46@^3.0.0:
   dependencies:
     punycode "^2.1.1"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
 tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
@@ -6900,13 +6894,6 @@ vite@^5.0.0:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitest-fetch-mock@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/vitest-fetch-mock/-/vitest-fetch-mock-0.3.0.tgz#a519293b61be1ce43377d720500bbfa89861e509"
-  integrity sha512-g6upWcL8/32fXL43/5f4VHcocuwQIi9Fj5othcK9gPO8XqSEGtnIZdenr2IaipDr61ReRFt+vaOEgo8jiUUX5w==
-  dependencies:
-    cross-fetch "^4.0.0"
-
 vitest@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/vitest/-/vitest-1.2.1.tgz#9afb705826a2c6260a71b625d28b49117833dce6"
@@ -6941,11 +6928,6 @@ w3c-xmlserializer@^4.0.0:
   dependencies:
     xml-name-validator "^4.0.0"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
 webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
@@ -6970,14 +6952,6 @@ whatwg-url@^11.0.0:
   dependencies:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Changes

- Migrate API calls to Axios.
- Set API base path using Axios config.

This change means we can centrally handle 401 errors for all API calls and display the OIDC login if needed.

https://warthogs.atlassian.net/browse/WD-13813