### PR TITLE
ci: build on ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       rock: ${{ steps.set.outputs.rock }}
     steps:


### PR DESCRIPTION
`ubuntu-latest` was recently changed to 24.04, that is causing issues with rockcraft build: https://github.com/canonical/identity-platform-admin-ui/actions/runs/12623520000/job/35223698984?pr=495
As a temporary workaround we can fall back to ubuntu 22.04. I will open an issue in rockcraft to get help on investigating this.