### PR TITLE
IAM-1311 Migrate roles api to gRPC-gateway based server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,14 @@ module github.com/canonical/identity-platform-admin-ui
 go 1.24.0
 
 require (
-	github.com/canonical/identity-platform-api v0.0.0-20250228134808-c469846f6ca0
+	github.com/canonical/identity-platform-api v0.0.0-20250304153015-e1c4e5898c2c
 	github.com/canonical/rebac-admin-ui-handlers v0.1.0
 	github.com/coreos/go-oidc/v3 v3.10.0
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/go-chi/cors v1.2.1
 	github.com/go-playground/validator/v10 v10.22.0
 	github.com/google/uuid v1.6.0
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/openfga/go-sdk v0.3.7
 	github.com/openfga/language/pkg/go v0.0.0-20240122114256-aaa86ab89379
@@ -33,6 +34,8 @@ require (
 	go.uber.org/mock v0.4.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/oauth2 v0.26.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250227231956-55c901821b1e
+	google.golang.org/grpc v1.70.0
 	google.golang.org/protobuf v1.36.5
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.28.3
@@ -66,7 +69,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20221010195024-131d412537ea // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
@@ -100,9 +102,7 @@ require (
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250219182151-9fdb1cabc7b2 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250219182151-9fdb1cabc7b2 // indirect
-	google.golang.org/grpc v1.70.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250227231956-55c901821b1e // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/canonical/identity-platform-admin-ui
 go 1.24.0
 
 require (
+	github.com/canonical/identity-platform-api v0.0.0-20250228134808-c469846f6ca0
 	github.com/canonical/rebac-admin-ui-handlers v0.1.0
 	github.com/coreos/go-oidc/v3 v3.10.0
 	github.com/go-chi/chi/v5 v5.0.12

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
-github.com/canonical/identity-platform-api v0.0.0-20250228134808-c469846f6ca0 h1:q3+KRozFaTSX0RErpXcEkPZMnuLJyHczvX9yECUKuek=
-github.com/canonical/identity-platform-api v0.0.0-20250228134808-c469846f6ca0/go.mod h1:9ZnJGWSv749jQAygdb3aWatlwduXXcqgnFCkT0H897k=
+github.com/canonical/identity-platform-api v0.0.0-20250304153015-e1c4e5898c2c h1:aYok4XLuaTqTNo6JmAYFR51o6Q2trHBqvl8sW0Gf2zU=
+github.com/canonical/identity-platform-api v0.0.0-20250304153015-e1c4e5898c2c/go.mod h1:9ZnJGWSv749jQAygdb3aWatlwduXXcqgnFCkT0H897k=
 github.com/canonical/rebac-admin-ui-handlers v0.1.0 h1:Bef1N/RgQine8hHX4ZMksQz/1VKsy4DHK2XdhAzQsZs=
 github.com/canonical/rebac-admin-ui-handlers v0.1.0/go.mod h1:EIdBoaTHWYPkzNeUeXUBueJkglN9nQz5HLIvaOT7o1k=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
@@ -260,10 +260,10 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/genproto/googleapis/api v0.0.0-20250219182151-9fdb1cabc7b2 h1:35ZFtrCgaAjF7AFAK0+lRSf+4AyYnWRbH7og13p7rZ4=
-google.golang.org/genproto/googleapis/api v0.0.0-20250219182151-9fdb1cabc7b2/go.mod h1:W9ynFDP/shebLB1Hl/ESTOap2jHd6pmLXPNZC7SVDbA=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250219182151-9fdb1cabc7b2 h1:DMTIbak9GhdaSxEjvVzAeNZvyc03I61duqNbnm3SU0M=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250219182151-9fdb1cabc7b2/go.mod h1:LuRYeWDFV6WOn90g357N17oMCaxpgCnbi/44qJvDn2I=
+google.golang.org/genproto/googleapis/api v0.0.0-20250227231956-55c901821b1e h1:nsxey/MfoGzYNduN0NN/+hqP9iiCIYsrVbXb/8hjFM8=
+google.golang.org/genproto/googleapis/api v0.0.0-20250227231956-55c901821b1e/go.mod h1:Xsh8gBVxGCcbV8ZeTB9wI5XPyZ5RvC6V3CTeeplHbiA=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250227231956-55c901821b1e h1:YA5lmSs3zc/5w+xsRcHqpETkaYyK63ivEPzNTcUUlSA=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250227231956-55c901821b1e/go.mod h1:LuRYeWDFV6WOn90g357N17oMCaxpgCnbi/44qJvDn2I=
 google.golang.org/grpc v1.70.0 h1:pWFv03aZoHzlRKHWicjsZytKAiYCtNS0dHbXnIdq7jQ=
 google.golang.org/grpc v1.70.0/go.mod h1:ofIJqVKDXx/JiXrwr2IG4/zwdH9txy3IlF40RmcJSQw=
 google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/canonical/identity-platform-api v0.0.0-20250228134808-c469846f6ca0 h1:q3+KRozFaTSX0RErpXcEkPZMnuLJyHczvX9yECUKuek=
+github.com/canonical/identity-platform-api v0.0.0-20250228134808-c469846f6ca0/go.mod h1:9ZnJGWSv749jQAygdb3aWatlwduXXcqgnFCkT0H897k=
 github.com/canonical/rebac-admin-ui-handlers v0.1.0 h1:Bef1N/RgQine8hHX4ZMksQz/1VKsy4DHK2XdhAzQsZs=
 github.com/canonical/rebac-admin-ui-handlers v0.1.0/go.mod h1:EIdBoaTHWYPkzNeUeXUBueJkglN9nQz5HLIvaOT7o1k=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=

--- a/internal/http/types/gRPC_mappers.go
+++ b/internal/http/types/gRPC_mappers.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package types
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	v0Types "github.com/canonical/identity-platform-api/v0/http"
+	rpcStatus "google.golang.org/genproto/googleapis/rpc/status"
+)
+
+// SetHeaderFromMetadataFilter is the filter function to allow headers from the handlers to be set
+// on the HTTP response by the gRPC gateway (to be registered with WithForwardResponseOption)
+// DO NOT use WriteHeader func in filters like this one
+//
+// usage example:
+//
+// mux := runtime.NewServeMux(
+//
+//	runtime.WithForwardResponseOption(SetHeaderFromMetadataFilter),
+//
+// )
+func SetHeaderFromMetadataFilter(ctx context.Context, w http.ResponseWriter, _ proto.Message) error {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return status.Errorf(codes.Internal, "error getting incoming context metadata")
+	}
+
+	for key, values := range md {
+		// filter out grpcgateway headers
+		if strings.HasPrefix(key, "grpcgateway-") {
+			continue
+		}
+
+		for _, v := range values {
+			w.Header().Add(key, v)
+		}
+	}
+
+	return nil
+}
+
+// ForwardErrorResponseRewriter rewrites error message to comply with Admin UI
+// standard json response for errors. It doesn't do anything on other messages
+// usage example:
+//
+// mux := runtime.NewServeMux(
+//
+//	runtime.WithForwardResponseRewriter(ForwardErrorResponseRewriter),
+//
+// )
+func ForwardErrorResponseRewriter(_ context.Context, response proto.Message) (any, error) {
+	codeError, ok := response.(*rpcStatus.Status)
+	if !ok {
+		return response, nil
+	}
+
+	httpStatus := runtime.HTTPStatusFromCode(
+		codes.Code(codeError.Code),
+	)
+
+	return &v0Types.ErrorResponse{
+		Status:  int32(httpStatus),
+		Message: codeError.GetMessage(),
+	}, nil
+}

--- a/internal/http/types/gRPC_mappers_test.go
+++ b/internal/http/types/gRPC_mappers_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package types
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	v0Types "github.com/canonical/identity-platform-api/v0/http"
+	v0Roles "github.com/canonical/identity-platform-api/v0/roles"
+	rpcStatus "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestSetHeaderFromMetadataFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		context  context.Context
+		expected map[string]string
+		err      error
+	}{
+		{
+			name: "Valid metadata",
+			context: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				"key1":            "value1",
+				"key2":            "value2",
+				"grpcgateway-foo": "should-be-filtered",
+			})),
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			err: nil,
+		},
+		{
+			name:     "No metadata in context",
+			context:  context.Background(),
+			expected: nil,
+			err:      status.Errorf(codes.Internal, "error getting incoming context metadata"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			err := SetHeaderFromMetadataFilter(test.context, w, nil)
+
+			if (err != nil) != (test.err != nil) {
+				t.Errorf("expected error: %v, got: %v", test.err, err)
+			}
+
+			if test.expected != nil {
+				for key, expectedValue := range test.expected {
+					if got := w.Header().Get(key); got != expectedValue {
+						t.Errorf("expected header %s: %s, got: %s", key, expectedValue, got)
+					}
+				}
+				if w.Header().Get("grpcgateway-foo") != "" {
+					t.Errorf("grpcgateway-foo header should be filtered out")
+				}
+			}
+		})
+	}
+}
+
+func TestForwardErrorResponseRewriter(t *testing.T) {
+	untouchedResponse := &v0Roles.ListRolesResp{}
+
+	tests := []struct {
+		name     string
+		response proto.Message
+		expected any
+	}{
+		{
+			name:     "Valid grpc status",
+			response: &rpcStatus.Status{Code: int32(codes.NotFound), Message: "Resource not found"},
+			expected: &v0Types.ErrorResponse{
+				Status:  int32(http.StatusNotFound),
+				Message: "Resource not found",
+			},
+		},
+		{
+			name:     "Invalid response type",
+			response: untouchedResponse,
+			expected: untouchedResponse,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, _ := ForwardErrorResponseRewriter(context.Background(), test.response)
+
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("expected result: %v, got: %v", test.expected, result)
+			}
+		})
+	}
+}

--- a/internal/http/types/generic.go
+++ b/internal/http/types/generic.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd.
+// Copyright 2025 Canonical Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 
 package types
@@ -13,10 +13,10 @@ import (
 )
 
 type Response struct {
-	Data    interface{} `json:"data"`
+	Data    interface{} `json:"data,omitempty"`
 	Message string      `json:"message"`
 	Status  int         `json:"status"`
-	Meta    *Pagination `json:"_meta"`
+	Meta    *Pagination `json:"_meta,omitempty"`
 }
 
 // NavigationTokens are parameters used to navigate `list` result endpoints

--- a/pkg/roles/gRPC_handlers.go
+++ b/pkg/roles/gRPC_handlers.go
@@ -1,0 +1,305 @@
+// Copyright 2025 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package roles
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/authorization"
+	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
+	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
+	"github.com/canonical/identity-platform-admin-ui/pkg/authentication"
+
+	v0Roles "github.com/canonical/identity-platform-api/v0/roles"
+)
+
+type GrpcHandler struct {
+	svc ServiceInterface
+	// UnimplementedRolesServiceServer must be embedded to get forward compatible implementations.
+	v0Roles.UnimplementedRolesServiceServer
+
+	logger  logging.LoggerInterface
+	tracer  tracing.TracingInterface
+	monitor monitoring.MonitorInterface
+}
+
+func (g *GrpcHandler) ListRoles(ctx context.Context, _ *emptypb.Empty) (*v0Roles.ListRolesResp, error) {
+	ctx, span := g.tracer.Start(ctx, "roles.GrpcHandler.ListRoles")
+	defer span.End()
+
+	principal := authentication.PrincipalFromContext(ctx)
+
+	roles, err := g.svc.ListRoles(
+		ctx,
+		principal.Identifier(),
+	)
+
+	if err != nil {
+		g.logger.Errorf("failed to list roles: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to list roles: %v", err)
+	}
+
+	message := "List of roles"
+
+	return &v0Roles.ListRolesResp{
+		Data:    roles,
+		Status:  http.StatusOK,
+		Message: &message,
+	}, nil
+}
+
+func (g *GrpcHandler) GetRole(ctx context.Context, req *v0Roles.GetRoleReq) (*v0Roles.GetRoleResp, error) {
+	ctx, span := g.tracer.Start(ctx, "roles.GrpcHandler.GetRole")
+	defer span.End()
+
+	principal := authentication.PrincipalFromContext(ctx)
+	role, err := g.svc.GetRole(ctx, principal.Identifier(), req.GetId())
+
+	if err != nil {
+		g.logger.Errorf("failed to retrieve role: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to retrieve role: %v", err)
+	}
+
+	if role == nil {
+		g.logger.Debugf("role not found: %v", req.GetId())
+		return nil, status.Errorf(codes.NotFound, "role not found: %v", req.GetId())
+	}
+
+	message := "Role detail"
+
+	return &v0Roles.GetRoleResp{
+		Data: []*v0Roles.Role{
+			{
+				Id:   role.ID,
+				Name: role.Name,
+			},
+		},
+		Status:  http.StatusOK,
+		Message: &message,
+	}, nil
+}
+
+func (g *GrpcHandler) CreateRole(ctx context.Context, req *v0Roles.CreateRoleReq) (*v0Roles.CreateRoleResp, error) {
+	ctx, span := g.tracer.Start(ctx, "roles.GrpcHandler.CreateRole")
+	defer span.End()
+
+	role := req.GetRole()
+	if role == nil || role.GetName() == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "role name is empty")
+	}
+
+	principal := authentication.PrincipalFromContext(ctx)
+	createdRole, err := g.svc.CreateRole(ctx, principal.Identifier(), role.GetName())
+
+	if err != nil {
+		g.logger.Errorf("failed to create role: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to create role: %v", err)
+	}
+
+	message := fmt.Sprintf("Created role %s", createdRole.Name)
+
+	return &v0Roles.CreateRoleResp{
+		Data: []*v0Roles.Role{
+			{
+				Id:   createdRole.ID,
+				Name: createdRole.Name,
+			},
+		},
+		Status:  http.StatusCreated,
+		Message: &message,
+	}, nil
+}
+
+func (g *GrpcHandler) UpdateRole(ctx context.Context, _ *v0Roles.UpdateRoleReq) (*v0Roles.UpdateRoleResp, error) {
+	ctx, span := g.tracer.Start(ctx, "roles.GrpcHandler.UpdateRole")
+	defer span.End()
+
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateRole not implemented")
+}
+
+func (g *GrpcHandler) RemoveRole(ctx context.Context, req *v0Roles.RemoveRoleReq) (*v0Roles.RemoveRoleResp, error) {
+	ctx, span := g.tracer.Start(ctx, "roles.GrpcHandler.RemoveRole")
+	defer span.End()
+
+	roleID := req.GetId()
+	if roleID == "" {
+		g.logger.Debugf("role ID is empty")
+		return nil, status.Errorf(codes.InvalidArgument, "role ID is empty")
+	}
+
+	if err := g.svc.DeleteRole(ctx, roleID); err != nil {
+		g.logger.Errorf("failed to delete role: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to delete role: %v", err)
+	}
+
+	message := fmt.Sprintf("Deleted role %s", roleID)
+
+	return &v0Roles.RemoveRoleResp{
+		Status:  http.StatusOK,
+		Message: &message,
+	}, nil
+}
+
+func (g *GrpcHandler) ListRoleEntitlements(ctx context.Context, req *v0Roles.ListRoleEntitlementsReq) (*v0Roles.ListRoleEntitlementsResp, error) {
+	ctx, span := g.tracer.Start(ctx, "roles.GrpcHandler.ListRoleEntitlements")
+	defer span.End()
+
+	roleID := req.GetId()
+	if roleID == "" {
+		g.logger.Debugf("role ID is empty")
+		return nil, status.Errorf(codes.InvalidArgument, "role ID is empty")
+	}
+
+	paginator := types.NewTokenPaginator(g.tracer, g.logger)
+
+	if err := paginator.LoadFromGRPCContext(ctx); err != nil {
+		g.logger.Errorf("failed to load token paginator: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to load token paginator: %v", err)
+	}
+
+	permissions, pageTokens, err := g.svc.ListPermissions(ctx, roleID, paginator.GetAllTokens(ctx))
+
+	if err != nil {
+		g.logger.Errorf("failed to list entitlements for role %s, %v", roleID, err)
+		return nil, status.Errorf(codes.Internal, "failed to list entitlements for role %s, %v", roleID, err)
+	}
+
+	paginator.SetTokens(ctx, pageTokens)
+	paginationMetadataValue, err := paginator.PaginationHeader(ctx)
+
+	if err != nil {
+		g.logger.Errorf("error producing pagination metadata: %v", err)
+		return nil, status.Errorf(codes.Internal, "error producing pagination metadata: %v", err)
+	}
+
+	if paginationMetadataValue != "" {
+		md := metadata.New(map[string]string{types.GRPC_PAGINATION_METADATA: paginationMetadataValue})
+		if err = grpc.SendHeader(ctx, md); err != nil {
+			g.logger.Errorf("error getting outgoing context metadata: %v", err)
+			return nil, status.Errorf(codes.Internal, "error getting outgoing context metadata: %v", err)
+		}
+	}
+
+	message := "List of entitlements"
+
+	return &v0Roles.ListRoleEntitlementsResp{
+		Data:    permissions,
+		Status:  http.StatusOK,
+		Message: &message,
+	}, nil
+}
+
+func (g *GrpcHandler) UpdateRoleEntitlements(ctx context.Context, req *v0Roles.UpdateRoleEntitlementsReq) (*v0Roles.UpdateRoleEntitlementsResp, error) {
+	ctx, span := g.tracer.Start(ctx, "roles.GrpcHandler.UpdateRoleEntitlements")
+	defer span.End()
+
+	roleID := req.GetId()
+	if roleID == "" {
+		g.logger.Debugf("role ID is empty")
+		return nil, status.Errorf(codes.InvalidArgument, "role ID is empty")
+	}
+
+	permissions := make([]Permission, 0, len(req.GetEntitlementsPatchReq().GetUpdates()))
+
+	for _, permission := range req.GetEntitlementsPatchReq().GetUpdates() {
+		permissions = append(permissions, Permission{
+			Relation: permission.GetRelation(),
+			Object:   permission.GetObject(),
+		})
+	}
+
+	if err := g.svc.AssignPermissions(ctx, roleID, permissions...); err != nil {
+		g.logger.Errorf("failed to assign permissions: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to assign permissions: %v", err)
+	}
+
+	message := fmt.Sprintf("Updated permissions for role %s", roleID)
+
+	return &v0Roles.UpdateRoleEntitlementsResp{
+		Status:  http.StatusOK,
+		Message: &message,
+	}, nil
+}
+
+func (g *GrpcHandler) RemoveRoleEntitlement(ctx context.Context, req *v0Roles.RemoveRoleEntitlementReq) (*v0Roles.RemoveRoleEntitlementResp, error) {
+	ctx, span := g.tracer.Start(ctx, "roles.GrpcHandler.RemoveRoleEntitlement")
+	defer span.End()
+
+	roleID := req.GetId()
+	if roleID == "" {
+		g.logger.Errorf("role ID is empty")
+		return nil, status.Errorf(codes.InvalidArgument, "role ID is empty")
+	}
+
+	entitlementID := req.GetEntitlementId()
+	if entitlementID == "" {
+		g.logger.Errorf("entitlement ID is empty")
+		return nil, status.Errorf(codes.InvalidArgument, "entitlement ID is empty")
+	}
+
+	permission := authorization.NewURNFromURLParam(entitlementID)
+
+	err := g.svc.RemovePermissions(ctx, roleID, Permission{Relation: permission.Relation(), Object: permission.Object()})
+	if err != nil {
+		g.logger.Errorf("failed to remove permission %s from role %s: %v", permission.Relation(), roleID, err)
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to remove permission %s from role %s: %v",
+			permission.Relation(), roleID, err,
+		)
+	}
+
+	message := fmt.Sprintf("Removed permission %s for role %s", permission.Relation(), roleID)
+
+	return &v0Roles.RemoveRoleEntitlementResp{
+		Status:  http.StatusOK,
+		Message: &message,
+	}, nil
+}
+
+func (g *GrpcHandler) GetRoleGroups(ctx context.Context, req *v0Roles.GetRoleGroupsReq) (*v0Roles.GetRoleGroupsResp, error) {
+	ctx, span := g.tracer.Start(ctx, "roles.GrpcHandler.GetRoleGroups")
+	defer span.End()
+
+	roleID := req.GetId()
+	if roleID == "" {
+		g.logger.Debugf("role ID is empty")
+		return nil, status.Errorf(codes.InvalidArgument, "role ID is empty")
+	}
+
+	roles, err := g.svc.ListRoleGroups(ctx, roleID)
+	if err != nil {
+		g.logger.Errorf("failed to list role ID %s groups: %v", roleID, err)
+		return nil, status.Errorf(codes.Internal, "failed to list role ID %s groups: %v", roleID, err)
+	}
+
+	message := "List of groups"
+
+	return &v0Roles.GetRoleGroupsResp{
+		Data:    roles,
+		Status:  http.StatusOK,
+		Message: &message,
+	}, nil
+}
+
+func NewGrpcHandler(svc ServiceInterface, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *GrpcHandler {
+	g := new(GrpcHandler)
+
+	g.svc = svc
+	g.tracer = tracer
+	g.monitor = monitor
+	g.logger = logger
+
+	return g
+}

--- a/pkg/roles/gRPC_handlers_test.go
+++ b/pkg/roles/gRPC_handlers_test.go
@@ -1,0 +1,698 @@
+// Copyright 2025 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package roles
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	v0Roles "github.com/canonical/identity-platform-api/v0/roles"
+
+	"github.com/canonical/identity-platform-admin-ui/pkg/authentication"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package roles -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package roles -destination ./mock_interfaces.go -source=./interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package roles -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package roles -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+//go:generate mockgen -build_flags=--mod=mod -package roles -destination ./mock_validation.go -source=../../internal/validation/registry.go
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestListRoles(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name     string
+		expected *v0Roles.ListRolesResp
+		err      error
+	}{
+		{
+			name: "Successful list",
+			expected: &v0Roles.ListRolesResp{
+				Data:    []string{"admin", "user"},
+				Status:  http.StatusOK,
+				Message: strPtr("List of roles"),
+			},
+			err: nil,
+		},
+		{
+			name:     "Service error",
+			expected: nil,
+			err:      status.Errorf(codes.Internal, "failed to list roles"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockService := NewMockServiceInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockCtx := authentication.PrincipalContext(context.TODO(), &authentication.UserPrincipal{Email: "test-user"})
+
+			mockTracer.EXPECT().Start(gomock.Any(), "roles.GrpcHandler.ListRoles").Return(mockCtx, mockSpan)
+			if test.err != nil {
+				mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
+			}
+
+			var expectedData []string = nil
+			if test.expected != nil {
+				expectedData = test.expected.Data
+			}
+			mockService.EXPECT().ListRoles(gomock.Any(), gomock.Any()).Return(expectedData, test.err)
+
+			handler := NewGrpcHandler(mockService, mockTracer, mockMonitor, mockLogger)
+			resp, err := handler.ListRoles(mockCtx, &emptypb.Empty{})
+
+			if (err != nil) != (test.err != nil) {
+				t.Errorf("expected error: %v, got: %v", test.err, err)
+			}
+
+			if err == nil {
+				if resp.Status != test.expected.Status {
+					t.Errorf("expected status: %v, got: %v", test.expected.Status, resp.Status)
+				}
+				if !reflect.DeepEqual(resp.Data, test.expected.Data) {
+					t.Errorf("expected data: %v, got: %v", test.expected.Data, resp.Data)
+				}
+				if resp.Message == nil || *resp.Message != *test.expected.Message {
+					t.Errorf("expected message: %v, got: %v", *test.expected.Message, resp.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestGetRole(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name     string
+		req      *v0Roles.GetRoleReq
+		expected *v0Roles.GetRoleResp
+		err      error
+	}{
+		{
+			name: "Successful retrieval",
+			req:  &v0Roles.GetRoleReq{Id: "role1"},
+			expected: &v0Roles.GetRoleResp{
+				Data:    []*v0Roles.Role{{Id: "role1", Name: "role1"}},
+				Status:  http.StatusOK,
+				Message: strPtr("Role detail"),
+			},
+			err: nil,
+		},
+		{
+			name:     "Role not found",
+			req:      &v0Roles.GetRoleReq{Id: "unknown"},
+			expected: nil,
+			err:      status.Errorf(codes.NotFound, "role not found: unknown"),
+		},
+		{
+			name:     "Service error",
+			req:      &v0Roles.GetRoleReq{Id: "role1"},
+			expected: nil,
+			err:      status.Errorf(codes.Internal, "failed to retrieve role: role1"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockService := NewMockServiceInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockCtx := authentication.PrincipalContext(context.TODO(), &authentication.UserPrincipal{Email: "test-user"})
+
+			mockTracer.EXPECT().Start(gomock.Any(), "roles.GrpcHandler.GetRole").Return(mockCtx, mockSpan)
+
+			if test.name == "Role not found" {
+				mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any())
+			}
+
+			if test.name == "Service error" {
+				mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
+			}
+
+			var expectedRole *Role = nil
+			if test.expected != nil {
+				expectedRole = &Role{ID: test.expected.Data[0].Id, Name: test.expected.Data[0].Name}
+			}
+
+			if test.name == "Role not found" {
+				mockService.EXPECT().GetRole(gomock.Any(), gomock.Any(), test.req.GetId()).Return(nil, nil)
+			} else {
+				mockService.EXPECT().GetRole(gomock.Any(), gomock.Any(), test.req.GetId()).Return(expectedRole, test.err)
+			}
+
+			handler := NewGrpcHandler(mockService, mockTracer, mockMonitor, mockLogger)
+			resp, err := handler.GetRole(mockCtx, test.req)
+
+			if (err != nil) != (test.err != nil) {
+				t.Errorf("expected error: %v, got: %v", test.err, err)
+			}
+
+			if err == nil {
+				if resp.Status != test.expected.Status {
+					t.Errorf("expected status: %v, got: %v", test.expected.Status, resp.Status)
+				}
+				if !reflect.DeepEqual(resp.Data, test.expected.Data) {
+					t.Errorf("expected data: %v, got: %v", test.expected.Data, resp.Data)
+				}
+				if resp.Message == nil || *resp.Message != *test.expected.Message {
+					t.Errorf("expected message: %v, got: %v", *test.expected.Message, resp.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateRole(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name     string
+		req      *v0Roles.CreateRoleReq
+		expected *v0Roles.CreateRoleResp
+		err      error
+	}{
+		{
+			name: "Successful creation",
+			req:  &v0Roles.CreateRoleReq{Role: &v0Roles.Role{Name: "Admin"}},
+			expected: &v0Roles.CreateRoleResp{
+				Data:    []*v0Roles.Role{{Id: "role1", Name: "Admin"}},
+				Status:  http.StatusCreated,
+				Message: strPtr("Created role Admin"),
+			},
+			err: nil,
+		},
+		{
+			name:     "Empty role name",
+			req:      &v0Roles.CreateRoleReq{Role: &v0Roles.Role{Name: ""}},
+			expected: nil,
+			err:      status.Errorf(codes.InvalidArgument, "role name is empty"),
+		},
+		{
+			name:     "Service error",
+			req:      &v0Roles.CreateRoleReq{Role: &v0Roles.Role{Name: "Admin"}},
+			expected: nil,
+			err:      status.Errorf(codes.Internal, "failed to create role: some error"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockService := NewMockServiceInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockCtx := authentication.PrincipalContext(context.TODO(), &authentication.UserPrincipal{Email: "test-user"})
+
+			mockTracer.EXPECT().Start(gomock.Any(), "roles.GrpcHandler.CreateRole").Return(mockCtx, mockSpan)
+
+			if test.name == "Service error" {
+				mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
+			}
+
+			var createdRole *Role = nil
+			if test.expected != nil {
+				createdRole = &Role{ID: "role1", Name: test.expected.Data[0].Name}
+			}
+
+			if test.name != "Empty role name" {
+				mockService.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(createdRole, test.err)
+			}
+
+			handler := NewGrpcHandler(mockService, mockTracer, mockMonitor, mockLogger)
+			resp, err := handler.CreateRole(mockCtx, test.req)
+
+			if (err != nil) != (test.err != nil) {
+				t.Errorf("expected error: %v, got: %v", test.err, err)
+			}
+
+			if err == nil {
+				if resp.Status != test.expected.Status {
+					t.Errorf("expected status: %v, got: %v", test.expected.Status, resp.Status)
+				}
+				if !reflect.DeepEqual(resp.Data, test.expected.Data) {
+					t.Errorf("expected data: %v, got: %v", test.expected.Data, resp.Data)
+				}
+				if resp.Message == nil || *resp.Message != *test.expected.Message {
+					t.Errorf("expected message: %v, got: %v", *test.expected.Message, resp.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveRole(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name     string
+		req      *v0Roles.RemoveRoleReq
+		expected *v0Roles.RemoveRoleResp
+		err      error
+	}{
+		{
+			name: "Successful removal",
+			req:  &v0Roles.RemoveRoleReq{Id: "role1"},
+			expected: &v0Roles.RemoveRoleResp{
+				Status:  http.StatusOK,
+				Message: strPtr("Deleted role role1"),
+			},
+			err: nil,
+		},
+		{
+			name:     "Empty role ID",
+			req:      &v0Roles.RemoveRoleReq{Id: ""},
+			expected: nil,
+			err:      status.Errorf(codes.InvalidArgument, "role ID is empty"),
+		},
+		{
+			name:     "Service error",
+			req:      &v0Roles.RemoveRoleReq{Id: "role1"},
+			expected: nil,
+			err:      status.Errorf(codes.Internal, "failed to delete role: some error"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockService := NewMockServiceInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockCtx := authentication.PrincipalContext(context.TODO(), &authentication.UserPrincipal{Email: "test-user"})
+
+			mockTracer.EXPECT().Start(gomock.Any(), "roles.GrpcHandler.RemoveRole").Return(mockCtx, mockSpan)
+
+			if test.name == "Empty role ID" {
+				mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any())
+			} else if test.name == "Service error" {
+				mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
+			}
+
+			if test.name != "Empty role ID" {
+				mockService.EXPECT().DeleteRole(gomock.Any(), gomock.Any()).Return(test.err)
+			}
+
+			handler := NewGrpcHandler(mockService, mockTracer, mockMonitor, mockLogger)
+			resp, err := handler.RemoveRole(mockCtx, test.req)
+
+			if (err != nil) != (test.err != nil) {
+				t.Errorf("expected error: %v, got: %v", test.err, err)
+			}
+
+			if err == nil {
+				if resp.Status != test.expected.Status {
+					t.Errorf("expected status: %v, got: %v", test.expected.Status, resp.Status)
+				}
+				if resp.Message == nil || *resp.Message != *test.expected.Message {
+					t.Errorf("expected message: %v, got: %v", *test.expected.Message, resp.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestListRoleEntitlements(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name     string
+		req      *v0Roles.ListRoleEntitlementsReq
+		expected *v0Roles.ListRoleEntitlementsResp
+		err      error
+	}{
+		{
+			name: "Successful list",
+			req:  &v0Roles.ListRoleEntitlementsReq{Id: "role1"},
+			expected: &v0Roles.ListRoleEntitlementsResp{
+				Data:    []string{"can_view::identity:id1"},
+				Status:  http.StatusOK,
+				Message: strPtr("List of entitlements"),
+			},
+			err: nil,
+		},
+		{
+			name:     "Empty role ID",
+			req:      &v0Roles.ListRoleEntitlementsReq{Id: ""},
+			expected: nil,
+			err:      status.Errorf(codes.InvalidArgument, "role ID is empty"),
+		},
+		{
+			name:     "Paginator load error",
+			req:      &v0Roles.ListRoleEntitlementsReq{Id: "role1"},
+			expected: nil,
+			err:      status.Errorf(codes.Internal, "failed to load token paginator: some error"),
+		},
+		{
+			name:     "Service error",
+			req:      &v0Roles.ListRoleEntitlementsReq{Id: "role1"},
+			expected: nil,
+			err:      status.Errorf(codes.Internal, "failed to list entitlements for role role1, some error"),
+		},
+		{
+			name:     "Pagination metadata error",
+			req:      &v0Roles.ListRoleEntitlementsReq{Id: "role1"},
+			expected: nil,
+			err:      status.Errorf(codes.Internal, "error producing pagination metadata: some error"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockService := NewMockServiceInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockCtx := authentication.PrincipalContext(context.TODO(), &authentication.UserPrincipal{Email: "test-user"})
+
+			mockTracer.EXPECT().Start(gomock.Any(), gomock.Any()).AnyTimes().Return(mockCtx, mockSpan)
+
+			if test.name == "Empty role ID" {
+				mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any())
+			} else if test.name == "Paginator load error" || test.name == "Pagination metadata error" {
+				mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
+			} else if test.name == "Service error" {
+				mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any(), gomock.Any())
+			}
+
+			var serviceReturnValues []string
+			if test.expected != nil {
+				serviceReturnValues = test.expected.Data
+			}
+
+			if test.name != "Empty role ID" {
+				mockService.EXPECT().ListPermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(serviceReturnValues, nil, test.err)
+			}
+
+			handler := NewGrpcHandler(mockService, mockTracer, mockMonitor, mockLogger)
+			resp, err := handler.ListRoleEntitlements(mockCtx, test.req)
+
+			if (err != nil) != (test.err != nil) {
+				t.Errorf("expected error: %v, got: %v", test.err, err)
+			}
+
+			if err == nil {
+				if resp.Status != test.expected.Status {
+					t.Errorf("expected status: %v, got: %v", test.expected.Status, resp.Status)
+				}
+				if !reflect.DeepEqual(resp.Data, test.expected.Data) {
+					t.Errorf("expected data: %v, got: %v", test.expected.Data, resp.Data)
+				}
+				if resp.Message == nil || *resp.Message != *test.expected.Message {
+					t.Errorf("expected message: %v, got: %v", *test.expected.Message, resp.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateRoleEntitlements(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name     string
+		req      *v0Roles.UpdateRoleEntitlementsReq
+		expected *v0Roles.UpdateRoleEntitlementsResp
+		err      error
+	}{
+		{
+			name: "Successful update",
+			req: &v0Roles.UpdateRoleEntitlementsReq{
+				Id: "role1",
+				EntitlementsPatchReq: &v0Roles.Permissions{
+					Updates: []*v0Roles.Permission{
+						{Relation: "relation1", Object: "object1"},
+					},
+				},
+			},
+			expected: &v0Roles.UpdateRoleEntitlementsResp{
+				Status:  http.StatusOK,
+				Message: strPtr("Updated permissions for role role1"),
+			},
+			err: nil,
+		},
+		{
+			name: "Empty role ID",
+			req: &v0Roles.UpdateRoleEntitlementsReq{
+				Id: "",
+				EntitlementsPatchReq: &v0Roles.Permissions{
+					Updates: []*v0Roles.Permission{
+						{Relation: "relation1", Object: "object1"},
+					},
+				},
+			},
+			expected: nil,
+			err:      status.Errorf(codes.InvalidArgument, "role ID is empty"),
+		},
+		{
+			name: "Service error",
+			req: &v0Roles.UpdateRoleEntitlementsReq{
+				Id: "role1",
+				EntitlementsPatchReq: &v0Roles.Permissions{
+					Updates: []*v0Roles.Permission{
+						{Relation: "relation1", Object: "object1"},
+					},
+				},
+			},
+			expected: nil,
+			err:      status.Errorf(codes.Internal, "failed to assign permissions: some error"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockService := NewMockServiceInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockCtx := authentication.PrincipalContext(context.TODO(), &authentication.UserPrincipal{Email: "test-user"})
+
+			mockTracer.EXPECT().Start(gomock.Any(), "roles.GrpcHandler.UpdateRoleEntitlements").Return(mockCtx, mockSpan)
+
+			if test.name == "Empty role ID" {
+				mockLogger.EXPECT().Debugf(gomock.Any())
+			} else if test.name == "Service error" {
+				mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
+			}
+
+			if test.name != "Empty role ID" {
+				mockService.EXPECT().AssignPermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(test.err)
+			}
+
+			handler := NewGrpcHandler(mockService, mockTracer, mockMonitor, mockLogger)
+			resp, err := handler.UpdateRoleEntitlements(mockCtx, test.req)
+
+			if (err != nil) != (test.err != nil) {
+				t.Errorf("expected error: %v, got: %v", test.err, err)
+			}
+
+			if err == nil {
+				if resp.Status != test.expected.Status {
+					t.Errorf("expected status: %v, got: %v", test.expected.Status, resp.Status)
+				}
+				if resp.Message == nil || *resp.Message != *test.expected.Message {
+					t.Errorf("expected message: %v, got: %v", *test.expected.Message, resp.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveRoleEntitlement(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name     string
+		req      *v0Roles.RemoveRoleEntitlementReq
+		expected *v0Roles.RemoveRoleEntitlementResp
+		err      error
+	}{
+		{
+			name: "Successful removal",
+			req: &v0Roles.RemoveRoleEntitlementReq{
+				Id:            "role1",
+				EntitlementId: "can_edit::client:okta",
+			},
+			expected: &v0Roles.RemoveRoleEntitlementResp{
+				Status:  http.StatusOK,
+				Message: strPtr("Removed permission can_edit for role role1"),
+			},
+			err: nil,
+		},
+		{
+			name: "Empty role ID",
+			req: &v0Roles.RemoveRoleEntitlementReq{
+				Id:            "",
+				EntitlementId: "can_edit::client:okta",
+			},
+			expected: nil,
+			err:      status.Errorf(codes.InvalidArgument, "role ID is empty"),
+		},
+		{
+			name: "Empty entitlement ID",
+			req: &v0Roles.RemoveRoleEntitlementReq{
+				Id:            "role1",
+				EntitlementId: "",
+			},
+			expected: nil,
+			err:      status.Errorf(codes.InvalidArgument, "entitlement ID is empty"),
+		},
+		{
+			name: "Service error",
+			req: &v0Roles.RemoveRoleEntitlementReq{
+				Id:            "role1",
+				EntitlementId: "can_edit::client:okta",
+			},
+			expected: nil,
+			err:      status.Errorf(codes.Internal, "failed to remove permission relation1 from role role1: some error"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockService := NewMockServiceInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockCtx := authentication.PrincipalContext(context.TODO(), &authentication.UserPrincipal{Email: "test-user"})
+
+			mockTracer.EXPECT().Start(gomock.Any(), "roles.GrpcHandler.RemoveRoleEntitlement").Return(mockCtx, mockSpan)
+
+			if test.name == "Empty role ID" || test.name == "Empty entitlement ID" {
+				mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
+			} else if test.name == "Service error" {
+				mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
+			}
+
+			if test.name != "Empty role ID" && test.name != "Empty entitlement ID" {
+				mockService.EXPECT().RemovePermissions(gomock.Any(), gomock.Any(), gomock.Any()).Return(test.err)
+			}
+
+			handler := NewGrpcHandler(mockService, mockTracer, mockMonitor, mockLogger)
+			resp, err := handler.RemoveRoleEntitlement(mockCtx, test.req)
+
+			if (err != nil) != (test.err != nil) {
+				t.Errorf("expected error: %v, got: %v", test.err, err)
+			}
+
+			if err == nil {
+				if !reflect.DeepEqual(resp, test.expected) {
+					t.Errorf("expected: %v, got: %v", test.expected, resp)
+				}
+			}
+		})
+	}
+}
+
+func TestGetRoleGroups(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name     string
+		req      *v0Roles.GetRoleGroupsReq
+		expected *v0Roles.GetRoleGroupsResp
+		err      error
+	}{
+		{
+			name: "Successful retrieval",
+			req:  &v0Roles.GetRoleGroupsReq{Id: "role1"},
+			expected: &v0Roles.GetRoleGroupsResp{
+				Data:    []string{"group1"},
+				Status:  http.StatusOK,
+				Message: strPtr("List of groups"),
+			},
+			err: nil,
+		},
+		{
+			name:     "Empty role ID",
+			req:      &v0Roles.GetRoleGroupsReq{Id: ""},
+			expected: nil,
+			err:      status.Errorf(codes.InvalidArgument, "role ID is empty"),
+		},
+		{
+			name:     "Service error",
+			req:      &v0Roles.GetRoleGroupsReq{Id: "role1"},
+			expected: nil,
+			err:      status.Errorf(codes.Internal, "failed to list role ID role1 groups: some error"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockService := NewMockServiceInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockCtx := authentication.PrincipalContext(context.TODO(), &authentication.UserPrincipal{Email: "test-user"})
+
+			mockTracer.EXPECT().Start(gomock.Any(), "roles.GrpcHandler.GetRoleGroups").Return(mockCtx, mockSpan)
+
+			if test.name == "Empty role ID" {
+				mockLogger.EXPECT().Debugf(gomock.Any())
+			} else if test.name == "Service error" {
+				mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
+			}
+
+			if test.name != "Empty role ID" {
+				var expectedData []string = nil
+				if test.expected != nil {
+					expectedData = test.expected.Data
+				}
+				mockService.EXPECT().ListRoleGroups(gomock.Any(), gomock.Any()).Return(expectedData, test.err)
+			}
+
+			handler := NewGrpcHandler(mockService, mockTracer, mockMonitor, mockLogger)
+			resp, err := handler.GetRoleGroups(mockCtx, test.req)
+
+			if (err != nil) != (test.err != nil) {
+				t.Errorf("expected error: %v, got: %v", test.err, err)
+			}
+
+			if err == nil {
+				if !reflect.DeepEqual(resp, test.expected) {
+					t.Errorf("expected: %v, got: %v", test.expected, resp)
+				}
+			}
+		})
+	}
+}

--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -139,7 +139,7 @@ func (a *API) handleDetail(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(
 		types.Response{
 			Data:    []Role{*role},
-			Message: "Rule detail",
+			Message: "Role detail",
 			Status:  http.StatusOK,
 		},
 	)

--- a/pkg/roles/handlers_test.go
+++ b/pkg/roles/handlers_test.go
@@ -173,7 +173,7 @@ func TestHandleList(t *testing.T) {
 //     "data": [
 //         "administrator"
 //     ],
-//     "message": "Rule detail",
+//     "message": "Role detail",
 //     "status": 200
 // }
 
@@ -202,7 +202,7 @@ func TestHandleDetail(t *testing.T) {
 					ID:   "administrator",
 					Name: "administrator",
 				}},
-				Message: "Rule detail",
+				Message: "Role detail",
 				Status:  http.StatusOK,
 			},
 		},


### PR DESCRIPTION
## Description
This PR introduces the first API (Roles) based on the gRPC-gateway implementation from the generated code in https://github.com/canonical/identity-platform-api.

The gRPC_mapper.go file contains two functions needed to make sure the new APIs match the existing one.
- `SetHeaderFromMetadataFilter` is needed to make sure that response headers are set on the response object
- `ForwardErrorResponseRewriter` is needed to make sure error responses match the ones from the rest of the APIs

The gRPC_handlers.go contains the gRPC handlers implementations, mimicing what has been done for the handlers.go.

Test have been added for every new piece of code.

### Other changes
- `Response` object has been enriched with `omitempty` to avoid serializing nil values
- fixed a typo in the word "Rule" which is supposed to be "Role"