### PR TITLE
Drop LOG_FILE support

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -63,7 +63,7 @@ func serve() {
 		panic(fmt.Errorf("issues with environment sourcing: %s", err))
 	}
 
-	logger := logging.NewLogger(specs.LogLevel, specs.LogFile)
+	logger := logging.NewLogger(specs.LogLevel)
 	monitor := prometheus.NewMonitor("identity-admin-ui", logger)
 	tracer := tracing.NewTracer(tracing.NewConfig(specs.TracingEnabled, specs.OtelGRPCEndpoint, specs.OtelHTTPEndpoint, logger))
 

--- a/internal/config/specs.go
+++ b/internal/config/specs.go
@@ -10,7 +10,6 @@ type EnvSpec struct {
 	TracingEnabled   bool   `envconfig:"tracing_enabled" default:"true"`
 
 	LogLevel string `envconfig:"log_level" default:"error"`
-	LogFile  string `envconfig:"log_file" default:"log.txt"`
 
 	Port        int    `envconfig:"port" default:"8080"`
 	ContextPath string `envconfig:"context_path" default:"/"`

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -11,7 +11,6 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // NewLogger creates a new default logger
@@ -20,7 +19,7 @@ import (
 // defer logger.Desugar().Sync()
 // ```
 // to make sure all has been piped out before terminating
-func NewLogger(l, logpath string) *zap.SugaredLogger {
+func NewLogger(l string) *zap.SugaredLogger {
 	var lvl string
 
 	val := strings.ToLower(l)
@@ -57,22 +56,8 @@ func NewLogger(l, logpath string) *zap.SugaredLogger {
 		panic(err)
 	}
 
-	core := zapcore.NewTee(
-		zapcore.NewCore(zapcore.NewJSONEncoder(cfg.EncoderConfig), zapcore.AddSync(newRotator(logpath)), cfg.Level),
-		zapcore.NewCore(zapcore.NewJSONEncoder(cfg.EncoderConfig), zapcore.AddSync(os.Stdout), cfg.Level),
-	)
+	core := zapcore.NewCore(zapcore.NewJSONEncoder(cfg.EncoderConfig), zapcore.AddSync(os.Stdout), cfg.Level)
 
 	return zap.New(core).Sugar()
 
-}
-
-func newRotator(path string) *lumberjack.Logger {
-	r := new(lumberjack.Logger)
-
-	r.Filename = path
-	r.MaxSize = 500 // megabyte
-	r.MaxBackups = 2
-	r.MaxAge = 3 // day
-
-	return r
 }

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestDebugLogger(t *testing.T) {
 	assert := assert.New(t)
-	assert.NotPanics(func() { NewLogger("DEBUG", "log.txt") }, "No panic should have been thrown")
+	assert.NotPanics(func() { NewLogger("DEBUG") }, "No panic should have been thrown")
 }
 
 func TestInvalidLevel(t *testing.T) {
 	assert := assert.New(t)
-	assert.NotPanics(func() { NewLogger("invalid", "log.txt") }, "No panic should have been thrown")
+	assert.NotPanics(func() { NewLogger("invalid") }, "No panic should have been thrown")
 }


### PR DESCRIPTION
[IAM-1229](https://warthogs.atlassian.net/browse/IAM-1229)

Do not write logs to disk, the charm will need to migrate to LogForwarder

[IAM-1229]: https://warthogs.atlassian.net/browse/IAM-1229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ