### PR TITLE
Prevent renovate from upgrading openfga sdk

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -77,6 +77,12 @@
       "automerge": true,
       "schedule": ["at any time"],
       "additionalBranchPrefix": "auto-"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/openfga/go-sdk"],
+      "allowedVersions": "v0.3.7",
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Description
Based on @shipperizer suggestion https://github.com/canonical/identity-platform-admin-ui/pull/513#pullrequestreview-2557214603, we want to prevent OpenFGA sdk to go over the version that supports ListUsers API without introducing breaking changes, which is `v0.3.7`.