### PR TITLE
IAM 978 User invite - send email for identity creation with recovery code and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,20 @@ This is the Admin UI for the Canonical Identity Platform.
   middleware is enabled default to `true`
 - `AUTHENTICATION_ENABLED`: flag defining if the OAuth authentication middleware
   is enabled, default to `false`
-- `OIDC_ISSUER`: URL of the OIDC provider 
+- `OIDC_ISSUER`: URL of the OIDC provider
 - `OAUTH2_CLIENT_ID`: OAuth2 client ID used for authentication purposes
 - `OAUTH2_CLIENT_SECRET`: OAuth2 client secret used for authentication purposes
 - `OAUTH2_REDIRECT_URI`: URI used by the Oauth2 provider for the redirecting callback
 - `OAUTH2_CODEGRANT_SCOPES`: OAuth2 scopes, defaults to `openid,offline_access`
 - `OAUTH2_AUTH_COOKIES_ENCRYPTION_KEY`: 32 bytes string used for encrypting cookies
 - `ACCESS_TOKEN_VERIFICATION_STRATEGY`: OAuth2 verification startegy, one of `jwks` or `userinfo``
+- `MAIL_HOST`: host of the mail server (required)
+- `MAIL_PORT`: port exposed by the mail server (required)
+- `MAIL_USERNAME`: username to use for the simple authentication on the mail server (if present, both username and
+  password are used)
+- `MAIL_PASSWORD`: password to use for the simple authentication on the mail server
+- `MAIL_FROM_ADDRESS`: email address sending the email (required)
+- `MAIL_SEND_TIMEOUT_SECONDS`: timeout used to send emails (defaults to 15 seconds)
 
 ## Development setup
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -23,6 +23,7 @@ import (
 	k8s "github.com/canonical/identity-platform-admin-ui/internal/k8s"
 	ik "github.com/canonical/identity-platform-admin-ui/internal/kratos"
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/mail"
 	"github.com/canonical/identity-platform-admin-ui/internal/monitoring/prometheus"
 	io "github.com/canonical/identity-platform-admin-ui/internal/oathkeeper"
 	"github.com/canonical/identity-platform-admin-ui/internal/openfga"
@@ -164,9 +165,11 @@ func serve() {
 		hydraAdminClient,
 	)
 
+	mailConfig := mail.NewConfig(specs.MailHost, specs.MailPort, specs.MailUsername, specs.MailPassword, specs.MailFromAddress, specs.MailSendTimeoutSeconds)
+
 	ollyConfig := web.NewO11yConfig(tracer, monitor, logger)
 
-	routerConfig := web.NewRouterConfig(specs.ContextPath, specs.PayloadValidationEnabled, idpConfig, schemasConfig, rulesConfig, uiConfig, externalConfig, oauth2Config, ollyConfig)
+	routerConfig := web.NewRouterConfig(specs.ContextPath, specs.PayloadValidationEnabled, idpConfig, schemasConfig, rulesConfig, uiConfig, externalConfig, oauth2Config, mailConfig, ollyConfig)
 
 	router := web.NewRouter(routerConfig, wpool)
 

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/wneessen/go-mail v0.4.4 // indirect
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,8 @@ github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJ
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/wneessen/go-mail v0.4.4 h1:rI8wJzPYymUpUth87vFV3k313bmnid4v+FwhBAYYLFM=
+github.com/wneessen/go-mail v0.4.4/go.mod h1:zxOlafWCP/r6FEhAaRgH4IC1vg2YXxO0Nar9u0IScZ8=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -57,4 +57,11 @@ type EnvSpec struct {
 	PayloadValidationEnabled bool `envconfig:"payload_validation_enabled" default:"true"`
 
 	OpenFGAWorkersTotal int `envconfig:"openfga_workers_total" default:"150"`
+
+	MailHost               string `envconfig:"MAIL_HOST" required:"true"`
+	MailPort               int    `envconfig:"MAIL_PORT" required:"true"`
+	MailUsername           string `envconfig:"MAIL_USERNAME"`
+	MailPassword           string `envconfig:"MAIL_PASSWORD"`
+	MailFromAddress        string `envconfig:"MAIL_FROM_ADDRESS" required:"true"`
+	MailSendTimeoutSeconds int    `envconfig:"MAIL_SEND_TIMEOUT_SECONDS" default:"15"`
 }

--- a/internal/mail/html/user-invite.html
+++ b/internal/mail/html/user-invite.html
@@ -1,0 +1,85 @@
+<!-- Copyright 2024 Canonical Ltd. -->
+<!-- SPDX-License-Identifier: AGPL-3.0 -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <title>Verify Your Account</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f6f6f6;
+            color: #333;
+            margin: 0;
+            padding: 0;
+        }
+
+        .container {
+            width: 100%;
+            max-width: 600px;
+            margin: 20px auto;
+            background-color: #ffffff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+
+        .header {
+            text-align: center;
+            padding: 20px 0;
+        }
+
+        .header h1 {
+            color: #007BFF;
+            margin: 0;
+        }
+
+        .content {
+            text-align: center;
+        }
+
+        .content p {
+            font-size: 16px;
+            line-height: 1.5;
+            margin: 20px 0;
+        }
+
+        .verify-button {
+            display: inline-block;
+            background-color: #007BFF;
+            color: #ffffff;
+            text-decoration: none;
+            padding: 10px 20px;
+            border-radius: 5px;
+            font-size: 18px;
+            margin-top: 20px;
+        }
+
+        .footer {
+            text-align: center;
+            font-size: 12px;
+            color: #666;
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="header">
+        <h1>Verify Your Account</h1>
+    </div>
+    <div class="content">
+        <p>Hello,</p>
+        <p>Your account with the email address <strong>{{ .Email }}</strong> was recently created. To complete your
+            registration, click the button below:</p>
+        <p>Verification code <span><strong>{{ .RecoveryCode }}</strong></span></p>
+        <a class="verify-button" href="{{ .InviteUrl }}">Verify Account</a>
+    </div>
+    <div class="footer">
+        <p>&copy;Copyright 2024 Canonical Ltd.</p>
+    </div>
+</div>
+</body>
+</html>

--- a/internal/mail/interfaces.go
+++ b/internal/mail/interfaces.go
@@ -1,0 +1,19 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package mail
+
+import (
+	"context"
+	"html/template"
+
+	mail2 "github.com/wneessen/go-mail"
+)
+
+type EmailServiceInterface interface {
+	Send(context.Context, string, string, *template.Template, any) error
+}
+
+type MailClientInterface interface {
+	DialAndSendWithContext(context.Context, ...*mail2.Msg) error
+}

--- a/internal/mail/service.go
+++ b/internal/mail/service.go
@@ -1,0 +1,105 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package mail
+
+import (
+	"context"
+	"html/template"
+	"time"
+
+	"github.com/wneessen/go-mail"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+)
+
+type Config struct {
+	Host        string `validate:"required"`
+	Port        int    `validate:"required"`
+	Username    string
+	Password    string
+	FromAddress string `validate:"required"`
+	SendTimeout time.Duration
+}
+
+func NewConfig(host string, port int, username, password, from string, sendTimeout int) *Config {
+	c := new(Config)
+
+	c.Host = host
+	c.Port = port
+	c.Username = username
+	c.Password = password
+	c.FromAddress = from
+	c.SendTimeout = time.Duration(sendTimeout) * time.Second
+
+	return c
+}
+
+type EmailService struct {
+	from   string
+	client MailClientInterface
+
+	tracer  trace.Tracer
+	monitor monitoring.MonitorInterface
+	logger  logging.LoggerInterface
+}
+
+func (e *EmailService) Send(ctx context.Context, to, subject string, template *template.Template, templateArgs any) error {
+	ctx, span := e.tracer.Start(ctx, "mail.EmailService.Send")
+	defer span.End()
+
+	msg := mail.NewMsg()
+
+	if err := msg.From(e.from); err != nil {
+		return err
+	}
+
+	if err := msg.SetBodyHTMLTemplate(template, templateArgs); err != nil {
+		return err
+	}
+
+	if err := msg.To(to); err != nil {
+		return err
+	}
+
+	msg.Subject(subject)
+
+	return e.client.DialAndSendWithContext(ctx, msg)
+}
+
+func NewEmailService(config *Config, tracer trace.Tracer, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *EmailService {
+	s := new(EmailService)
+	s.from = config.FromAddress
+
+	var err error
+	mailOpts := []mail.Option{
+		mail.WithPort(config.Port),
+		mail.WithTLSPolicy(mail.TLSOpportunistic),
+		mail.WithTimeout(config.SendTimeout),
+	}
+
+	// treat smtp connection as authenticated only if username is passed
+	if config.Username != "" {
+		mailOpts = append(
+			mailOpts,
+			[]mail.Option{mail.WithSMTPAuth(mail.SMTPAuthPlain), mail.WithUsername(config.Username), mail.WithPassword(config.Password)}...,
+		)
+	}
+
+	s.client, err = mail.NewClient(
+		config.Host,
+		mailOpts...,
+	)
+
+	if err != nil {
+		logger.Fatalf("failed to create email client: %s", err)
+	}
+
+	s.monitor = monitor
+	s.tracer = tracer
+	s.logger = logger
+
+	return s
+}

--- a/internal/mail/service_test.go
+++ b/internal/mail/service_test.go
@@ -1,0 +1,119 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package mail
+
+import (
+	"context"
+	"errors"
+	"html/template"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/mock/gomock"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package mail -destination ./mock_interfaces.go -source=./interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package mail -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package mail -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package mail -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+
+func TestEmailService_Send(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTempl, _ := LoadTemplate(UserCreationInvite)
+
+	mockArgs := UserCreationInviteArgs{
+		InviteUrl:    "test-url",
+		RecoveryCode: "test-code",
+		Email:        "test-mail",
+	}
+
+	tests := []struct {
+		name         string
+		from         string
+		to           string
+		template     *template.Template
+		templateArgs any
+		setupMocks   func(*MockMailClientInterface)
+		errMsg       string
+	}{
+		{
+			name:     "Success",
+			from:     "example@mail.com",
+			to:       "example@mail.com",
+			template: mockTempl,
+			setupMocks: func(c *MockMailClientInterface) {
+				c.EXPECT().DialAndSendWithContext(gomock.Any(), gomock.Any()).Return(nil)
+			},
+		},
+		{
+			name:         "FromError",
+			from:         "invalid from address",
+			to:           "",
+			template:     nil,
+			templateArgs: nil,
+			errMsg:       "failed to parse mail address \"invalid from address\": mail: no angle-addr",
+			setupMocks:   func(c *MockMailClientInterface) {},
+		},
+		{
+			name:         "TemplateBodyError",
+			from:         "from@example.com",
+			to:           "",
+			template:     nil,
+			templateArgs: nil,
+			errMsg:       "template pointer is nil",
+			setupMocks:   func(c *MockMailClientInterface) {},
+		},
+		{
+			name:         "ToError",
+			from:         "from@example.com",
+			to:           "invalid to address",
+			template:     mockTempl,
+			templateArgs: mockArgs,
+			errMsg:       "failed to parse mail address \"invalid to address\": mail: no angle-addr",
+			setupMocks:   func(c *MockMailClientInterface) {},
+		},
+		{
+			name:         "SendError",
+			from:         "from@example.com",
+			to:           "to@example.com",
+			template:     mockTempl,
+			templateArgs: mockArgs,
+			errMsg:       "test-error",
+			setupMocks: func(c *MockMailClientInterface) {
+				c.EXPECT().DialAndSendWithContext(gomock.Any(), gomock.Any()).Return(errors.New("test-error"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+
+			mockTracer := NewMockTracer(ctrl)
+			mockCtx := context.TODO()
+			mockTracer.EXPECT().Start(gomock.Any(), "mail.EmailService.Send").Return(mockCtx, trace.SpanFromContext(mockCtx)).AnyTimes()
+
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+
+			mockClient := NewMockMailClientInterface(ctrl)
+
+			e := &EmailService{
+				from:    tt.from,
+				client:  mockClient,
+				tracer:  mockTracer,
+				monitor: mockMonitor,
+				logger:  mockLogger,
+			}
+
+			tt.setupMocks(mockClient)
+
+			if err := e.Send(context.TODO(), tt.to, "test-subject", tt.template, tt.templateArgs); (err != nil) != (tt.errMsg != "") {
+				t.Errorf("Send() error, got = %v, want %v", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}

--- a/internal/mail/templates.go
+++ b/internal/mail/templates.go
@@ -1,0 +1,38 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package mail
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"strings"
+)
+
+var (
+	//go:embed html/user-invite.html
+	UserCreationInvite embed.FS
+)
+
+var (
+	templates = map[embed.FS]string{
+		UserCreationInvite: "html/user-invite.html",
+	}
+)
+
+type UserCreationInviteArgs struct {
+	InviteUrl    string
+	RecoveryCode string
+	Email        string
+}
+
+func LoadTemplate(templateFS embed.FS) (*template.Template, error) {
+	templatePattern, ok := templates[templateFS]
+	if !ok {
+		return nil, fmt.Errorf("template not found")
+	}
+
+	templateName := strings.SplitN(templatePattern, "/", 2)[1]
+	return template.New(templateName).ParseFS(templateFS, templatePattern)
+}

--- a/internal/mail/templates_test.go
+++ b/internal/mail/templates_test.go
@@ -1,0 +1,60 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package mail
+
+import (
+	"embed"
+	"testing"
+)
+
+func TestLoadTemplate(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		templateFS   embed.FS
+		templateName string
+		errorMsg     string
+	}{
+		{
+			name:         "Template available",
+			templateFS:   UserCreationInvite,
+			templateName: "user-invite.html",
+		},
+		{
+			name:       "Template not available",
+			templateFS: embed.FS{},
+			errorMsg:   "template not found",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			template, err := LoadTemplate(tt.templateFS)
+
+			if tt.errorMsg != "" {
+				if err == nil {
+					t.Errorf("expected error != nil")
+					return
+				}
+
+				if err.Error() != tt.errorMsg {
+					t.Errorf("expected error message %q, got %q", tt.errorMsg, err.Error())
+				}
+			}
+
+			if tt.errorMsg == "" {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+					return
+				}
+
+				if template.Name() != tt.templateName {
+					t.Errorf("expected templateName %s, got %s", tt.templateName, template.Name())
+				}
+			}
+
+		})
+	}
+}

--- a/pkg/identities/handlers.go
+++ b/pkg/identities/handlers.go
@@ -160,6 +160,20 @@ func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	createdIdentity := &ids.Identities[0]
+	err = a.service.SendUserCreationEmail(r.Context(), createdIdentity)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(
+			types.Response{
+				Message: err.Error(),
+				Status:  http.StatusInternalServerError,
+			},
+		)
+
+		return
+	}
+
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(
 		types.Response{

--- a/pkg/identities/handlers_test.go
+++ b/pkg/identities/handlers_test.go
@@ -313,6 +313,7 @@ func TestHandleCreateSuccess(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v0/identities", bytes.NewReader(payload))
 
 	mockService.EXPECT().CreateIdentity(gomock.Any(), identityBody).Return(&IdentityData{Identities: []kClient.Identity{*identity}}, nil)
+	mockService.EXPECT().SendUserCreationEmail(gomock.Any(), identity).Return(nil)
 
 	w := httptest.NewRecorder()
 	mux := chi.NewMux()

--- a/pkg/identities/interfaces.go
+++ b/pkg/identities/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd
+// Copyright 2024 Canonical Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 
 package identities
@@ -22,6 +22,7 @@ type ServiceInterface interface {
 	CreateIdentity(context.Context, *kClient.CreateIdentityBody) (*IdentityData, error)
 	UpdateIdentity(context.Context, string, *kClient.UpdateIdentityBody) (*IdentityData, error)
 	DeleteIdentity(context.Context, string) (*IdentityData, error)
+	SendUserCreationEmail(context.Context, *kClient.Identity) error
 }
 
 type OpenFGAStoreInterface interface {


### PR DESCRIPTION
## Description
This PR introduces a new dependency for the low level email operations.
With this PR when a new identity is created through the REST API, an email is sent to the identity email with a link and code to use for the first login to complete the registration resetting the password.

Right now we're using a temporary template I made, but @huwshimi will implement a new one as soon as our UX expert provides one.

### Testing
To perform a manual test for this PR you can deploy the Admin UI with its dependencies (you can disable authentication and authorization to make testing smoother) and with the MAIL_HOST, MAIL_PORT, MAIL_USERNAME, MAIL_PASSWORD env variables, and just create an identity.
Suggestion: use `maildev` for testing, run it as a docker container with
```
$ docker run -p 1080:1080 -p 1026:1025 maildev/maildev
```

then go to `http://localhost:1080` to visit maildev dashboard. You'll be able to see any email "sent" by admin ui in that dashboard.