### PR TITLE
chore: GO111MODULE removed

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,8 +84,6 @@ jobs:
           go install github.com/mikefarah/yq/v4@v4.44.3
           echo "OCI_FACTORY=$(go env GOPATH)/bin/oci-factory" >> $GITHUB_ENV
           echo "YQ=$(go env GOPATH)/bin/yq" >> $GITHUB_ENV
-        env:
-          GO111MODULE: "on"
       - name: Set EOLs and version
         run: |
           echo EOL_STABLE=$(date -d "$(date +'%Y-%m-%d') +6 month" "+%Y-%m-%d") >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-GO111MODULE?=on
 CGO_ENABLED?=0
 GOOS?=linux
 GO_BIN?=app

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,4 +1,3 @@
-GO111MODULE?=on
 CGO_ENABLED?=0
 GOOS?=linux
 GO_BIN?=app


### PR DESCRIPTION
GO111MODULE param shouldn't be in use.

A couple of sources:

https://go.dev/blog/go116-module-changes#modules-on-by-default
https://maelvls.dev/go111module-everywhere/