### PR TITLE
IAM-1320 "Migrate" metrics api

### DIFF
--- a/pkg/metrics/handlers.go
+++ b/pkg/metrics/handlers.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd
+// Copyright 2025 Canonical Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 
 package metrics
@@ -22,6 +22,12 @@ func (a *API) RegisterEndpoints(mux *chi.Mux) {
 
 func (a *API) prometheusHTTP(w http.ResponseWriter, r *http.Request) {
 	promhttp.Handler().ServeHTTP(w, r)
+}
+
+func (a *API) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		a.prometheusHTTP(w, r)
+	})
 }
 
 func NewAPI(logger logging.LoggerInterface) *API {

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -211,7 +211,7 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 
 	// register endpoints as last step
 	//statusAPI.RegisterEndpoints(apiRouter)
-	metricsAPI.RegisterEndpoints(apiRouter)
+	//metricsAPI.RegisterEndpoints(apiRouter)
 
 	identitiesAPI.RegisterEndpoints(apiRouter)
 	clientsAPI.RegisterEndpoints(apiRouter)
@@ -247,6 +247,7 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 	apiRouter.Mount("/api/v0/groups", gRPCGatewayMux)
 	apiRouter.Mount("/api/v0/status", gRPCGatewayMux)
 	apiRouter.Mount("/api/v0/version", gRPCGatewayMux)
+	apiRouter.Mount("/api/v0/metrics", metricsAPI.Handler())
 	/********* gRPC gateway integration **********/
 
 	if oauth2Config.Enabled {


### PR DESCRIPTION
## Description
This PR doesn't really migrate metrics API. What it does is
- exposing an `http.Handler` for ease of registration, which wraps the current metrics handler
  - this allows us to have a final version of the ported APIs that will allow us to tidy up the registration for all API without having broken down pieces added to the mux as we're doing right now with the new mux for the gRPC gateway