### PR TITLE
IAM-951 fix broken href for non-empty context-path

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -8,7 +8,11 @@
     <title>Identity platform</title>
     <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" type="image/x-icon" />
 
-    <script>const global = globalThis;</script>
+    <script>
+        const global = globalThis;
+        const base = "{{ . }}";
+    </script>
+    <base href="{{ . }}ui/" />
   </head>
   <body>
 

--- a/ui/src/util/basePaths.spec.ts
+++ b/ui/src/util/basePaths.spec.ts
@@ -5,54 +5,32 @@ import {
 } from "./basePaths";
 
 vi.mock("./basePaths", async () => {
-  vi.stubGlobal("location", { pathname: "/example/ui/" });
+  window.base = "/example";
   const actual = await vi.importActual("./basePaths");
   return {
     ...actual,
     basePath: "/example/ui/",
-    apiBasePath: "/example/ui/../api/v0/",
+    apiBasePath: "/example/api/v0/",
   };
 });
 
 describe("calculateBasePath", () => {
   it("resolves with ui path", () => {
-    vi.stubGlobal("location", { pathname: "/ui/" });
+    window.base = "/test/";
     const result = calculateBasePath();
-    expect(result).toBe("/ui/");
+    expect(result).toBe("/test/");
   });
 
   it("resolves with ui path without trailing slash", () => {
-    vi.stubGlobal("location", { pathname: "/ui" });
+    window.base = "/test";
     const result = calculateBasePath();
-    expect(result).toBe("/ui/");
+    expect(result).toBe("/test/");
   });
 
-  it("resolves with ui path and discards detail page location", () => {
-    vi.stubGlobal("location", { pathname: "/ui/foo/bar" });
-    const result = calculateBasePath();
-    expect(result).toBe("/ui/");
-  });
-
-  it("resolves with prefixed ui path", () => {
-    vi.stubGlobal("location", { pathname: "/prefix/ui/" });
-    const result = calculateBasePath();
-    expect(result).toBe("/prefix/ui/");
-  });
-
-  it("resolves with prefixed ui path on a detail page", () => {
-    vi.stubGlobal("location", { pathname: "/prefix/ui/foo/bar/baz" });
-    const result = calculateBasePath();
-    expect(result).toBe("/prefix/ui/");
-  });
-
-  it("resolves with root path if /ui/ is not part of the pathname", () => {
-    vi.stubGlobal("location", { pathname: "/foo/bar/baz" });
-    const result = calculateBasePath();
-    expect(result).toBe("/");
-  });
-
-  it("resolves with root path for partial ui substrings", () => {
-    vi.stubGlobal("location", { pathname: "/prefix/uipartial" });
+  it("resolves with root path if the base is not provided", () => {
+    if (window.base) {
+      delete window.base;
+    }
     const result = calculateBasePath();
     expect(result).toBe("/");
   });
@@ -70,10 +48,10 @@ describe("appendBasePath", () => {
 
 describe("appendAPIBasePath", () => {
   it("handles paths with a leading slash", () => {
-    expect(appendAPIBasePath("/test")).toBe("/example/ui/../api/v0/test");
+    expect(appendAPIBasePath("/test")).toBe("/example/api/v0/test");
   });
 
   it("handles paths without a leading slash", () => {
-    expect(appendAPIBasePath("test")).toBe("/example/ui/../api/v0/test");
+    expect(appendAPIBasePath("test")).toBe("/example/api/v0/test");
   });
 });

--- a/ui/src/util/basePaths.ts
+++ b/ui/src/util/basePaths.ts
@@ -1,18 +1,25 @@
 import { removeTrailingSlash } from "util/removeTrailingSlash";
 type BasePath = `/${string}`;
 
+declare global {
+  interface Window {
+    base?: string;
+  }
+}
+
 export const calculateBasePath = (): BasePath => {
-  const path = window.location.pathname;
-  // find first occurrence of /ui/ and return the string before it
-  const basePath = path.match(/(.*\/ui(?:\/|$))/);
+  let basePath = "";
+  if ("base" in window && typeof window.base === "string") {
+    basePath = window.base;
+  }
   if (basePath) {
-    return `${removeTrailingSlash(basePath[0])}/` as BasePath;
+    return `${removeTrailingSlash(basePath)}/` as BasePath;
   }
   return "/";
 };
 
-export const basePath: BasePath = calculateBasePath();
-export const apiBasePath: BasePath = `${basePath}../api/v0/`;
+export const basePath: BasePath = `${calculateBasePath()}ui`;
+export const apiBasePath: BasePath = `${calculateBasePath()}api/v0/`;
 
 export const appendBasePath = (path: string) =>
   `${removeTrailingSlash(basePath)}/${path.replace(/^\//, "")}`;


### PR DESCRIPTION
## Description
Switch to html/template for rendering context path dynamically for `index.html`
This way when serving Admin UI under a context path we don't break the UI.
UI still expects to be under `/context-path(if present)/ui`.

## N.B.
We still need web team intervention to make the produced `index.html` to have the following prefix for its assets: `{{ . }}ui`

Example
```html
<head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />

    <title>Identity platform</title>
    <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" type="image/x-icon" />

    <script>const global = globalThis;</script>
    <script type="module" crossorigin src="{{ . }}ui/assets/index-D2_UOyoG.js"></script>
    <link rel="stylesheet" crossorigin href="{{ . }}ui/assets/index-tyeITY-6.css">
  </head>
```

This PR was manually tested simulating a fake context-path under which the UI could be served. See the example with `with-context-path` used as a fake path. The index html file GETs the right path for the assets.

![pr-context-path](https://github.com/user-attachments/assets/000077fd-758b-4f04-be5f-22fc1632b9f3)


### Fixes
Fixes #350 
