### PR TITLE
fix: avoid escaping when passing URL to template

### DIFF
--- a/pkg/ui/handlers.go
+++ b/pkg/ui/handlers.go
@@ -107,7 +107,7 @@ func (a *API) uiFiles(w http.ResponseWriter, r *http.Request) {
 			normContextPath += "/"
 		}
 
-		err = t.Execute(w, normContextPath)
+		err = t.Execute(w, template.URL(normContextPath))
 		if err != nil {
 			a.logger.Error("Failed to process %s template: ", indexTemplate, err)
 			a.internalServerErrorResponse(w, err)


### PR DESCRIPTION
## Description
This PR provides a small change in how the context path is passed to the template that renders the index.html, making it work without escaping slashes that may be present in the context path itself.
This aims at fixing a possible cause of weird behavior in the loading of the UI.
