### PR TITLE
IAM 1064 Don't request audience in login request

### DIFF
--- a/pkg/authentication/handlers_test.go
+++ b/pkg/authentication/handlers_test.go
@@ -77,7 +77,7 @@ func TestHandleLogin(t *testing.T) {
 		t.Fatalf("response code error, expected %d, got %d", http.StatusFound, mockResponse.Code)
 	}
 
-	expectedLocation := "/api/v0/?audience=mock-client-id&client_id=mock-client-id&nonce=mock-nonce&redirect_uri=http%3A%2F%2Flocalhost%2Fredirect&response_type=code&scope=openid+offline_access&state=mock-state"
+	expectedLocation := "/api/v0/?client_id=mock-client-id&nonce=mock-nonce&redirect_uri=http%3A%2F%2Flocalhost%2Fredirect&response_type=code&scope=openid+offline_access&state=mock-state"
 	location := mockResponse.Header().Get("Location")
 	if !strings.HasPrefix(location, expectedLocation) {
 		t.Fatalf("location header error, expected %s, got %s", expectedLocation, location)

--- a/pkg/authentication/oidc.go
+++ b/pkg/authentication/oidc.go
@@ -50,8 +50,7 @@ func (o *OAuth2Context) LoginRedirect(ctx context.Context, nonce, state string) 
 	_, span := o.tracer.Start(ctx, "authentication.OAuth2Context.LoginRedirect")
 	defer span.End()
 
-	// TODO: remove `audience` parameter when https://github.com/canonical/identity-platform-login-ui/issues/244 is addressed
-	return o.client.AuthCodeURL(state, oidc.Nonce(nonce), oauth2.SetAuthURLParam("audience", o.client.ClientID))
+	return o.client.AuthCodeURL(state, oidc.Nonce(nonce))
 }
 
 func (o *OAuth2Context) RetrieveTokens(ctx context.Context, code string) (*oauth2.Token, error) {

--- a/pkg/authentication/oidc_test.go
+++ b/pkg/authentication/oidc_test.go
@@ -140,7 +140,7 @@ func TestOAuth2Context_LoginRedirect(t *testing.T) {
 
 	location := oauth2Context.LoginRedirect(mockRequest.Context(), "mock-nonce", "mock-state")
 
-	expectedLocation := "?audience=mock-client-id&client_id=mock-client-id&nonce=mock-nonce&redirect_uri=http%3A%2F%2Flocalhost%2Fapi%2Fv0%2Fauth%2Fcallback&response_type=code&scope=openid+offline_access&state=mock-state"
+	expectedLocation := "?client_id=mock-client-id&nonce=mock-nonce&redirect_uri=http%3A%2F%2Flocalhost%2Fapi%2Fv0%2Fauth%2Fcallback&response_type=code&scope=openid+offline_access&state=mock-state"
 
 	if location != expectedLocation {
 		t.Fatalf("location header error, expected %s, got %s", expectedLocation, location)


### PR DESCRIPTION
## Description
Remove the audience parameter from the oauth2 login redirection and adjusts tests accordingly.

This was manually tested also, and the jwt minted by hydra are still the same as expected.

Fixes #415 