### PR TITLE
feat: pass label when creating idps

### DIFF
--- a/ui/src/pages/providers/ProviderCreate/ProviderCreate.test.tsx
+++ b/ui/src/pages/providers/ProviderCreate/ProviderCreate.test.tsx
@@ -64,6 +64,7 @@ test("calls the API on submit", async () => {
     ...initialValues,
     scope: initialValues.scope.split(","),
     ...values,
+    label: values.id,
   });
 });
 

--- a/ui/src/pages/providers/ProviderCreate/ProviderCreate.tsx
+++ b/ui/src/pages/providers/ProviderCreate/ProviderCreate.tsx
@@ -46,7 +46,11 @@ const ProviderCreate: FC = () => {
     validationSchema: ProviderCreateSchema,
     onSubmit: (values) => {
       createProvider(
-        JSON.stringify({ ...values, scope: values.scope?.split(",") }),
+        JSON.stringify({
+          ...values,
+          label: values.id,
+          scope: values.scope?.split(","),
+        }),
       )
         .then(() => {
           void queryClient.invalidateQueries({

--- a/ui/src/pages/providers/ProviderEdit/ProviderEdit.test.tsx
+++ b/ui/src/pages/providers/ProviderEdit/ProviderEdit.test.tsx
@@ -92,6 +92,7 @@ test("calls the API on submit", async () => {
     client_secret: provider.client_secret,
     id: provider.id,
     issuer_url: provider.issuer_url,
+    label: provider.id,
     mapper_url: provider.mapper_url,
     microsoft_tenant: provider.microsoft_tenant,
     provider: provider.provider,
@@ -100,6 +101,20 @@ test("calls the API on submit", async () => {
     token_url: provider.token_url,
     scope: [values.scope],
   });
+});
+
+test("does not send blank strings for requested_claims", async () => {
+  mock
+    .onGet(`/idps/${provider.id}`)
+    .reply(200, { data: [{ ...provider, requested_claims: "" }] });
+  renderComponent(<ProviderEdit />, {
+    url: `/?id=${provider.id}`,
+  });
+  await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT }));
+  expect(
+    (JSON.parse(mock.history.patch[0].data as string) as IdentityProvider)
+      .requested_claims,
+  ).toBeUndefined();
 });
 
 test("handles API success", async () => {

--- a/ui/src/pages/providers/ProviderEdit/ProviderEdit.tsx
+++ b/ui/src/pages/providers/ProviderEdit/ProviderEdit.tsx
@@ -57,7 +57,12 @@ const ProviderEdit: FC = () => {
     onSubmit: (values) => {
       updateProvider(
         provider?.id ?? "",
-        JSON.stringify({ ...values, scope: values.scope?.split(",") }),
+        JSON.stringify({
+          ...values,
+          label: values.id,
+          requested_claims: values.requested_claims || undefined,
+          scope: values.scope?.split(","),
+        }),
       )
         .then(() => {
           void queryClient.invalidateQueries({

--- a/ui/src/pages/providers/ProviderForm/ProviderForm.tsx
+++ b/ui/src/pages/providers/ProviderForm/ProviderForm.tsx
@@ -131,6 +131,13 @@ const ProviderForm: FC<Props> = ({ formik, isEdit = false }) => {
         label={Label.NAME}
         error={formik.touched.id ? formik.errors.id : null}
         disabled={isEdit}
+        help={
+          <>
+            Name will be used as the button label for signing in.
+            <br />
+            {"Example: Sign in with <Name>"}
+          </>
+        }
       />
       <Input
         {...formik.getFieldProps("client_id")}


### PR DESCRIPTION
## Changes

Pass the name to the label value when created/editing idps.
Also fixed an issue when updating idps where it would pass an empty string to `requested_claims` which is not valid JSON.

https://warthogs.atlassian.net/browse/IAM-1057
Fixes: #410.