### PR TITLE
WD-17046 - refactor: replace icon components with standard icons

### DIFF
--- a/ui/src/components/IconLeft.tsx
+++ b/ui/src/components/IconLeft.tsx
@@ -1,7 +1,0 @@
-import React, { FC } from "react";
-
-const IconLeft: FC = () => {
-  return <i className="p-icon--chevron-down" style={{ rotate: "90deg" }} />;
-};
-
-export default IconLeft;

--- a/ui/src/components/IconRight.tsx
+++ b/ui/src/components/IconRight.tsx
@@ -1,7 +1,0 @@
-import React, { FC } from "react";
-
-const IconRight: FC = () => {
-  return <i className="p-icon--chevron-down" style={{ rotate: "270deg" }} />;
-};
-
-export default IconRight;

--- a/ui/src/components/Pagination/Pagination.tsx
+++ b/ui/src/components/Pagination/Pagination.tsx
@@ -1,9 +1,7 @@
 import React, { FC } from "react";
 import { PaginatedResponse } from "types/api";
-import { Button } from "@canonical/react-components";
+import { Button, Icon } from "@canonical/react-components";
 import { usePagination } from "util/usePagination";
-import IconLeft from "components/IconLeft";
-import IconRight from "components/IconRight";
 
 interface Props {
   response?: PaginatedResponse<unknown[]>;
@@ -26,18 +24,18 @@ const Pagination: FC<Props> = ({ response }) => {
     <>
       {showFirstLink && (
         <Button onClick={() => setPageToken("")} title="First page">
-          <IconLeft />
-          <IconLeft />
+          <Icon name="chevron-left" />
+          <Icon name="chevron-left" />
         </Button>
       )}
       {prev && (
         <Button onClick={() => setPageToken(prev)} title="Previous page">
-          <IconLeft />
+          <Icon name="chevron-left" />
         </Button>
       )}
       {next && (
         <Button onClick={() => setPageToken(next)} title="Next page">
-          <IconRight />
+          <Icon name="chevron-right" />
         </Button>
       )}
     </>


### PR DESCRIPTION
## Changes

- Replace left and right icon components with standard icons.

https://warthogs.atlassian.net/browse/WD-17046

## Screenshots

Before:

<img width="224" alt="Screenshot 2024-11-25 at 5 14 57 pm" src="https://github.com/user-attachments/assets/beb94b5b-a99b-42da-8334-caba66736d9a">

After:

<img width="239" alt="Screenshot 2024-11-25 at 5 16 30 pm" src="https://github.com/user-attachments/assets/1fce5c7d-b1bc-49d7-b72c-b76b773f840c">

