### PR TITLE
Upgrade upload-artifact to v4 after deprecation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
       id: set
       run: echo "rock=${{ steps.rockcraft.outputs.rock }}" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+    - uses: actions/upload-artifact@v4
       with:
         path: ${{ steps.rockcraft.outputs.rock }}
         name: ${{ steps.rockcraft.outputs.rock }}
@@ -35,7 +35,7 @@ jobs:
       run: syft $(realpath ${{ steps.rockcraft.outputs.rock }}) -o spdx-json=identity_platform_admin_ui.sbom.json
 
     - name: Upload SBOM
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+      uses: actions/upload-artifact@v4
       with:
         name: identity-platform-admin-ui-sbom
         path: "identity_platform_admin_ui.sbom.json"

--- a/.github/workflows/ossf.yaml
+++ b/.github/workflows/ossf.yaml
@@ -46,7 +46,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           files: ./coverage.out
       - name: Upload Go test results
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+        uses: actions/upload-artifact@v4
         with:
           name: Go-results
           path: test.json


### PR DESCRIPTION
## Description
Upload artifact action v3 got deprecated.

## References
- https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/