### PR TITLE
IAM-1013 Implement granular payload authorization check for Group `Assign{Roles,Identities}` handlers

### DIFF
--- a/internal/authorization/util.go
+++ b/internal/authorization/util.go
@@ -1,0 +1,62 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package authorization
+
+import (
+	"fmt"
+)
+
+const (
+	MEMBER_RELATION   = "member"
+	ASSIGNEE_RELATION = "assignee"
+	CAN_VIEW_RELATION = "can_view"
+)
+
+func UserForTuple(userId string) string {
+	return fmt.Sprintf("user:%s", userId)
+}
+
+func UserWildcardForTuple() string {
+	return fmt.Sprintf("user:*")
+}
+
+func RoleForTuple(roleId string) string {
+	return fmt.Sprintf("role:%s", roleId)
+}
+
+func RoleAssigneeForTuple(roleId string) string {
+	return fmt.Sprintf("role:%s#%s", roleId, ASSIGNEE_RELATION)
+}
+
+func GroupForTuple(groupId string) string {
+	return fmt.Sprintf("group:%s", groupId)
+}
+
+func GroupMemberForTuple(groupId string) string {
+	return fmt.Sprintf("group:%s#%s", groupId, MEMBER_RELATION)
+}
+
+func IdentityForTuple(identityId string) string {
+	return fmt.Sprintf("identity:%s", identityId)
+}
+
+func SchemeForTuple(schemeId string) string {
+	return fmt.Sprintf("scheme:%s", schemeId)
+}
+
+func ClientForTuple(clientId string) string {
+	return fmt.Sprintf("client:%s", clientId)
+}
+
+func ProviderForTuple(providerId string) string {
+	return fmt.Sprintf("provider:%s", providerId)
+}
+
+func RuleForTuple(ruleId string) string {
+	return fmt.Sprintf("rule:%s", ruleId)
+}
+
+func ApplicationForTuple(applicationId string) string {
+	return fmt.Sprintf("application:%s", applicationId)
+}

--- a/pkg/groups/interfaces.go
+++ b/pkg/groups/interfaces.go
@@ -26,6 +26,8 @@ type ServiceInterface interface {
 	ListIdentities(context.Context, string, string) ([]string, string, error)
 	AssignIdentities(context.Context, string, ...string) error
 	RemoveIdentities(context.Context, string, ...string) error
+	CanAssignRoles(context.Context, string, ...string) (bool, error)
+	CanAssignIdentities(context.Context, string, ...string) (bool, error)
 }
 
 // OpenFGAClientInterface is the interface used to decouple the OpenFGA store implementation
@@ -35,4 +37,5 @@ type OpenFGAClientInterface interface {
 	WriteTuples(context.Context, ...ofga.Tuple) error
 	DeleteTuples(context.Context, ...ofga.Tuple) error
 	Check(context.Context, string, string, string, ...ofga.Tuple) (bool, error)
+	BatchCheck(context.Context, ...ofga.Tuple) (bool, error)
 }

--- a/pkg/groups/service.go
+++ b/pkg/groups/service.go
@@ -6,27 +6,22 @@ package groups
 import (
 	"context"
 	"fmt"
-	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
-	"github.com/canonical/identity-platform-admin-ui/pkg/authentication"
-	v1 "github.com/canonical/rebac-admin-ui-handlers/v1"
-	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
 	"strings"
 	"sync"
 
+	v1 "github.com/canonical/rebac-admin-ui-handlers/v1"
+	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
+	"github.com/canonical/identity-platform-admin-ui/pkg/authentication"
+
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/canonical/identity-platform-admin-ui/internal/authorization"
+	authz "github.com/canonical/identity-platform-admin-ui/internal/authorization"
 	"github.com/canonical/identity-platform-admin-ui/internal/logging"
 	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
 	ofga "github.com/canonical/identity-platform-admin-ui/internal/openfga"
 	"github.com/canonical/identity-platform-admin-ui/internal/pool"
-)
-
-const (
-	MEMBER_RELATION   = "member"
-	ASSIGNEE_RELATION = "assignee"
-	// TODO: @barco centralize common relation name definitions
-	CAN_VIEW_RELATION = "can_view"
 )
 
 type listPermissionsResult struct {
@@ -47,20 +42,12 @@ type Service struct {
 	logger  logging.LoggerInterface
 }
 
-func (s *Service) buildGroupMember(ctx context.Context, ID string) string {
-	_, span := s.tracer.Start(ctx, "groups.Service.buildGroupMember")
-	defer span.End()
-
-	return fmt.Sprintf("group:%s#%s", ID, MEMBER_RELATION)
-
-}
-
 // ListGroups returns all the groups a specific user can see (using "can_view" OpenFGA relation)
 func (s *Service) ListGroups(ctx context.Context, userID string) ([]string, error) {
 	ctx, span := s.tracer.Start(ctx, "groups.Service.ListGroups")
 	defer span.End()
 
-	groups, err := s.ofga.ListObjects(ctx, fmt.Sprintf("user:%s", userID), "can_view", "group")
+	groups, err := s.ofga.ListObjects(ctx, authz.UserForTuple(userID), authz.CAN_VIEW_RELATION, "group")
 
 	if err != nil {
 		s.logger.Error(err.Error())
@@ -75,7 +62,7 @@ func (s *Service) ListRoles(ctx context.Context, ID string) ([]string, error) {
 	ctx, span := s.tracer.Start(ctx, "groups.Service.ListRoles")
 	defer span.End()
 
-	roles, err := s.ofga.ListObjects(ctx, s.buildGroupMember(ctx, ID), ASSIGNEE_RELATION, "role")
+	roles, err := s.ofga.ListObjects(ctx, authz.GroupMemberForTuple(ID), authz.ASSIGNEE_RELATION, "role")
 
 	if err != nil {
 		s.logger.Error(err.Error())
@@ -150,7 +137,7 @@ func (s *Service) GetGroup(ctx context.Context, userID, ID string) (*Group, erro
 	ctx, span := s.tracer.Start(ctx, "groups.Service.GetGroup")
 	defer span.End()
 
-	exists, err := s.ofga.Check(ctx, fmt.Sprintf("user:%s", userID), "can_view", fmt.Sprintf("group:%s", ID))
+	exists, err := s.ofga.Check(ctx, authz.UserForTuple(userID), authz.CAN_VIEW_RELATION, authz.GroupForTuple(ID))
 
 	if err != nil {
 		s.logger.Error(err.Error())
@@ -181,14 +168,13 @@ func (s *Service) CreateGroup(ctx context.Context, userID, groupName string) (*G
 	// `define can_view: [user, user:*, group#assignee, group#member] or assignee or admin from privileged`
 	// might sort the problem
 
-	// TODO @shipperizer offload to privileged creator object
-	group := fmt.Sprintf("group:%s", groupName)
-	user := fmt.Sprintf("user:%s", userID)
+	group := authz.GroupForTuple(groupName)
+	user := authz.UserForTuple(userID)
 
 	err := s.ofga.WriteTuples(
 		ctx,
-		*ofga.NewTuple(user, MEMBER_RELATION, group),
-		*ofga.NewTuple(user, CAN_VIEW_RELATION, group),
+		*ofga.NewTuple(user, authz.MEMBER_RELATION, group),
+		*ofga.NewTuple(user, authz.CAN_VIEW_RELATION, group),
 	)
 
 	if err != nil {
@@ -213,7 +199,7 @@ func (s *Service) AssignRoles(ctx context.Context, ID string, roles ...string) e
 	rs := make([]ofga.Tuple, 0)
 
 	for _, role := range roles {
-		rs = append(rs, *ofga.NewTuple(s.buildGroupMember(ctx, ID), ASSIGNEE_RELATION, fmt.Sprintf("role:%s", role)))
+		rs = append(rs, *ofga.NewTuple(authz.GroupMemberForTuple(ID), authz.ASSIGNEE_RELATION, authz.RoleForTuple(role)))
 	}
 
 	err := s.ofga.WriteTuples(ctx, rs...)
@@ -237,7 +223,7 @@ func (s *Service) RemoveRoles(ctx context.Context, ID string, roles ...string) e
 	rs := make([]ofga.Tuple, 0)
 
 	for _, role := range roles {
-		rs = append(rs, *ofga.NewTuple(s.buildGroupMember(ctx, ID), ASSIGNEE_RELATION, fmt.Sprintf("role:%s", role)))
+		rs = append(rs, *ofga.NewTuple(authz.GroupMemberForTuple(ID), authz.ASSIGNEE_RELATION, authz.RoleForTuple(role)))
 	}
 
 	err := s.ofga.DeleteTuples(ctx, rs...)
@@ -262,7 +248,7 @@ func (s *Service) AssignPermissions(ctx context.Context, ID string, permissions 
 	ps := make([]ofga.Tuple, 0)
 
 	for _, p := range permissions {
-		ps = append(ps, *ofga.NewTuple(s.buildGroupMember(ctx, ID), p.Relation, p.Object))
+		ps = append(ps, *ofga.NewTuple(authz.GroupMemberForTuple(ID), p.Relation, p.Object))
 	}
 
 	err := s.ofga.WriteTuples(ctx, ps...)
@@ -287,7 +273,7 @@ func (s *Service) RemovePermissions(ctx context.Context, ID string, permissions 
 	ps := make([]ofga.Tuple, 0)
 
 	for _, p := range permissions {
-		ps = append(ps, *ofga.NewTuple(s.buildGroupMember(ctx, ID), p.Relation, p.Object))
+		ps = append(ps, *ofga.NewTuple(authz.GroupMemberForTuple(ID), p.Relation, p.Object))
 	}
 
 	err := s.ofga.DeleteTuples(ctx, ps...)
@@ -351,7 +337,7 @@ func (s *Service) ListIdentities(ctx context.Context, ID, continuationToken stri
 	ctx, span := s.tracer.Start(ctx, "groups.Service.ListIdentities")
 	defer span.End()
 
-	r, err := s.ofga.ReadTuples(ctx, "", MEMBER_RELATION, fmt.Sprintf("group:%s", ID), continuationToken)
+	r, err := s.ofga.ReadTuples(ctx, "", authz.MEMBER_RELATION, authz.GroupForTuple(ID), continuationToken)
 
 	if err != nil {
 		s.logger.Error(err.Error())
@@ -380,9 +366,8 @@ func (s *Service) AssignIdentities(ctx context.Context, ID string, identities ..
 
 	ids := make([]ofga.Tuple, 0)
 
-	for _, identity := range identities {
-		// TODO @shipperizer swap user for identity if/when model changes
-		ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", identity), MEMBER_RELATION, fmt.Sprintf("group:%s", ID)))
+	for _, user := range identities {
+		ids = append(ids, *ofga.NewTuple(authz.UserForTuple(user), authz.MEMBER_RELATION, authz.GroupForTuple(ID)))
 	}
 
 	err := s.ofga.WriteTuples(ctx, ids...)
@@ -402,9 +387,8 @@ func (s *Service) RemoveIdentities(ctx context.Context, ID string, identities ..
 
 	ids := make([]ofga.Tuple, 0)
 
-	for _, identity := range identities {
-		// TODO @shipperizer swap user for identity if/when model changes
-		ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", identity), MEMBER_RELATION, fmt.Sprintf("group:%s", ID)))
+	for _, user := range identities {
+		ids = append(ids, *ofga.NewTuple(authz.UserForTuple(user), authz.MEMBER_RELATION, authz.GroupForTuple(ID)))
 	}
 
 	err := s.ofga.DeleteTuples(ctx, ids...)
@@ -424,7 +408,7 @@ func (s *Service) listPermissionsByType(ctx context.Context, ID, pType, continua
 	ctx, span := s.tracer.Start(ctx, "groups.Service.listPermissionsByType")
 	defer span.End()
 
-	r, err := s.ofga.ReadTuples(ctx, s.buildGroupMember(ctx, ID), "", fmt.Sprintf("%s:", pType), continuationToken)
+	r, err := s.ofga.ReadTuples(ctx, authz.GroupMemberForTuple(ID), "", fmt.Sprintf("%s:", pType), continuationToken)
 
 	if err != nil {
 		s.logger.Error(err.Error())
@@ -439,7 +423,7 @@ func (s *Service) listPermissionsByType(ctx context.Context, ID, pType, continua
 			continue
 		}
 
-		permissions = append(permissions, authorization.NewURN(t.Key.Relation, t.Key.Object).ID())
+		permissions = append(permissions, authz.NewURN(t.Key.Relation, t.Key.Object).ID())
 	}
 
 	return permissions, r.GetContinuationToken(), nil
@@ -450,7 +434,7 @@ func (s *Service) removePermissionsByType(ctx context.Context, ID, pType string)
 	defer span.End()
 
 	cToken := ""
-	memberRelation := s.buildGroupMember(ctx, ID)
+	memberRelation := authz.GroupMemberForTuple(ID)
 	permissions := make([]ofga.Tuple, 0)
 	for {
 		r, err := s.ofga.ReadTuples(ctx, memberRelation, "", fmt.Sprintf("%s:", pType), cToken)
@@ -485,7 +469,7 @@ func (s *Service) removeDirectAssociations(ctx context.Context, ID, relation str
 	cToken := ""
 	directs := make([]ofga.Tuple, 0)
 	for {
-		r, err := s.ofga.ReadTuples(ctx, "", relation, fmt.Sprintf("group:%s", ID), cToken)
+		r, err := s.ofga.ReadTuples(ctx, "", relation, authz.GroupForTuple(ID), cToken)
 
 		if err != nil {
 			s.logger.Errorf("error when retrieving tuples for %s group, %s relation", relation, ID)
@@ -836,7 +820,7 @@ func (s *V1Service) GetGroupEntitlements(ctx context.Context, groupId string, pa
 	}
 
 	for _, permission := range permissions {
-		p := authorization.NewURNFromURLParam(permission)
+		p := authz.NewURNFromURLParam(permission)
 		entity := strings.SplitN(p.Object(), ":", 2)
 		r.Data = append(
 			r.Data,

--- a/pkg/groups/service_test.go
+++ b/pkg/groups/service_test.go
@@ -7,12 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
-	"github.com/canonical/identity-platform-admin-ui/pkg/authentication"
-	v1 "github.com/canonical/rebac-admin-ui-handlers/v1"
-	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
-	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"sort"
 	"strings"
@@ -20,13 +14,21 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/canonical/rebac-admin-ui-handlers/v1"
+	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
+	"github.com/canonical/identity-platform-admin-ui/pkg/authentication"
+
 	"github.com/google/uuid"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/openfga/go-sdk/client"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/mock/gomock"
 
-	"github.com/canonical/identity-platform-admin-ui/internal/authorization"
+	authz "github.com/canonical/identity-platform-admin-ui/internal/authorization"
 	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
 	ofga "github.com/canonical/identity-platform-admin-ui/internal/openfga"
 	"github.com/canonical/identity-platform-admin-ui/internal/pool"
@@ -191,8 +193,7 @@ func TestServiceListRoles(t *testing.T) {
 			svc := NewService(mockOpenFGA, workerPool, mockTracer, mockMonitor, mockLogger)
 
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.ListRoles").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
-			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
-			mockOpenFGA.EXPECT().ListObjects(gomock.Any(), fmt.Sprintf("group:%s#%s", test.input, MEMBER_RELATION), ASSIGNEE_RELATION, "role").Return(test.expected.roles, test.expected.err)
+			mockOpenFGA.EXPECT().ListObjects(gomock.Any(), fmt.Sprintf("group:%s#%s", test.input, authz.MEMBER_RELATION), authz.ASSIGNEE_RELATION, "role").Return(test.expected.roles, test.expected.err)
 
 			if test.expected.err != nil {
 				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
@@ -315,7 +316,7 @@ func TestServiceListIdentities(t *testing.T) {
 					tuples,
 					*openfga.NewTuple(
 						*openfga.NewTupleKey(
-							t, ASSIGNEE_RELATION, fmt.Sprintf("group:%s", test.input.group),
+							t, authz.ASSIGNEE_RELATION, fmt.Sprintf("group:%s", test.input.group),
 						),
 						time.Now(),
 					),
@@ -328,7 +329,7 @@ func TestServiceListIdentities(t *testing.T) {
 			svc := NewService(mockOpenFGA, workerPool, mockTracer, mockMonitor, mockLogger)
 
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.ListIdentities").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
-			mockOpenFGA.EXPECT().ReadTuples(gomock.Any(), "", MEMBER_RELATION, fmt.Sprintf("group:%s", test.input.group), test.input.token).Return(r, test.expected.err)
+			mockOpenFGA.EXPECT().ReadTuples(gomock.Any(), "", authz.MEMBER_RELATION, fmt.Sprintf("group:%s", test.input.group), test.input.token).Return(r, test.expected.err)
 
 			if test.expected.err != nil {
 				mockLogger.EXPECT().Error(gomock.Any()).Times(1)
@@ -394,14 +395,13 @@ func TestServiceAssignRoles(t *testing.T) {
 
 			svc := NewService(mockOpenFGA, workerPool, mockTracer, mockMonitor, mockLogger)
 
-			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.AssignRoles").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockOpenFGA.EXPECT().WriteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
 				func(ctx context.Context, tuples ...ofga.Tuple) error {
 					roles := make([]ofga.Tuple, 0)
 
 					for _, role := range test.input.roles {
-						roles = append(roles, *ofga.NewTuple(fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION), ASSIGNEE_RELATION, fmt.Sprintf("role:%s", role)))
+						roles = append(roles, *ofga.NewTuple(fmt.Sprintf("group:%s#%s", test.input.group, authz.MEMBER_RELATION), authz.ASSIGNEE_RELATION, fmt.Sprintf("role:%s", role)))
 					}
 
 					if !reflect.DeepEqual(roles, tuples) {
@@ -468,14 +468,13 @@ func TestServiceRemoveRoles(t *testing.T) {
 
 			svc := NewService(mockOpenFGA, workerPool, mockTracer, mockMonitor, mockLogger)
 
-			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.RemoveRoles").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockOpenFGA.EXPECT().DeleteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
 				func(ctx context.Context, tuples ...ofga.Tuple) error {
 					roles := make([]ofga.Tuple, 0)
 
 					for _, role := range test.input.roles {
-						roles = append(roles, *ofga.NewTuple(fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION), ASSIGNEE_RELATION, fmt.Sprintf("role:%s", role)))
+						roles = append(roles, *ofga.NewTuple(fmt.Sprintf("group:%s#%s", test.input.group, authz.MEMBER_RELATION), authz.ASSIGNEE_RELATION, fmt.Sprintf("role:%s", role)))
 					}
 
 					if !reflect.DeepEqual(roles, tuples) {
@@ -542,14 +541,13 @@ func TestServiceAssignIdentities(t *testing.T) {
 
 			svc := NewService(mockOpenFGA, workerPool, mockTracer, mockMonitor, mockLogger)
 
-			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.AssignIdentities").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockOpenFGA.EXPECT().WriteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
 				func(ctx context.Context, tuples ...ofga.Tuple) error {
 					ids := make([]ofga.Tuple, 0)
 
 					for _, i := range test.input.identities {
-						ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", i), MEMBER_RELATION, fmt.Sprintf("group:%s", test.input.group)))
+						ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", i), authz.MEMBER_RELATION, fmt.Sprintf("group:%s", test.input.group)))
 					}
 
 					if !reflect.DeepEqual(ids, tuples) {
@@ -616,14 +614,13 @@ func TestServiceRemoveIdentities(t *testing.T) {
 
 			svc := NewService(mockOpenFGA, workerPool, mockTracer, mockMonitor, mockLogger)
 
-			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.RemoveIdentities").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockOpenFGA.EXPECT().DeleteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
 				func(ctx context.Context, tuples ...ofga.Tuple) error {
 					ids := make([]ofga.Tuple, 0)
 
 					for _, i := range test.input.identities {
-						ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", i), MEMBER_RELATION, fmt.Sprintf("group:%s", test.input.group)))
+						ids = append(ids, *ofga.NewTuple(fmt.Sprintf("user:%s", i), authz.MEMBER_RELATION, fmt.Sprintf("group:%s", test.input.group)))
 					}
 
 					if !reflect.DeepEqual(ids, tuples) {
@@ -712,7 +709,6 @@ func TestServiceGetGroup(t *testing.T) {
 
 			svc := NewService(mockOpenFGA, workerPool, mockTracer, mockMonitor, mockLogger)
 
-			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.GetGroup").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockOpenFGA.EXPECT().Check(gomock.Any(), fmt.Sprintf("user:%s", test.input.user), "can_view", fmt.Sprintf("group:%s", test.input.group)).Return(test.expected.check, test.expected.err)
 
@@ -776,7 +772,6 @@ func TestServiceCreateGroup(t *testing.T) {
 
 			svc := NewService(mockOpenFGA, workerPool, mockTracer, mockMonitor, mockLogger)
 
-			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.CreateGroup").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 
 			mockOpenFGA.EXPECT().WriteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
@@ -785,8 +780,8 @@ func TestServiceCreateGroup(t *testing.T) {
 
 					ps = append(
 						ps,
-						*ofga.NewTuple(fmt.Sprintf("user:%s", test.input.user), MEMBER_RELATION, fmt.Sprintf("group:%s", test.input.group)),
-						*ofga.NewTuple(fmt.Sprintf("user:%s", test.input.user), CAN_VIEW_RELATION, fmt.Sprintf("group:%s", test.input.group)),
+						*ofga.NewTuple(fmt.Sprintf("user:%s", test.input.user), authz.MEMBER_RELATION, fmt.Sprintf("group:%s", test.input.group)),
+						*ofga.NewTuple(fmt.Sprintf("user:%s", test.input.user), authz.CAN_VIEW_RELATION, fmt.Sprintf("group:%s", test.input.group)),
 					)
 
 					if !reflect.DeepEqual(ps, tuples) {
@@ -849,7 +844,6 @@ func TestServiceDeleteGroup(t *testing.T) {
 
 			svc := NewService(mockOpenFGA, workerPool, mockTracer, mockMonitor, mockLogger)
 
-			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.DeleteGroup").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.removePermissionsByType").Times(6).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.removeDirectAssociations").Times(6).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
@@ -863,7 +857,7 @@ func TestServiceDeleteGroup(t *testing.T) {
 
 				calls = append(
 					calls,
-					mockOpenFGA.EXPECT().ReadTuples(gomock.Any(), fmt.Sprintf("group:%s#%s", test.input, MEMBER_RELATION), "", fmt.Sprintf("%s:", pType), "").Times(1).DoAndReturn(
+					mockOpenFGA.EXPECT().ReadTuples(gomock.Any(), fmt.Sprintf("group:%s#%s", test.input, authz.MEMBER_RELATION), "", fmt.Sprintf("%s:", pType), "").Times(1).DoAndReturn(
 						func(ctx context.Context, user, relation, object, continuationToken string) (*client.ClientReadResponse, error) {
 							if test.expected != nil {
 								return nil, test.expected
@@ -901,13 +895,13 @@ func TestServiceDeleteGroup(t *testing.T) {
 							tuples := []openfga.Tuple{
 								*openfga.NewTuple(
 									*openfga.NewTupleKey(
-										"user:test", MEMBER_RELATION, object,
+										"user:test", authz.MEMBER_RELATION, object,
 									),
 									time.Now(),
 								),
 								*openfga.NewTuple(
 									*openfga.NewTupleKey(
-										"group:test#member", MEMBER_RELATION, object,
+										"group:test#member", authz.MEMBER_RELATION, object,
 									),
 									time.Now(),
 								),
@@ -933,8 +927,8 @@ func TestServiceDeleteGroup(t *testing.T) {
 						case 1:
 							tuple := tuples[0]
 
-							if tuple.User != fmt.Sprintf("group:%s#%s", test.input, MEMBER_RELATION) && tuple.User != authorization.ADMIN_OBJECT {
-								t.Errorf("expected user to be one of %v got %v", []string{fmt.Sprintf("group:%s#%s", test.input, MEMBER_RELATION), authorization.ADMIN_OBJECT}, tuple.User)
+							if tuple.User != fmt.Sprintf("group:%s#%s", test.input, authz.MEMBER_RELATION) && tuple.User != authz.ADMIN_OBJECT {
+								t.Errorf("expected user to be one of %v got %v", []string{fmt.Sprintf("group:%s#%s", test.input, authz.MEMBER_RELATION), authz.ADMIN_OBJECT}, tuple.User)
 							}
 
 							if tuple.Relation != "privileged" && tuple.Relation != "can_edit" {
@@ -950,8 +944,8 @@ func TestServiceDeleteGroup(t *testing.T) {
 									t.Errorf("expected user to be one of %v got %v", []string{"user:test", "group:test#member"}, tuple.User)
 								}
 
-								if tuple.Relation != MEMBER_RELATION {
-									t.Errorf("expected relation to be of %v got %v", MEMBER_RELATION, tuple.Relation)
+								if tuple.Relation != authz.MEMBER_RELATION {
+									t.Errorf("expected relation to be of %v got %v", authz.MEMBER_RELATION, tuple.Relation)
 								}
 
 								if tuple.Object != fmt.Sprintf("group:%s", test.input) {
@@ -1022,7 +1016,6 @@ func TestServiceListPermissions(t *testing.T) {
 			}
 			svc := NewService(mockOpenFGA, workerPool, mockTracer, mockMonitor, mockLogger)
 
-			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.ListPermissions").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.listPermissionsByType").Times(6).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 
@@ -1056,8 +1049,8 @@ func TestServiceListPermissions(t *testing.T) {
 								return nil, test.expected
 							}
 
-							if user != fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION) {
-								t.Errorf("wrong user parameter expected %s got %s", fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION), user)
+							if user != fmt.Sprintf("group:%s#%s", test.input.group, authz.MEMBER_RELATION) {
+								t.Errorf("wrong user parameter expected %s got %s", fmt.Sprintf("group:%s#%s", test.input.group, authz.MEMBER_RELATION), user)
 							}
 
 							if object == "group:" && continuationToken != "test" {
@@ -1077,7 +1070,7 @@ func TestServiceListPermissions(t *testing.T) {
 								tuples = append(tuples,
 									*openfga.NewTuple(
 										*openfga.NewTupleKey(
-											fmt.Sprintf("group:%s#%s", user, MEMBER_RELATION), "assignee", fmt.Sprintf("%stest", object),
+											fmt.Sprintf("group:%s#%s", user, authz.MEMBER_RELATION), "assignee", fmt.Sprintf("%stest", object),
 										),
 										time.Now(),
 									),
@@ -1169,14 +1162,13 @@ func TestServiceAssignPermissions(t *testing.T) {
 
 			svc := NewService(mockOpenFGA, workerPool, mockTracer, mockMonitor, mockLogger)
 
-			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.AssignPermissions").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockOpenFGA.EXPECT().WriteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
 				func(ctx context.Context, tuples ...ofga.Tuple) error {
 					ps := make([]ofga.Tuple, 0)
 
 					for _, p := range test.input.permissions {
-						ps = append(ps, *ofga.NewTuple(fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION), p.Relation, p.Object))
+						ps = append(ps, *ofga.NewTuple(fmt.Sprintf("group:%s#%s", test.input.group, authz.MEMBER_RELATION), p.Relation, p.Object))
 					}
 
 					if !reflect.DeepEqual(ps, tuples) {
@@ -1249,14 +1241,13 @@ func TestServiceRemovePermissions(t *testing.T) {
 
 			svc := NewService(mockOpenFGA, workerPool, mockTracer, mockMonitor, mockLogger)
 
-			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.buildGroupMember").AnyTimes().Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockTracer.EXPECT().Start(gomock.Any(), "groups.Service.RemovePermissions").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
 			mockOpenFGA.EXPECT().DeleteTuples(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
 				func(ctx context.Context, tuples ...ofga.Tuple) error {
 					ps := make([]ofga.Tuple, 0)
 
 					for _, p := range test.input.permissions {
-						ps = append(ps, *ofga.NewTuple(fmt.Sprintf("group:%s#%s", test.input.group, MEMBER_RELATION), p.Relation, p.Object))
+						ps = append(ps, *ofga.NewTuple(fmt.Sprintf("group:%s#%s", test.input.group, authz.MEMBER_RELATION), p.Relation, p.Object))
 					}
 
 					if !reflect.DeepEqual(ps, tuples) {


### PR DESCRIPTION
## Description
This PR adds implementation to check if the Assign{Identities,Roles} operation can be performed.
It leverages a BatchCheck that was previously not exposed on the underling client interface of the OpenFGA service.


## Changes
- removed tracing from `buildGroupMember`-like functions
- moved existing OpenFGA tuple building functions under `internal/authorization/util.go` and introduced functions to build tuple elements for all types in the OpenFGA authorization model
- added CanAssignIdentities and CanAssignRoles methods in groups service
- added tests and adjusted existing after adoption of new functions