### PR TITLE
IAM-1047 provider defaults to non existant schema

### DIFF
--- a/pkg/idp/third_party.go
+++ b/pkg/idp/third_party.go
@@ -50,19 +50,19 @@ type Configuration struct {
 	// IssuerURL is the OpenID Connect Server URL. You can leave this empty if `provider` is not set to `generic`.
 	// If set, neither `auth_url` nor `token_url` are required.
 	// validate that this field is required only when Provider field == "generic"
-	IssuerURL string `json:"issuer_url" yaml:"issuer_url" validate:"required_if=Provider generic"`
+	IssuerURL string `json:"issuer_url" yaml:"issuer_url"`
 
 	// AuthURL is the authorize url, typically something like: https://example.org/oauth2/auth
 	// Should only be used when the OAuth2 / OpenID Connect server is not supporting OpenID Connect Discovery and when
 	// `provider` is set to `generic`.
-	// validate that this field is required only when Provider field == "generic"
-	AuthURL string `json:"auth_url" yaml:"auth_url" validate:"required_if=Provider generic"`
+	// validate that this field is required only when Provider field == "generic" and IssuerURL is empty
+	AuthURL string `json:"auth_url" yaml:"auth_url"`
 
 	// TokenURL is the token url, typically something like: https://example.org/oauth2/token
 	// Should only be used when the OAuth2 / OpenID Connect server is not supporting OpenID Connect Discovery and when
 	// `provider` is set to `generic`.
-	// validate that this field is required only when Provider field == "generic"
-	TokenURL string `json:"token_url" yaml:"token_url" validate:"required_if=Provider generic"`
+	// validate that this field is required only when Provider field == "generic" and IssuerURL is empty
+	TokenURL string `json:"token_url" yaml:"token_url"`
 
 	// Tenant is the Azure AD Tenant to use for authentication, and must be set when `provider` is set to `microsoft`.
 	// Can be either `common`, `organizations`, `consumers` for a multitenant application or a specific tenant like
@@ -103,7 +103,7 @@ type Configuration struct {
 	// profile information) to hydrate the identity's data.
 	//
 	// It can be either a URL (file://, http(s)://, base64://) or an inline JSONNet code snippet.
-	Mapper string `json:"mapper_url" yaml:"mapper_url" validate:"required"`
+	Mapper string `json:"mapper_url" yaml:"mapper_url"`
 
 	// RequestedClaims string encoded json object that specifies claims and optionally their properties which should be
 	// included in the id_token or returned from the UserInfo Endpoint.

--- a/pkg/idp/validation_test.go
+++ b/pkg/idp/validation_test.go
@@ -120,6 +120,45 @@ func TestValidate(t *testing.T) {
 			expectedError:  nil,
 		},
 		{
+			name:     "CreateIdPSuccessWithOIDCDiscovery",
+			method:   http.MethodPost,
+			endpoint: "",
+			body: func() []byte {
+				conf := new(Configuration)
+				conf.ID = "google_generic"
+				conf.Provider = "generic"
+				conf.IssuerURL = "mock-url"
+				conf.SubjectSource = "me"
+				conf.Scope = []string{}
+				conf.Mapper = "mock-url"
+
+				marshal, _ := json.Marshal(conf)
+				return marshal
+			},
+			expectedResult: nil,
+			expectedError:  nil,
+		},
+		{
+			name:     "CreateIdPSuccessWithoutOIDCDiscovery",
+			method:   http.MethodPost,
+			endpoint: "",
+			body: func() []byte {
+				conf := new(Configuration)
+				conf.ID = "google_generic"
+				conf.Provider = "generic"
+				conf.AuthURL = "mock-url"
+				conf.TokenURL = "mock-url"
+				conf.SubjectSource = "me"
+				conf.Scope = []string{}
+				conf.Mapper = "mock-url"
+
+				marshal, _ := json.Marshal(conf)
+				return marshal
+			},
+			expectedResult: nil,
+			expectedError:  nil,
+		},
+		{
 			name:     "PartialUpdateIdPSuccess",
 			method:   http.MethodPatch,
 			endpoint: "/",
@@ -155,6 +194,23 @@ func TestValidate(t *testing.T) {
 			body: func() []byte {
 				conf := new(Configuration)
 				conf.Provider = "microsoft"
+				conf.SubjectSource = "me"
+				conf.Scope = []string{"profile"}
+				conf.Mapper = "mock-url"
+
+				marshal, _ := json.Marshal(conf)
+				return marshal
+			},
+			expectedResult: validator.ValidationErrors{},
+			expectedError:  nil,
+		},
+		{
+			name:     "CreateIdPEmptyURLsAndIssuerValidationError",
+			method:   http.MethodPost,
+			endpoint: "",
+			body: func() []byte {
+				conf := new(Configuration)
+				conf.Provider = "generic"
 				conf.SubjectSource = "me"
 				conf.Scope = []string{"profile"}
 				conf.Mapper = "mock-url"

--- a/ui/src/pages/providers/ProviderCreate.tsx
+++ b/ui/src/pages/providers/ProviderCreate.tsx
@@ -1,3 +1,6 @@
+// Copyright 2024 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
 import { FC } from "react";
 import {
   ActionButton,
@@ -31,7 +34,7 @@ const ProviderCreate: FC = () => {
       id: "",
       client_id: "",
       client_secret: "",
-      mapper_url: "file:///etc/config/kratos/okta_schema.jsonnet",
+      mapper_url: "",
       scope: "email",
       subject_source: "userinfo",
     },


### PR DESCRIPTION
## Description
The only way to address https://github.com/canonical/identity-platform-admin-ui/issues/405 right now is to remove the default value.

I opened issue https://github.com/canonical/identity-platform-admin-ui/issues/455 to address the lack of a dropdown and more info about how to populate the Mapper field in the Create Provider form.

## Changes
- Since Kratos supports OIDC discovery, for the `generic` provider type we are allowing AuthURL and TokenURL to be empty in case IssuerURL is non empty
- Also, now IssuerURL can be empty if AuthURL and TokenURL are both provided
- Mapper is also allowed to be empty since Kratos will use the default schema in case that field is empty
- added a custom validation function to validate AuthURL and TokenURL presence in case IssuerURL is not specified
- added test entry to test the changes