### PR TITLE
WD-13637 - feat: display login on 401 responses

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@canonical/react-components": "0.59.0",
-    "@canonical/rebac-admin": "0.0.1-alpha.5",
+    "@canonical/rebac-admin": "0.0.1-alpha.6",
     "@tanstack/react-query": "^5.28.6",
     "@use-it/event-listener": "0.1.7",
     "axios": "1.6.8",

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,0 +1,83 @@
+import { QueryCache, QueryClient } from "@tanstack/react-query";
+import { screen, waitFor } from "@testing-library/dom";
+import MockAdapter from "axios-mock-adapter";
+
+import { authURLs } from "api/auth";
+import { LoginLabel } from "components/Login";
+import { renderComponent } from "test/utils";
+
+import App from "./App";
+import { axiosInstance } from "./api/axios";
+
+const mock = new MockAdapter(axiosInstance);
+
+beforeEach(() => {
+  mock.reset();
+  mock.onGet(authURLs.me).reply(200, {
+    data: {
+      email: "email",
+      name: "name",
+      nonce: "nonce",
+      sid: "sid",
+      sub: "sub",
+    },
+  });
+});
+
+test("does not display login for successful responses", async () => {
+  mock.onGet("/test").reply(200, {});
+  renderComponent(<App />);
+  await axiosInstance.get("/test");
+  expect(
+    await screen.findByRole("heading", { name: LoginLabel.TITLE }),
+  ).not.toBeInTheDocument();
+});
+
+test("does not display login for non-authentication errors", async () => {
+  mock.onGet("/test").reply(500, {});
+  renderComponent(<App />);
+  axiosInstance.get("/test").catch(() => {
+    // Don't do anything with this 500 error.
+  });
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("heading", { name: LoginLabel.TITLE }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+test("displays login for authentication errors", async () => {
+  mock.onGet("/test").reply(401, {});
+  renderComponent(<App />);
+  axiosInstance.get("/test").catch(() => {
+    // Don't do anything with this 401 error.
+  });
+  expect(
+    await screen.findByRole("heading", { name: LoginLabel.TITLE }),
+  ).toBeInTheDocument();
+});
+
+test("does not invalidate the cache on authentication errors from /auth/me", async () => {
+  mock.onGet(authURLs.me).reply(401, {});
+  const queryCache = new QueryCache();
+  let cacheInvalidated = false;
+  queryCache.subscribe((event) => {
+    if ("action" in event && event.action.type === "invalidate") {
+      cacheInvalidated = true;
+    }
+  });
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: 1,
+      },
+    },
+    queryCache,
+  });
+  renderComponent(<App />, { queryClient });
+  await axiosInstance.get(authURLs.me).catch(() => {
+    // Don't do anything with this 401 error.
+  });
+  expect(cacheInvalidated).toBeFalsy();
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,10 @@
-import { FC } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { FC, useRef } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { ReBACAdmin } from "@canonical/rebac-admin";
+import { AxiosError } from "axios";
+
+import { authURLs } from "api/auth";
 import ClientList from "pages/clients/ClientList";
 import NoMatch from "components/NoMatch";
 import ProviderList from "pages/providers/ProviderList";
@@ -8,8 +12,36 @@ import IdentityList from "pages/identities/IdentityList";
 import SchemaList from "pages/schemas/SchemaList";
 import { apiBasePath } from "util/basePaths";
 import Layout from "components/Layout/Layout";
+import { queryKeys } from "util/queryKeys";
+import { axiosInstance } from "./api/axios";
 
 const App: FC = () => {
+  const queryClient = useQueryClient();
+
+  useRef(
+    axiosInstance.interceptors.response.use(
+      (response) => response,
+      (error: AxiosError) => {
+        if (
+          error.response?.status === 401 &&
+          // The 'me' endpoint is used to check whether the user is
+          // authenticated, so don't invalidate the cache for these requests as
+          // that would cause it to be fetched again and cause an infinite loop.
+          error.config?.url !== authURLs.me
+        ) {
+          // Handle any unauthenticated requests and clear the cache for the
+          // auth endpoints so that the user details will get requested again
+          // and display the login screen if needed.
+          void queryClient.invalidateQueries({
+            queryKey: [queryKeys.auth],
+          });
+          return;
+        }
+        return Promise.reject(error);
+      },
+    ),
+  );
+
   return (
     <Routes>
       <Route path="/" element={<Layout />}>
@@ -21,7 +53,11 @@ const App: FC = () => {
         <Route
           path="/*"
           element={
-            <ReBACAdmin apiURL={apiBasePath} asidePanelId="app-layout" />
+            <ReBACAdmin
+              apiURL={apiBasePath}
+              asidePanelId="app-layout"
+              axiosInstance={axiosInstance}
+            />
           }
         />
         <Route path="*" element={<NoMatch />} />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,7 +10,6 @@ import NoMatch from "components/NoMatch";
 import ProviderList from "pages/providers/ProviderList";
 import IdentityList from "pages/identities/IdentityList";
 import SchemaList from "pages/schemas/SchemaList";
-import { apiBasePath } from "util/basePaths";
 import Layout from "components/Layout/Layout";
 import { queryKeys } from "util/queryKeys";
 import { axiosInstance } from "./api/axios";
@@ -35,7 +34,7 @@ const App: FC = () => {
           void queryClient.invalidateQueries({
             queryKey: [queryKeys.auth],
           });
-          return;
+          return null;
         }
         return Promise.reject(error);
       },
@@ -54,7 +53,6 @@ const App: FC = () => {
           path="/*"
           element={
             <ReBACAdmin
-              apiURL={apiBasePath}
               asidePanelId="app-layout"
               axiosInstance={axiosInstance}
             />

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1198,10 +1198,10 @@
     react-table "7.8.0"
     react-useportal "1.0.19"
 
-"@canonical/rebac-admin@0.0.1-alpha.5":
-  version "0.0.1-alpha.5"
-  resolved "https://registry.yarnpkg.com/@canonical/rebac-admin/-/rebac-admin-0.0.1-alpha.5.tgz#88adc001c84453a93dc031c823a904693c21a4fd"
-  integrity sha512-d0ijUN10R36aQcoNh9FqV4WCtGpcq5jzxTAWrmuSfM7FuBV7toenCJhw6winn3gYhMfbCvJchADkpbf4hbMw4w==
+"@canonical/rebac-admin@0.0.1-alpha.6":
+  version "0.0.1-alpha.6"
+  resolved "https://registry.yarnpkg.com/@canonical/rebac-admin/-/rebac-admin-0.0.1-alpha.6.tgz#9d8648227c8a9f8cab662f7027b81f956b6d7857"
+  integrity sha512-BtnehwLzH1giBPSbsxAL4JmkGnXs8ccxM5OcQ7qClBKWacTp8tSvWjS7qD8PX9BCeK/wXMZvlBd4C/elINcW0w==
   dependencies:
     async-limiter "2.0.0"
     classnames "2.5.1"


### PR DESCRIPTION
## Changes

- Add a global error handler. https://warthogs.atlassian.net/browse/WD-13636
- Display login if 401 response is received for any API response. https://warthogs.atlassian.net/browse/WD-13637

## QA

- Log in.
- In another tab log out (visit http://localhost:8000/api/v0/auth/logout).
- Go back to the first tab and click on a different page.
- The API should return a 401 and the login button should get displayed.
