### PR TITLE
chore(ci): fix UI coverage

### DIFF
--- a/.github/workflows/ui-coverage.yml
+++ b/.github/workflows/ui-coverage.yml
@@ -16,7 +16,9 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: coverage
           run-id: ${{ github.event.workflow_run.id }}
+          path: "./ui"
       - name: "Report Coverage"
         uses: davelosert/vitest-coverage-report-action@v2
         with:

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage
-          path: coverage
+          path: ui/coverage
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/ui/README.md
+++ b/ui/README.md
@@ -4,7 +4,7 @@ This is the Admin UI for the Canonical identity platform.
 
 ## Development server
 
-Haproxy needs to be installed:
+HAProxy needs to be installed:
 
 ```shell
 apt install haproxy


### PR DESCRIPTION
## Changes

- Fix the coverage path that gets uploaded.
- Download the coverage path to the correct location.

Note: this won't succeed until the workflow file has landed on main.