### PR TITLE
IAM-1319 Migrate Status API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/canonical/identity-platform-admin-ui
 go 1.24.0
 
 require (
-	github.com/canonical/identity-platform-api v0.0.0-20250314142936-a6a2b2d1f0c0
+	github.com/canonical/identity-platform-api v0.0.0-20250325161223-af7476dafc9b
 	github.com/canonical/rebac-admin-ui-handlers v0.1.0
 	github.com/coreos/go-oidc/v3 v3.10.0
 	github.com/go-chi/chi/v5 v5.0.12

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/canonical/identity-platform-api v0.0.0-20250313151502-c4756095b0ac h1
 github.com/canonical/identity-platform-api v0.0.0-20250313151502-c4756095b0ac/go.mod h1:C6zhDB2TE3TwA9UfDzAy3RlgU3YgOWuRoRyfl7po4Y4=
 github.com/canonical/identity-platform-api v0.0.0-20250314142936-a6a2b2d1f0c0 h1:l60uywVNngXSYB4Eppa2ChqxMi5xUb1Pz+Zk1kGYfNQ=
 github.com/canonical/identity-platform-api v0.0.0-20250314142936-a6a2b2d1f0c0/go.mod h1:C6zhDB2TE3TwA9UfDzAy3RlgU3YgOWuRoRyfl7po4Y4=
+github.com/canonical/identity-platform-api v0.0.0-20250325161223-af7476dafc9b h1:tF+fSdTcao/haTlJzVRWd//QAHksnp53NQRVOHlzA6E=
+github.com/canonical/identity-platform-api v0.0.0-20250325161223-af7476dafc9b/go.mod h1:C6zhDB2TE3TwA9UfDzAy3RlgU3YgOWuRoRyfl7po4Y4=
 github.com/canonical/rebac-admin-ui-handlers v0.1.0 h1:Bef1N/RgQine8hHX4ZMksQz/1VKsy4DHK2XdhAzQsZs=
 github.com/canonical/rebac-admin-ui-handlers v0.1.0/go.mod h1:EIdBoaTHWYPkzNeUeXUBueJkglN9nQz5HLIvaOT7o1k=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=

--- a/pkg/status/gRPC_handlers.go
+++ b/pkg/status/gRPC_handlers.go
@@ -1,0 +1,67 @@
+// Copyright 2025 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package status
+
+import (
+	"context"
+
+	v0Status "github.com/canonical/identity-platform-api/v0/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
+)
+
+type GrpcHandler struct {
+	// UnimplementedStatusServiceServer must be embedded to get forward compatible implementations.
+	v0Status.UnimplementedStatusServiceServer
+
+	logger  logging.LoggerInterface
+	tracer  tracing.TracingInterface
+	monitor monitoring.MonitorInterface
+}
+
+func (g *GrpcHandler) GetStatus(ctx context.Context, _ *emptypb.Empty) (*v0Status.Status, error) {
+	ctx, span := g.tracer.Start(ctx, "status.GrpcHandler.GetStatus")
+	defer span.End()
+
+	status := &v0Status.Status{
+		Status:    "Ok",
+		BuildInfo: v0StatusBuildInfo(),
+	}
+
+	return status, nil
+}
+
+func (g *GrpcHandler) GetVersion(ctx context.Context, _ *emptypb.Empty) (*v0Status.BuildInfo, error) {
+	ctx, span := g.tracer.Start(ctx, "status.GrpcHandler.GetVersion")
+	defer span.End()
+
+	return v0StatusBuildInfo(), nil
+}
+
+func v0StatusBuildInfo() *v0Status.BuildInfo {
+	var ret *v0Status.BuildInfo = nil
+
+	if info := buildInfo(); info != nil {
+		ret = &v0Status.BuildInfo{
+			Version:    info.Version,
+			CommitHash: info.CommitHash,
+			Name:       info.Name,
+		}
+	}
+
+	return ret
+}
+
+func NewGrpcHandler(tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *GrpcHandler {
+	g := new(GrpcHandler)
+
+	g.tracer = tracer
+	g.monitor = monitor
+	g.logger = logger
+
+	return g
+}

--- a/pkg/status/gRPC_handlers_test.go
+++ b/pkg/status/gRPC_handlers_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package status
+
+import (
+	"context"
+	"testing"
+
+	v0Status "github.com/canonical/identity-platform-api/v0/status"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/mock/gomock"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package status -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package status -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package status -destination ./mock_tracer.go 	go.opentelemetry.io/otel/trace Tracer
+
+func TestGrpcHandler_GetStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name string
+		want *v0Status.Status
+	}{
+		{
+			name: "Status OK",
+			want: &v0Status.Status{
+				Status: "Ok",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockTracer.EXPECT().Start(gomock.Any(), "status.GrpcHandler.GetStatus").Return(context.TODO(), mockSpan)
+
+			g := NewGrpcHandler(mockTracer, mockMonitor, mockLogger)
+
+			got, _ := g.GetStatus(context.TODO(), nil)
+
+			if got.GetStatus() != tt.want.GetStatus() {
+				t.Errorf("expected status: %v, got %v", tt.want.GetStatus(), got.GetStatus())
+			}
+		})
+	}
+}

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -9,6 +9,7 @@ import (
 
 	v0Groups "github.com/canonical/identity-platform-api/v0/groups"
 	v0Roles "github.com/canonical/identity-platform-api/v0/roles"
+	v0Status "github.com/canonical/identity-platform-api/v0/status"
 	v1 "github.com/canonical/rebac-admin-ui-handlers/v1"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-chi/chi/v5"
@@ -110,7 +111,7 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 
 	router.Use(middlewares...)
 
-	statusAPI := status.NewAPI(tracer, monitor, logger)
+	//statusAPI := status.NewAPI(tracer, monitor, logger)
 	metricsAPI := metrics.NewAPI(logger)
 
 	identitiesAPI := identities.NewAPI(
@@ -209,7 +210,7 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 	}
 
 	// register endpoints as last step
-	statusAPI.RegisterEndpoints(apiRouter)
+	//statusAPI.RegisterEndpoints(apiRouter)
 	metricsAPI.RegisterEndpoints(apiRouter)
 
 	identitiesAPI.RegisterEndpoints(apiRouter)
@@ -237,8 +238,15 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 		panic(err)
 	}
 
+	err = v0Status.RegisterStatusServiceHandlerServer(context.Background(), gRPCGatewayMux, status.NewGrpcHandler(tracer, monitor, logger))
+	if err != nil {
+		panic(err)
+	}
+
 	apiRouter.Mount("/api/v0/roles", gRPCGatewayMux)
 	apiRouter.Mount("/api/v0/groups", gRPCGatewayMux)
+	apiRouter.Mount("/api/v0/status", gRPCGatewayMux)
+	apiRouter.Mount("/api/v0/version", gRPCGatewayMux)
 	/********* gRPC gateway integration **********/
 
 	if oauth2Config.Enabled {


### PR DESCRIPTION
## Description
Port Status API to protobuf based/gRPC gateway based implementation.

Builds on top of https://github.com/canonical/identity-platform-api/pull/16