### PR TITLE
chore(ci): fix ui coverage path

### DIFF
--- a/.github/workflows/ui-coverage.yml
+++ b/.github/workflows/ui-coverage.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           name: coverage
           run-id: ${{ github.event.workflow_run.id }}
-          path: "./ui"
+          path: "./ui/coverage"
       - name: "Report Coverage"
         uses: davelosert/vitest-coverage-report-action@v2
         with:


### PR DESCRIPTION
## changes

Include the dir name in the output path of the coverage artefact. I've tested this: https://github.com/canonical/identity-platform-admin-ui/pull/481 so hopefully this will finally function correctly.