### PR TITLE
Upgrade download-artifact to v4

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
     - name: Download Artifact
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.rock }}
 


### PR DESCRIPTION
## Description
Download artifact action v3 got deprecated.

## References
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/