### PR TITLE
IAM-1285 Adopt ListUsers API

### DIFF
--- a/internal/openfga/interfaces.go
+++ b/internal/openfga/interfaces.go
@@ -1,5 +1,5 @@
-// Copyright 2024 Canonical Ltd.
-// SPDX-License-Identifier: AGPL
+// Copyright 2025 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package openfga
 
@@ -29,6 +29,8 @@ type OpenFGACoreClientInterface interface {
 	WriteExecute(client.SdkClientWriteRequestInterface) (*client.ClientWriteResponse, error)
 	ListObjects(context.Context) client.SdkClientListObjectsRequestInterface
 	ListObjectsExecute(client.SdkClientListObjectsRequestInterface) (*client.ClientListObjectsResponse, error)
+	ListUsers(context.Context) client.SdkClientListUsersRequestInterface
+	ListUsersExecute(client.SdkClientListUsersRequestInterface) (*client.ClientListUsersResponse, error)
 }
 
 // OpenFGAClientInterface is the interface used to decouple the OpenFGA store implementation

--- a/internal/openfga/noop.go
+++ b/internal/openfga/noop.go
@@ -1,5 +1,5 @@
-// Copyright 2024 Canonical Ltd
-// SPDX-License-Identifier: AGPL
+// Copyright 2025 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
 
 package openfga
 
@@ -31,6 +31,10 @@ func NewNoopClient(tracer tracing.TracingInterface, monitor monitoring.MonitorIn
 }
 
 func (c *NoopClient) ListObjects(ctx context.Context, user, relation, objectType string) ([]string, error) {
+	return make([]string, 0), nil
+}
+
+func (c *NoopClient) ListUsers(ctx context.Context, userFilter, relation, object string) ([]string, error) {
 	return make([]string, 0), nil
 }
 

--- a/pkg/groups/handlers.go
+++ b/pkg/groups/handlers.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd.
+// Copyright 2025 Canonical Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 
 package groups
@@ -582,17 +582,7 @@ func (a *API) handleListIdentities(w http.ResponseWriter, r *http.Request) {
 
 	ID := chi.URLParam(r, "id")
 
-	paginator := types.NewTokenPaginator(a.tracer, a.logger)
-
-	if err := paginator.LoadFromRequest(r.Context(), r); err != nil {
-		a.logger.Error(err)
-	}
-
-	identities, pageToken, err := a.service.ListIdentities(
-		r.Context(),
-		ID,
-		paginator.GetToken(r.Context(), GROUP_TOKEN_KEY),
-	)
+	identities, err := a.service.ListIdentities(r.Context(), ID)
 
 	if err != nil {
 		rr := types.Response{
@@ -606,16 +596,6 @@ func (a *API) handleListIdentities(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	paginator.SetToken(r.Context(), GROUP_TOKEN_KEY, pageToken)
-
-	pageHeader, err := paginator.PaginationHeader(r.Context())
-
-	if err != nil {
-		a.logger.Errorf("error producing pagination header: %s", err)
-		pageHeader = ""
-	}
-
-	w.Header().Add(types.PAGINATION_HEADER, pageHeader)
 	w.WriteHeader(http.StatusOK)
 
 	json.NewEncoder(w).Encode(

--- a/pkg/groups/interfaces.go
+++ b/pkg/groups/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd.
+// Copyright 2025 Canonical Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 
 package groups
@@ -23,7 +23,7 @@ type ServiceInterface interface {
 	ListPermissions(context.Context, string, map[string]string) ([]string, map[string]string, error)
 	AssignPermissions(context.Context, string, ...Permission) error
 	RemovePermissions(context.Context, string, ...Permission) error
-	ListIdentities(context.Context, string, string) ([]string, string, error)
+	ListIdentities(context.Context, string) ([]string, error)
 	AssignIdentities(context.Context, string, ...string) error
 	RemoveIdentities(context.Context, string, ...string) error
 	CanAssignRoles(context.Context, string, ...string) (bool, error)
@@ -33,6 +33,7 @@ type ServiceInterface interface {
 // OpenFGAClientInterface is the interface used to decouple the OpenFGA store implementation
 type OpenFGAClientInterface interface {
 	ListObjects(context.Context, string, string, string) ([]string, error)
+	ListUsers(context.Context, string, string, string) ([]string, error)
 	ReadTuples(context.Context, string, string, string, string) (*client.ClientReadResponse, error)
 	WriteTuples(context.Context, ...ofga.Tuple) error
 	DeleteTuples(context.Context, ...ofga.Tuple) error

--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd.
+// Copyright 2025 Canonical Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 
 package roles
@@ -317,17 +317,7 @@ func (a *API) handleListRoleGroup(w http.ResponseWriter, r *http.Request) {
 
 	ID := chi.URLParam(r, "id")
 
-	paginator := types.NewTokenPaginator(a.tracer, a.logger)
-
-	if err := paginator.LoadFromRequest(r.Context(), r); err != nil {
-		a.logger.Error(err)
-	}
-
-	roles, pageToken, err := a.service.ListRoleGroups(
-		r.Context(),
-		ID,
-		paginator.GetToken(r.Context(), ROLE_TOKEN_KEY),
-	)
+	roles, err := a.service.ListRoleGroups(r.Context(), ID)
 
 	if err != nil {
 		rr := types.Response{
@@ -341,16 +331,6 @@ func (a *API) handleListRoleGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	paginator.SetToken(r.Context(), ROLE_TOKEN_KEY, pageToken)
-
-	pageHeader, err := paginator.PaginationHeader(r.Context())
-
-	if err != nil {
-		a.logger.Errorf("error producing pagination header: %s", err)
-		pageHeader = ""
-	}
-
-	w.Header().Add(types.PAGINATION_HEADER, pageHeader)
 	w.WriteHeader(http.StatusOK)
 
 	json.NewEncoder(w).Encode(

--- a/pkg/roles/handlers_test.go
+++ b/pkg/roles/handlers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd.
+// Copyright 2025 Canonical Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 
 package roles
@@ -576,10 +576,7 @@ func TestHandleListRoleGroupsSuccess(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v0/roles/%s/groups", roleID), nil)
 			req = req.WithContext(authentication.PrincipalContext(req.Context(), &authentication.UserPrincipal{Email: "test-user"}))
 
-			mockTracer.EXPECT().Start(gomock.Any(), "types.TokenPaginator.LoadFromRequest").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
-			mockTracer.EXPECT().Start(gomock.Any(), "types.TokenPaginator.PaginationHeader").Times(1).Return(context.TODO(), trace.SpanFromContext(context.TODO()))
-
-			mockService.EXPECT().ListRoleGroups(gomock.Any(), roleID, "").Return(test.expected.groups, test.expected.cTokens["roles"], nil)
+			mockService.EXPECT().ListRoleGroups(gomock.Any(), roleID).Return(test.expected.groups, nil)
 
 			w := httptest.NewRecorder()
 			mux := chi.NewMux()
@@ -597,22 +594,6 @@ func TestHandleListRoleGroupsSuccess(t *testing.T) {
 
 			if res.StatusCode != http.StatusOK {
 				t.Errorf("expected HTTP status code 200 got %v", res.StatusCode)
-			}
-
-			tokenMap, err := base64.StdEncoding.DecodeString(res.Header.Get(types.PAGINATION_HEADER))
-
-			if test.expected.cTokens != nil {
-				if err != nil {
-					t.Errorf("expected continuation token in headers")
-				}
-
-				tokens := map[string]string{}
-
-				_ = json.Unmarshal(tokenMap, &tokens)
-
-				if !reflect.DeepEqual(tokens, test.expected.cTokens) {
-					t.Errorf("expected continuation tokens to match: %v - %v", tokens, test.expected.cTokens)
-				}
 			}
 
 			// duplicate types.Response attribute we care and assign the proper type instead of interface{}

--- a/pkg/roles/interfaces.go
+++ b/pkg/roles/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd.
+// Copyright 2025 Canonical Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 
 package roles
@@ -17,7 +17,7 @@ type ServiceInterface interface {
 	GetRole(context.Context, string, string) (*Role, error)
 	CreateRole(context.Context, string, string) (*Role, error)
 	DeleteRole(context.Context, string) error
-	ListRoleGroups(context.Context, string, string) ([]string, string, error)
+	ListRoleGroups(context.Context, string) ([]string, error)
 	ListPermissions(context.Context, string, map[string]string) ([]string, map[string]string, error)
 	AssignPermissions(context.Context, string, ...Permission) error
 	RemovePermissions(context.Context, string, ...Permission) error
@@ -26,6 +26,7 @@ type ServiceInterface interface {
 // OpenFGAClientInterface is the interface used to decouple the OpenFGA store implementation
 type OpenFGAClientInterface interface {
 	ListObjects(context.Context, string, string, string) ([]string, error)
+	ListUsers(context.Context, string, string, string) ([]string, error)
 	ReadTuples(context.Context, string, string, string, string) (*client.ClientReadResponse, error)
 	WriteTuples(context.Context, ...ofga.Tuple) error
 	DeleteTuples(context.Context, ...ofga.Tuple) error

--- a/pkg/roles/service.go
+++ b/pkg/roles/service.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd.
+// Copyright 2025 Canonical Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 
 package roles
@@ -21,12 +21,6 @@ import (
 	ofga "github.com/canonical/identity-platform-admin-ui/internal/openfga"
 	"github.com/canonical/identity-platform-admin-ui/internal/pool"
 	"github.com/canonical/identity-platform-admin-ui/pkg/authentication"
-)
-
-const (
-	ASSIGNEE_RELATION = "assignee"
-	CAN_VIEW_RELATION = "can_view"
-	ALL_USERS         = "user:*"
 )
 
 type listPermissionsResult struct {
@@ -134,8 +128,8 @@ func (s *Service) CreateRole(ctx context.Context, userID, ID string) (*Role, err
 
 	err := s.ofga.WriteTuples(
 		ctx,
-		*ofga.NewTuple(user, ASSIGNEE_RELATION, role),
-		*ofga.NewTuple(user, CAN_VIEW_RELATION, role),
+		*ofga.NewTuple(user, authorization.ASSIGNEE_RELATION, role),
+		*ofga.NewTuple(user, authorization.CAN_VIEW_RELATION, role),
 	)
 
 	if err != nil {
@@ -438,7 +432,7 @@ func (s *Service) directRelations() []string {
 }
 
 func (s *Service) getRoleAssigneeUser(roleID string) string {
-	return fmt.Sprintf("role:%s#%s", roleID, ASSIGNEE_RELATION)
+	return fmt.Sprintf("role:%s#%s", roleID, authorization.ASSIGNEE_RELATION)
 }
 
 // NewService returns the implementtation of the business logic for the roles API
@@ -607,13 +601,13 @@ func (s *V1Service) GetRoleEntitlements(ctx context.Context, roleId string, para
 
 	for _, permission := range permissions {
 		p := authorization.NewURNFromURLParam(permission)
-                entity := strings.SplitN(p.Object(), ":", 2)
+		entity := strings.SplitN(p.Object(), ":", 2)
 		r.Data = append(
 			r.Data,
 			resources.EntityEntitlement{
 				Entitlement: p.Relation(),
 				EntityType:  entity[0],
-				EntityId:       entity[1],
+				EntityId:    entity[1],
 			},
 		)
 	}

--- a/pkg/web/interfaces.go
+++ b/pkg/web/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd
+// Copyright 2025 Canonical Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 
 package web
@@ -25,6 +25,7 @@ type OpenFGAClientInterface interface {
 	DeleteTuple(context.Context, string, string, string) error
 	Check(context.Context, string, string, string, ...ofga.Tuple) (bool, error)
 	ListObjects(context.Context, string, string, string) ([]string, error)
+	ListUsers(context.Context, string, string, string) ([]string, error)
 	WriteTuples(context.Context, ...ofga.Tuple) error
 	DeleteTuples(context.Context, ...ofga.Tuple) error
 	BatchCheck(context.Context, ...ofga.Tuple) (bool, error)


### PR DESCRIPTION
## Description
This PR build on the preparatory work of the previous OpenFGA upgrades from the PRs mentioned below.
Adoption of the ListUsers API in both the `roles` package and the `groups` package to improve the implementation of the 
- `roles.ListRoleGroups`
- `groups.ListGroupIdentities`

The `OpenFGACoreClientInterface` for the core OpenFGA client has been updated with the additional methods for the ListUsers API.

The `ListUsers` replaces the `ReadTuples`. One difference to note is that the ListUsers doesn't provide paginated results so the continuation token has been removed from the signature and the return type.

Tests have been adjusted accordingly.

## References
- https://github.com/canonical/identity-platform-admin-ui/pull/513
- https://github.com/canonical/identity-platform-login-ui/pull/427
- https://github.com/canonical/openfga-operator/pull/146
- https://github.com/canonical/openfga-rock/pull/15
- https://github.com/canonical/identity-platform-admin-ui/pull/514