### PR TITLE
feat: introduce hierarchy for can_relations

### DIFF
--- a/internal/authorization/schema.openfga
+++ b/internal/authorization/schema.openfga
@@ -14,9 +14,9 @@ type role
 
     define can_create: [user, role#assignee, group#member] or admin from privileged
     define can_delete: [user, role#assignee, group#member] or admin from privileged
-    define can_edit: [user, role#assignee, group#member] or admin from privileged
-    define can_view: [user, user:*, role#assignee, group#member] or admin from privileged
-    
+    define can_edit: [user, role#assignee, group#member] or can_delete or admin from privileged
+    define can_view: [user, user:*, role#assignee, group#member] or can_edit or admin from privileged
+
 type group
  relations
     define privileged: [privileged]
@@ -24,61 +24,61 @@ type group
 
     define can_create: [user, role#assignee, group#member] or admin from privileged
     define can_delete: [user, role#assignee, group#member] or admin from privileged
-    define can_edit: [user, role#assignee, group#member] or admin from privileged
-    define can_view: [user, user:*, role#assignee, group#member] or admin from privileged
+    define can_edit: [user, role#assignee, group#member] or can_delete or admin from privileged
+    define can_view: [user, user:*, role#assignee, group#member] or can_edit or admin from privileged
 
 type identity
  relations
     define privileged: [privileged]
-    
+
     define can_create: [user, role#assignee, group#member] or admin from privileged
     define can_delete: [user, role#assignee, group#member] or admin from privileged
-    define can_edit: [user, role#assignee, group#member] or admin from privileged
-    define can_view: [user, user:*, role#assignee, group#member] or admin from privileged
-  
+    define can_edit: [user, role#assignee, group#member] or can_delete or admin from privileged
+    define can_view: [user, user:*, role#assignee, group#member] or can_edit or admin from privileged
+
 type scheme
  relations
     define privileged: [privileged]
-    
+
     define can_create: [user, role#assignee, group#member] or admin from privileged
     define can_delete: [user, role#assignee, group#member] or admin from privileged
-    define can_edit: [user, role#assignee, group#member] or admin from privileged
-    define can_view: [user, user:*, role#assignee, group#member] or admin from privileged
-    
+    define can_edit: [user, role#assignee, group#member] or can_delete or admin from privileged
+    define can_view: [user, user:*, role#assignee, group#member] or can_edit or admin from privileged
+
 type client
  relations
     define privileged: [privileged]
-    
+
     define can_create: [user, role#assignee, group#member] or admin from privileged
     define can_delete: [user, role#assignee, group#member] or admin from privileged
-    define can_edit: [user, role#assignee, group#member] or admin from privileged
-    define can_view: [user, user:*, role#assignee, group#member] or admin from privileged 
+    define can_edit: [user, role#assignee, group#member] or can_delete or admin from privileged
+    define can_view: [user, user:*, role#assignee, group#member] or can_edit or admin from privileged
 
 type provider
  relations
     define privileged: [privileged]
-    
+
     define can_create: [user, role#assignee, group#member] or admin from privileged
     define can_delete: [user, role#assignee, group#member] or admin from privileged
-    define can_edit: [user, role#assignee, group#member] or admin from privileged
-    define can_view: [user, user:*, role#assignee, group#member] or admin from privileged 
+    define can_edit: [user, role#assignee, group#member] or can_delete or admin from privileged
+    define can_view: [user, user:*, role#assignee, group#member] or can_edit or admin from privileged
 
 type rule
  relations
     define privileged: [privileged]
-    
+
     define can_create: [user, role#assignee, group#member] or admin from privileged
     define can_delete: [user, role#assignee, group#member] or admin from privileged
-    define can_edit: [user, role#assignee, group#member] or admin from privileged
-    define can_view: [user, user:*, role#assignee, group#member] or admin from privileged 
+    define can_edit: [user, role#assignee, group#member] or can_delete or admin from privileged
+    define can_view: [user, user:*, role#assignee, group#member] or can_edit or admin from privileged
 
 # need to model how to assign applications for the login UI, if copying current model or adjusting it
 type application
  relations
     define privileged: [privileged]
-    
+
     define can_create: [user, role#assignee, group#member] or admin from privileged
     define can_delete: [user, role#assignee, group#member] or admin from privileged
-    define can_edit: [user, role#assignee, group#member] or admin from privileged
-    define can_view: [user, user:*, role#assignee, group#member] or admin from privileged 
+    define can_edit: [user, role#assignee, group#member] or can_delete or admin from privileged
+    define can_view: [user, user:*, role#assignee, group#member] or can_edit or admin from privileged
 


### PR DESCRIPTION
## Description
This PR introduces a hierarchy for all `can_*` relations in the OpenFGA authorization model.
The hierarchy is as follows
- if a user can delete an object (top permission for can_* permission) then the user can also edit it
- if a user can edit an object, then the user can also view it
- if a user can view an object, the user doesn't inherit additional permissions from this relation only

So: `can_delete` >> `can_edit` >> `can_view`
Can create is not touched by this since it gets special treatment in the implementation.

## Why
This is done with the intention of simplifying both user experience and developer life when it comes to reasoning about user authorization based on entitlements.
This way we can rely on some simple implications to treat entitlements. Also, this allows us to not crowd the OpenFGA store with "same user" tuples.
