### PR TITLE
IAM-1315 Port identities api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/canonical/identity-platform-admin-ui
 go 1.24.0
 
 require (
-	github.com/canonical/identity-platform-api v0.0.0-20250325161223-af7476dafc9b
+	github.com/canonical/identity-platform-api v0.0.0-20250409090411-c09b61da80d5
 	github.com/canonical/rebac-admin-ui-handlers v0.1.0
 	github.com/coreos/go-oidc/v3 v3.10.0
 	github.com/go-chi/chi/v5 v5.0.12

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,12 @@ github.com/canonical/identity-platform-api v0.0.0-20250314142936-a6a2b2d1f0c0 h1
 github.com/canonical/identity-platform-api v0.0.0-20250314142936-a6a2b2d1f0c0/go.mod h1:C6zhDB2TE3TwA9UfDzAy3RlgU3YgOWuRoRyfl7po4Y4=
 github.com/canonical/identity-platform-api v0.0.0-20250325161223-af7476dafc9b h1:tF+fSdTcao/haTlJzVRWd//QAHksnp53NQRVOHlzA6E=
 github.com/canonical/identity-platform-api v0.0.0-20250325161223-af7476dafc9b/go.mod h1:C6zhDB2TE3TwA9UfDzAy3RlgU3YgOWuRoRyfl7po4Y4=
+github.com/canonical/identity-platform-api v0.0.0-20250407091622-42d63c7f78c6 h1:tWRriZLl0EnVT/hrjvAOmcDo2u3WPg7pTVjBAwxwDao=
+github.com/canonical/identity-platform-api v0.0.0-20250407091622-42d63c7f78c6/go.mod h1:C6zhDB2TE3TwA9UfDzAy3RlgU3YgOWuRoRyfl7po4Y4=
+github.com/canonical/identity-platform-api v0.0.0-20250409084952-7c95f69776ea h1:vPA4HvOM4OXMHxXU0CXyg/6ZqqonBsjQSkA99ffBD/A=
+github.com/canonical/identity-platform-api v0.0.0-20250409084952-7c95f69776ea/go.mod h1:C6zhDB2TE3TwA9UfDzAy3RlgU3YgOWuRoRyfl7po4Y4=
+github.com/canonical/identity-platform-api v0.0.0-20250409090411-c09b61da80d5 h1:MuZiXMFqAc5IiVhn7tOxFYM9ahOpereVQ/lxo9nuzRY=
+github.com/canonical/identity-platform-api v0.0.0-20250409090411-c09b61da80d5/go.mod h1:C6zhDB2TE3TwA9UfDzAy3RlgU3YgOWuRoRyfl7po4Y4=
 github.com/canonical/rebac-admin-ui-handlers v0.1.0 h1:Bef1N/RgQine8hHX4ZMksQz/1VKsy4DHK2XdhAzQsZs=
 github.com/canonical/rebac-admin-ui-handlers v0.1.0/go.mod h1:EIdBoaTHWYPkzNeUeXUBueJkglN9nQz5HLIvaOT7o1k=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=

--- a/pkg/groups/gRPC_handlers.go
+++ b/pkg/groups/gRPC_handlers.go
@@ -26,7 +26,7 @@ import (
 
 type GrpcHandler struct {
 	svc ServiceInterface
-	// UnimplementedRolesServiceServer must be embedded to get forward compatible implementations.
+	// UnimplementedGroupsServiceServer must be embedded to get forward compatible implementations.
 	v0Groups.UnimplementedGroupsServiceServer
 
 	logger  logging.LoggerInterface

--- a/pkg/identities/gRPC_handlers.go
+++ b/pkg/identities/gRPC_handlers.go
@@ -1,0 +1,232 @@
+// Copyright 2025 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package identities
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	v0Types "github.com/canonical/identity-platform-api/v0/http"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+	"github.com/canonical/identity-platform-admin-ui/internal/monitoring"
+	"github.com/canonical/identity-platform-admin-ui/internal/tracing"
+
+	v0Identities "github.com/canonical/identity-platform-api/v0/identities"
+)
+
+const DEFAULT_PAGINATION_SIZE = 100
+
+type GrpcHandler struct {
+	svc    ServiceInterface
+	mapper *GrpcPbMapper
+	// UnimplementedIdentitiesServiceServer must be embedded to get forward compatible implementations.
+	v0Identities.UnimplementedIdentitiesServiceServer
+
+	logger  logging.LoggerInterface
+	tracer  tracing.TracingInterface
+	monitor monitoring.MonitorInterface
+}
+
+func (g *GrpcHandler) ListIdentities(ctx context.Context, req *v0Identities.ListIdentitiesReq) (*v0Identities.ListIdentitiesResp, error) {
+	ctx, span := g.tracer.Start(ctx, "identities.GrpcHandler.ListIdentities")
+	defer span.End()
+
+	credID := req.GetCredID()
+	if credID == "" {
+		g.logger.Debug("credID is empty")
+		return nil, status.Error(codes.InvalidArgument, "credID is empty")
+	}
+
+	var pageSize int64 = DEFAULT_PAGINATION_SIZE
+	if req.GetSize() != "" {
+		size, err := strconv.ParseInt(req.GetSize(), 10, 64)
+		if err != nil {
+			g.logger.Debug("page size parameter is not an int")
+			return nil, status.Errorf(codes.InvalidArgument, "page size parameter is not an int, %v", err)
+		}
+
+		pageSize = size
+	}
+
+	identities, err := g.svc.ListIdentities(ctx, pageSize, req.GetPageToken(), credID)
+	if err != nil {
+		g.logger.Errorf("failed to list identities, %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to list identities, %v", err)
+	}
+
+	mappedIdentities, err := g.mapper.FromIdentitiesModel(identities.Identities)
+	if err != nil {
+		g.logger.Errorf("failed to map from identities, %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to map from identities, %v", err)
+	}
+
+	message := "List of identities"
+
+	next := identities.Tokens.Next
+	prev := identities.Tokens.Prev
+
+	return &v0Identities.ListIdentitiesResp{
+		Data:    mappedIdentities,
+		Status:  http.StatusOK,
+		Message: &message,
+		XMeta: &v0Types.Pagination{
+			Size: int32(len(identities.Identities)),
+			Next: &next,
+			Prev: &prev,
+		},
+	}, nil
+}
+
+func (g *GrpcHandler) GetIdentity(ctx context.Context, req *v0Identities.GetIdentityReq) (*v0Identities.GetIdentityResp, error) {
+	ctx, span := g.tracer.Start(ctx, "identities.GrpcHandler.GetIdentity")
+	defer span.End()
+
+	id := req.GetId()
+
+	identities, err := g.svc.GetIdentity(ctx, id)
+	if err != nil {
+		g.logger.Errorf("failed to get identity %s, %v", id, err)
+		return nil, status.Errorf(codes.Internal, "failed to get identity %s, %v", id, err)
+	}
+
+	mappedIdentities, err := g.mapper.FromIdentitiesModel(identities.Identities)
+	if err != nil {
+		g.logger.Errorf("failed to map from identities, %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to map from identities, %v", err)
+	}
+
+	message := "Identity detail"
+
+	return &v0Identities.GetIdentityResp{
+		Data:    mappedIdentities,
+		Status:  http.StatusOK,
+		Message: &message,
+	}, nil
+}
+
+func (g *GrpcHandler) CreateIdentity(ctx context.Context, req *v0Identities.CreateIdentityReq) (*v0Identities.CreateIdentityResp, error) {
+	ctx, span := g.tracer.Start(ctx, "identities.GrpcHandler.CreateIdentity")
+	defer span.End()
+
+	createIdentityBody := req.GetIdentity()
+
+	mappedCreateIdentityBody, err := g.mapper.ToCreateIdentityModel(createIdentityBody)
+	if err != nil {
+		g.logger.Errorf("failed to map to createIdentityBody, %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to map to createIdentityBody, %v", err)
+	}
+
+	identities, err := g.svc.CreateIdentity(ctx, mappedCreateIdentityBody)
+	if err != nil {
+		g.logger.Errorf("failed to create identity, %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to create identity, %v", err)
+	}
+
+	err = g.svc.SendUserCreationEmail(ctx, &identities.Identities[0])
+	if err != nil {
+		g.logger.Errorf("failed to send user creation email, %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to send user creation email, %v", err)
+	}
+
+	mappedIdentities, err := g.mapper.FromIdentitiesModel(identities.Identities)
+	if err != nil {
+		g.logger.Errorf("failed to map from identities, %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to map from identities, %v", err)
+	}
+
+	message := "Created identity"
+
+	return &v0Identities.CreateIdentityResp{
+		Data:    mappedIdentities,
+		Status:  http.StatusCreated,
+		Message: &message,
+	}, nil
+}
+
+func (g *GrpcHandler) UpdateIdentity(ctx context.Context, req *v0Identities.UpdateIdentityReq) (*v0Identities.UpdateIdentityResp, error) {
+	ctx, span := g.tracer.Start(ctx, "identities.GrpcHandler.UpdateIdentity")
+	defer span.End()
+
+	id := req.GetId()
+	if id == "" {
+		g.logger.Debug("identity ID is empty")
+		return nil, status.Error(codes.InvalidArgument, "identity ID is empty")
+	}
+
+	updateIdentityBody := req.GetIdentity()
+
+	mappedUpdateIdentityBody, err := g.mapper.ToUpdateIdentityModel(updateIdentityBody)
+	if err != nil {
+		g.logger.Errorf("failed to map to updateIdentityBody, %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to map to updateIdentityBody, %v", err)
+	}
+
+	identities, err := g.svc.UpdateIdentity(ctx, id, mappedUpdateIdentityBody)
+	if err != nil {
+		g.logger.Errorf("failed to update identity %s, %v", id, err)
+		return nil, status.Errorf(codes.Internal, "failed to update identity %s, %v", id, err)
+	}
+
+	mappedIdentities, err := g.mapper.FromIdentitiesModel(identities.Identities)
+	if err != nil {
+		g.logger.Errorf("failed to map from identities, %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to map from identities, %v", err)
+	}
+
+	message := "Updated identity"
+
+	return &v0Identities.UpdateIdentityResp{
+		Data:    mappedIdentities,
+		Status:  http.StatusOK,
+		Message: &message,
+	}, nil
+}
+
+func (g *GrpcHandler) RemoveIdentity(ctx context.Context, req *v0Identities.RemoveIdentityReq) (*v0Identities.RemoveIdentityResp, error) {
+	ctx, span := g.tracer.Start(ctx, "identities.GrpcHandler.RemoveIdentity")
+	defer span.End()
+
+	id := req.GetId()
+	if id == "" {
+		g.logger.Debug("identity ID is empty")
+		return nil, status.Error(codes.InvalidArgument, "identity ID is empty")
+	}
+
+	identities, err := g.svc.DeleteIdentity(ctx, id)
+	if err != nil {
+		g.logger.Errorf("failed to delete identity %s, %v", id, err)
+		return nil, status.Errorf(codes.Internal, "failed to delete identity %s, %v", id, err)
+	}
+
+	mappedIdentities, err := g.mapper.FromIdentitiesModel(identities.Identities)
+	if err != nil {
+		g.logger.Errorf("failed to map from identities, %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to map from identities, %v", err)
+	}
+
+	message := "Identity deleted"
+
+	return &v0Identities.RemoveIdentityResp{
+		Data:    mappedIdentities,
+		Status:  http.StatusOK,
+		Message: &message,
+	}, nil
+}
+
+func NewGrpcHandler(svc ServiceInterface, mapper *GrpcPbMapper, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *GrpcHandler {
+	g := new(GrpcHandler)
+
+	g.svc = svc
+	g.mapper = mapper
+
+	g.tracer = tracer
+	g.monitor = monitor
+	g.logger = logger
+
+	return g
+}

--- a/pkg/identities/gRPC_handlers_test.go
+++ b/pkg/identities/gRPC_handlers_test.go
@@ -1,0 +1,528 @@
+// Copyright 2025 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package identities
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	v0Types "github.com/canonical/identity-platform-api/v0/http"
+	v0Identities "github.com/canonical/identity-platform-api/v0/identities"
+	kClient "github.com/ory/kratos-client-go"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/http/types"
+	"github.com/canonical/identity-platform-admin-ui/pkg/authentication"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package identities -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package identities -destination ./mock_interfaces.go -source=./interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package identities -destination ./mock_monitor.go -source=../../internal/monitoring/interfaces.go
+//go:generate mockgen -build_flags=--mod=mod -package identities -destination ./mock_tracing.go go.opentelemetry.io/otel/trace Tracer
+
+func ptr(s string) *string {
+	return &s
+}
+
+func TestGrpcHandler_ListIdentities(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockState := "mock-state"
+
+	tests := []struct {
+		name      string
+		req       *v0Identities.ListIdentitiesReq
+		mockSetup func(mockService *MockServiceInterface, mockLogger *MockLoggerInterface)
+		want      *v0Identities.ListIdentitiesResp
+		err       error
+	}{
+		{
+			name: "Success",
+			req: &v0Identities.ListIdentitiesReq{
+				CredID: "123",
+				Size:   ptr("2"),
+			},
+			mockSetup: func(mockService *MockServiceInterface, mockLogger *MockLoggerInterface) {
+				mockService.EXPECT().ListIdentities(gomock.Any(), int64(2), "", "123").
+					Return(&IdentityData{
+						Identities: []kClient.Identity{
+							{Id: "1", State: &mockState, OrganizationId: kClient.NullableString{}},
+							{Id: "2", State: &mockState, OrganizationId: kClient.NullableString{}},
+						},
+						Tokens: types.NavigationTokens{Next: "next", Prev: "prev"},
+					}, nil)
+			},
+			want: &v0Identities.ListIdentitiesResp{
+				Data: []*v0Identities.Identity{
+					{Id: "1", State: &mockState, OrganizationId: &v0Identities.NullableString{}},
+					{Id: "2", State: &mockState, OrganizationId: &v0Identities.NullableString{}},
+				},
+				Status:  http.StatusOK,
+				Message: ptr("List of identities"),
+				XMeta: &v0Types.Pagination{
+					Size: 2,
+					Next: ptr("next"),
+					Prev: ptr("prev"),
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "empty credID",
+			req:  &v0Identities.ListIdentitiesReq{},
+			mockSetup: func(_ *MockServiceInterface, mockLogger *MockLoggerInterface) {
+				mockLogger.EXPECT().Debug("credID is empty")
+			},
+			want: nil,
+			err:  status.Error(codes.InvalidArgument, "credID is empty"),
+		},
+		{
+			name: "invalid page size format",
+			req: &v0Identities.ListIdentitiesReq{
+				CredID: "123",
+				Size:   ptr("not-an-int"),
+			},
+			mockSetup: func(_ *MockServiceInterface, mockLogger *MockLoggerInterface) {
+				mockLogger.EXPECT().Debug("page size parameter is not an int")
+			},
+			want: nil,
+			err:  status.Error(codes.InvalidArgument, "page size parameter is not an int, strconv.ParseInt: parsing \"not-an-int\": invalid syntax"),
+		},
+		{
+			name: "ListIdentities service returns error",
+			req: &v0Identities.ListIdentitiesReq{
+				CredID: "123",
+				Size:   ptr("10"),
+			},
+			mockSetup: func(mockService *MockServiceInterface, mockLogger *MockLoggerInterface) {
+				mockService.EXPECT().ListIdentities(gomock.Any(), int64(10), "", "123").
+					Return(nil, fmt.Errorf("db error"))
+				mockLogger.EXPECT().Errorf("failed to list identities, %v", gomock.Any())
+			},
+			want: nil,
+			err:  status.Error(codes.Internal, "failed to list identities, db error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := NewMockServiceInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockCtx := authentication.PrincipalContext(context.TODO(), &authentication.UserPrincipal{Email: "test-user"})
+			mockTracer.EXPECT().Start(gomock.Any(), "identities.GrpcHandler.ListIdentities").Return(mockCtx, mockSpan)
+
+			tt.mockSetup(mockService, mockLogger)
+
+			g := NewGrpcHandler(mockService, NewGrpcMapper(mockLogger), mockTracer, mockMonitor, mockLogger)
+
+			got, err := g.ListIdentities(context.TODO(), tt.req)
+			if err != nil && err.Error() != tt.err.Error() {
+				t.Errorf("ListIdentities() error = %v, want %v", err, tt.err)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ListIdentities() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGrpcHandler_GetIdentity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockState := "mock-state"
+
+	tests := []struct {
+		name      string
+		req       *v0Identities.GetIdentityReq
+		mockSetup func(mockService *MockServiceInterface, mockLogger *MockLoggerInterface)
+		want      *v0Identities.GetIdentityResp
+		err       error
+	}{
+		{
+			name: "Success",
+			req:  &v0Identities.GetIdentityReq{Id: "identity-1"},
+			mockSetup: func(mockService *MockServiceInterface, _ *MockLoggerInterface) {
+				mockService.EXPECT().
+					GetIdentity(gomock.Any(), "identity-1").
+					Return(&IdentityData{
+						Identities: []kClient.Identity{
+							{Id: "identity-1", State: &mockState, OrganizationId: kClient.NullableString{}},
+						},
+					}, nil)
+			},
+			want: &v0Identities.GetIdentityResp{
+				Data: []*v0Identities.Identity{
+					{Id: "identity-1", State: &mockState, OrganizationId: &v0Identities.NullableString{}},
+				},
+				Status:  http.StatusOK,
+				Message: ptr("Identity detail"),
+			},
+			err: nil,
+		},
+		{
+			name: "Service returns error",
+			req:  &v0Identities.GetIdentityReq{Id: "identity-2"},
+			mockSetup: func(mockService *MockServiceInterface, mockLogger *MockLoggerInterface) {
+				mockService.EXPECT().
+					GetIdentity(gomock.Any(), "identity-2").
+					Return(nil, fmt.Errorf("db failure"))
+
+				mockLogger.EXPECT().
+					Errorf("failed to get identity %s, %v", "identity-2", gomock.Any())
+			},
+			want: nil,
+			err:  status.Error(codes.Internal, "failed to get identity identity-2, db failure"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := NewMockServiceInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockCtx := authentication.PrincipalContext(context.TODO(), &authentication.UserPrincipal{Email: "test-user"})
+			mockTracer.EXPECT().Start(gomock.Any(), "identities.GrpcHandler.GetIdentity").Return(mockCtx, mockSpan)
+
+			tt.mockSetup(mockService, mockLogger)
+
+			g := NewGrpcHandler(mockService, NewGrpcMapper(mockLogger), mockTracer, mockMonitor, mockLogger)
+
+			got, err := g.GetIdentity(context.TODO(), tt.req)
+			if err != nil && err.Error() != tt.err.Error() {
+				t.Errorf("GetIdentity() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetIdentity() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGrpcHandler_CreateIdentity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockState := "mock-state"
+	mockSchemaId := "new-schema-id"
+
+	tests := []struct {
+		name      string
+		req       *v0Identities.CreateIdentityReq
+		mockSetup func(mockService *MockServiceInterface, mockLogger *MockLoggerInterface)
+		want      *v0Identities.CreateIdentityResp
+		err       error
+	}{
+		{
+			name: "Success",
+			req: &v0Identities.CreateIdentityReq{
+				Identity: &v0Identities.CreateIdentityBody{
+					SchemaId: mockSchemaId,
+					State:    mockState,
+				},
+			},
+			mockSetup: func(mockService *MockServiceInterface, _ *MockLoggerInterface) {
+				mockService.EXPECT().
+					CreateIdentity(gomock.Any(), &kClient.CreateIdentityBody{
+						SchemaId: mockSchemaId,
+						State:    &mockState,
+					}).
+					Return(&IdentityData{
+						Identities: []kClient.Identity{{SchemaId: "new-schema-id", State: &mockState, OrganizationId: kClient.NullableString{}}},
+					}, nil)
+
+				mockService.EXPECT().
+					SendUserCreationEmail(gomock.Any(), &kClient.Identity{SchemaId: "new-schema-id", State: &mockState, OrganizationId: kClient.NullableString{}}).
+					Return(nil)
+			},
+			want: &v0Identities.CreateIdentityResp{
+				Data: []*v0Identities.Identity{
+					{SchemaId: "new-schema-id", State: &mockState, OrganizationId: &v0Identities.NullableString{}},
+				},
+				Status:  http.StatusCreated,
+				Message: ptr("Created identity"),
+			},
+			err: nil,
+		},
+		{
+			name: "CreateIdentity fails",
+			req: &v0Identities.CreateIdentityReq{
+				Identity: &v0Identities.CreateIdentityBody{
+					SchemaId: mockSchemaId,
+					State:    mockState,
+				},
+			},
+			mockSetup: func(mockService *MockServiceInterface, mockLogger *MockLoggerInterface) {
+				mockService.EXPECT().
+					CreateIdentity(gomock.Any(), &kClient.CreateIdentityBody{
+						SchemaId: mockSchemaId,
+						State:    &mockState,
+					}).
+					Return(nil, fmt.Errorf("creation failed"))
+
+				mockLogger.EXPECT().
+					Errorf("failed to create identity, %v", gomock.Any())
+			},
+			want: nil,
+			err:  status.Error(codes.Internal, "failed to create identity, creation failed"),
+		},
+		{
+			name: "SendUserCreationEmail fails",
+			req: &v0Identities.CreateIdentityReq{
+				Identity: &v0Identities.CreateIdentityBody{
+					SchemaId: mockSchemaId,
+					State:    mockState,
+				},
+			},
+			mockSetup: func(mockService *MockServiceInterface, mockLogger *MockLoggerInterface) {
+				mockService.EXPECT().
+					CreateIdentity(gomock.Any(), &kClient.CreateIdentityBody{
+						SchemaId: mockSchemaId,
+						State:    &mockState,
+					}).
+					Return(&IdentityData{
+						Identities: []kClient.Identity{{Id: "created-id"}},
+					}, nil)
+
+				mockService.EXPECT().
+					SendUserCreationEmail(gomock.Any(), &kClient.Identity{Id: "created-id"}).
+					Return(fmt.Errorf("email failed"))
+
+				mockLogger.EXPECT().
+					Errorf("failed to send user creation email, %v", gomock.Any())
+			},
+			want: nil,
+			err:  status.Error(codes.Internal, "failed to send user creation email, email failed"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := NewMockServiceInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockCtx := authentication.PrincipalContext(context.TODO(), &authentication.UserPrincipal{Email: "test-user"})
+			mockTracer.EXPECT().Start(gomock.Any(), "identities.GrpcHandler.CreateIdentity").Return(mockCtx, mockSpan)
+
+			tt.mockSetup(mockService, mockLogger)
+
+			g := NewGrpcHandler(mockService, NewGrpcMapper(mockLogger), mockTracer, mockMonitor, mockLogger)
+
+			got, err := g.CreateIdentity(context.TODO(), tt.req)
+			if err != nil && err.Error() != tt.err.Error() {
+				t.Errorf("CreateIdentity() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateIdentity() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGrpcHandler_UpdateIdentity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockState := "mock-state"
+	mockSchemaId := "new-schema-id"
+
+	tests := []struct {
+		name      string
+		req       *v0Identities.UpdateIdentityReq
+		mockSetup func(mockService *MockServiceInterface, mockLogger *MockLoggerInterface)
+		want      *v0Identities.UpdateIdentityResp
+		err       error
+	}{
+		{
+			name: "Success",
+			req: &v0Identities.UpdateIdentityReq{
+				Id: "123",
+				Identity: &v0Identities.UpdateIdentityBody{
+					SchemaId: mockSchemaId,
+					State:    mockState,
+				},
+			},
+			mockSetup: func(mockService *MockServiceInterface, _ *MockLoggerInterface) {
+				mockService.EXPECT().
+					UpdateIdentity(gomock.Any(), "123", &kClient.UpdateIdentityBody{
+						SchemaId: mockSchemaId,
+						State:    mockState,
+					}).
+					Return(&IdentityData{
+						Identities: []kClient.Identity{{Id: "123", State: &mockState, OrganizationId: kClient.NullableString{}}},
+					}, nil)
+			},
+			want: &v0Identities.UpdateIdentityResp{
+				Data: []*v0Identities.Identity{
+					{Id: "123", State: &mockState, OrganizationId: &v0Identities.NullableString{}},
+				},
+				Status:  http.StatusOK,
+				Message: ptr("Updated identity"),
+			},
+			err: nil,
+		},
+		{
+			name: "Empty ID",
+			req: &v0Identities.UpdateIdentityReq{
+				Id: "",
+			},
+			mockSetup: func(_ *MockServiceInterface, mockLogger *MockLoggerInterface) {
+				mockLogger.EXPECT().
+					Debug("identity ID is empty")
+			},
+			want: nil,
+			err:  status.Error(codes.InvalidArgument, "identity ID is empty"),
+		},
+		{
+			name: "UpdateIdentity fails",
+			req: &v0Identities.UpdateIdentityReq{
+				Id: "123",
+				Identity: &v0Identities.UpdateIdentityBody{
+					SchemaId: mockSchemaId,
+					State:    mockState,
+				},
+			},
+			mockSetup: func(mockService *MockServiceInterface, mockLogger *MockLoggerInterface) {
+				mockService.EXPECT().
+					UpdateIdentity(gomock.Any(), "123", &kClient.UpdateIdentityBody{
+						SchemaId: mockSchemaId,
+						State:    mockState,
+					}).
+					Return(nil, fmt.Errorf("update failed"))
+
+				mockLogger.EXPECT().
+					Errorf("failed to update identity %s, %v", "123", gomock.Any())
+			},
+			want: nil,
+			err:  status.Error(codes.Internal, "failed to update identity 123, update failed"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := NewMockServiceInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockCtx := authentication.PrincipalContext(context.TODO(), &authentication.UserPrincipal{Email: "test-user"})
+			mockTracer.EXPECT().Start(gomock.Any(), "identities.GrpcHandler.UpdateIdentity").Return(mockCtx, mockSpan)
+
+			tt.mockSetup(mockService, mockLogger)
+
+			g := NewGrpcHandler(mockService, NewGrpcMapper(mockLogger), mockTracer, mockMonitor, mockLogger)
+
+			got, err := g.UpdateIdentity(context.TODO(), tt.req)
+			if err != nil && err.Error() != tt.err.Error() {
+				t.Errorf("UpdateIdentity() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateIdentity() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGrpcHandler_RemoveIdentity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockState := "mock-state"
+
+	tests := []struct {
+		name      string
+		req       *v0Identities.RemoveIdentityReq
+		mockSetup func(mockService *MockServiceInterface, mockLogger *MockLoggerInterface)
+		want      *v0Identities.RemoveIdentityResp
+		err       error
+	}{
+		{
+			name: "Success",
+			req:  &v0Identities.RemoveIdentityReq{Id: "123"},
+			mockSetup: func(mockService *MockServiceInterface, _ *MockLoggerInterface) {
+				mockService.EXPECT().
+					DeleteIdentity(gomock.Any(), "123").
+					Return(&IdentityData{
+						Identities: []kClient.Identity{{Id: "123", State: &mockState, OrganizationId: kClient.NullableString{}}},
+					}, nil)
+			},
+			want: &v0Identities.RemoveIdentityResp{
+				Data: []*v0Identities.Identity{
+					{Id: "123", State: &mockState, OrganizationId: &v0Identities.NullableString{}},
+				},
+				Status:  http.StatusOK,
+				Message: ptr("Identity deleted"),
+			},
+			err: nil,
+		},
+		{
+			name: "Empty ID",
+			req:  &v0Identities.RemoveIdentityReq{Id: ""},
+			mockSetup: func(_ *MockServiceInterface, mockLogger *MockLoggerInterface) {
+				mockLogger.EXPECT().
+					Debug("identity ID is empty")
+			},
+			want: nil,
+			err:  status.Error(codes.InvalidArgument, "identity ID is empty"),
+		},
+		{
+			name: "DeleteIdentity fails",
+			req:  &v0Identities.RemoveIdentityReq{Id: "123"},
+			mockSetup: func(mockService *MockServiceInterface, mockLogger *MockLoggerInterface) {
+				mockService.EXPECT().
+					DeleteIdentity(gomock.Any(), "123").
+					Return(nil, fmt.Errorf("delete error"))
+
+				mockLogger.EXPECT().
+					Errorf("failed to delete identity %s, %v", "123", gomock.Any())
+			},
+			want: nil,
+			err:  status.Error(codes.Internal, "failed to delete identity 123, delete error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := NewMockServiceInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+			mockTracer := NewMockTracer(ctrl)
+			mockMonitor := NewMockMonitorInterface(ctrl)
+			mockSpan := trace.SpanFromContext(context.TODO())
+
+			mockCtx := authentication.PrincipalContext(context.TODO(), &authentication.UserPrincipal{Email: "test-user"})
+			mockTracer.EXPECT().Start(gomock.Any(), "identities.GrpcHandler.RemoveIdentity").Return(mockCtx, mockSpan)
+
+			tt.mockSetup(mockService, mockLogger)
+
+			g := NewGrpcHandler(mockService, NewGrpcMapper(mockLogger), mockTracer, mockMonitor, mockLogger)
+
+			got, err := g.RemoveIdentity(context.TODO(), tt.req)
+			if err != nil && err.Error() != tt.err.Error() {
+				t.Errorf("RemoveIdentity() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RemoveIdentity() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/identities/gRPC_mappers.go
+++ b/pkg/identities/gRPC_mappers.go
@@ -1,0 +1,477 @@
+// Copyright 2025 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package identities
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	v0Identities "github.com/canonical/identity-platform-api/v0/identities"
+	kClient "github.com/ory/kratos-client-go"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/canonical/identity-platform-admin-ui/internal/logging"
+)
+
+// Mapping methods names prefixes
+// kratos model to protobuf model => `[Ff]rom*`
+// protobuf model to kratos model => [Tt]o*
+
+type GrpcPbMapper struct {
+	logger logging.LoggerInterface
+}
+
+func (g *GrpcPbMapper) FromIdentitiesModel(identities []kClient.Identity) ([]*v0Identities.Identity, error) {
+	if identities == nil {
+		return nil, nil
+	}
+
+	ret := make([]*v0Identities.Identity, 0, len(identities))
+	for _, identity := range identities {
+		mappedIdentity, err := g.fromIdentity(identity)
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, mappedIdentity)
+	}
+
+	return ret, nil
+}
+
+func (g *GrpcPbMapper) fromIdentity(identity kClient.Identity) (*v0Identities.Identity, error) {
+
+	organizationId := g.fromNullableString(identity.OrganizationId)
+	state := identity.GetState()
+	credentials := g.fromIdentityCredentials(identity.Credentials)
+
+	metadataAdmin, err := g.fromStruct(identity.MetadataAdmin)
+	if err != nil {
+		return nil, err
+	}
+
+	metadataPublic, err := g.fromStruct(identity.MetadataPublic)
+	if err != nil {
+		return nil, err
+	}
+
+	recoveryAddresses, err := g.fromRecoveryAddresses(identity.RecoveryAddresses)
+	if err != nil {
+		return nil, err
+	}
+
+	verifiableAddresses, err := g.fromVerifiableAddresses(identity.VerifiableAddresses)
+	if err != nil {
+		return nil, err
+	}
+
+	traits, err := g.fromStruct(identity.Traits)
+	if err != nil {
+		return nil, err
+	}
+
+	additionalProperties, err := g.fromStringAnyMap(identity.AdditionalProperties)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v0Identities.Identity{
+		CreatedAt:            g.fromTime(identity.CreatedAt),
+		Credentials:          credentials,
+		Id:                   identity.GetId(),
+		MetadataAdmin:        metadataAdmin,
+		MetadataPublic:       metadataPublic,
+		OrganizationId:       organizationId,
+		RecoveryAddresses:    recoveryAddresses,
+		SchemaId:             identity.GetSchemaId(),
+		SchemaUrl:            identity.GetSchemaUrl(),
+		State:                &state,
+		StateChangedAt:       g.fromTime(identity.StateChangedAt),
+		Traits:               traits,
+		UpdatedAt:            g.fromTime(identity.UpdatedAt),
+		VerifiableAddresses:  verifiableAddresses,
+		AdditionalProperties: additionalProperties,
+	}, nil
+}
+
+func (g *GrpcPbMapper) fromTime(t *time.Time) *timestamppb.Timestamp {
+	if t == nil {
+		return nil
+	}
+
+	return timestamppb.New(*t)
+}
+
+func (g *GrpcPbMapper) fromNullableString(organizationId kClient.NullableString) *v0Identities.NullableString {
+	return &v0Identities.NullableString{
+		Value: organizationId.Get(),
+		IsSet: organizationId.IsSet(),
+	}
+}
+
+func (g *GrpcPbMapper) fromIdentityCredentials(credentials *map[string]kClient.IdentityCredentials) map[string]*v0Identities.IdentityCredentials {
+	if credentials == nil {
+		return nil
+	}
+
+	creds := make(map[string]*v0Identities.IdentityCredentials, len(*credentials))
+	for k, v := range *credentials {
+		config, _ := g.fromStringAnyMap(v.Config)
+		additionalProps, _ := g.fromStringAnyMap(v.AdditionalProperties)
+
+		creds[k] = &v0Identities.IdentityCredentials{
+			Config:               config,
+			CreatedAt:            g.fromTime(v.CreatedAt),
+			Identifiers:          v.Identifiers,
+			Type:                 v.Type,
+			UpdatedAt:            g.fromTime(v.UpdatedAt),
+			Version:              v.Version,
+			AdditionalProperties: additionalProps,
+		}
+	}
+
+	return creds
+}
+
+func (g *GrpcPbMapper) fromStringAnyMap(m map[string]interface{}) (map[string]*structpb.Value, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	ret := make(map[string]*structpb.Value, len(m))
+
+	for key, value := range m {
+		mappedValue, err := structpb.NewValue(value)
+		if err != nil {
+			g.logger.Errorf("error converting stringValuePtrMap key %s, value %v : %v", key, value, err)
+			return nil, fmt.Errorf("error converting stringValuePtrMap key %s, value %v : %v", key, value, err)
+		}
+
+		ret[key] = mappedValue
+	}
+
+	return ret, nil
+}
+
+func (g *GrpcPbMapper) fromStruct(value interface{}) (*structpb.Struct, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	m, err := g.toStringAnyMap(value)
+	if err != nil {
+		g.logger.Errorf("error transforming any to map, value %v : %v", value, err)
+		return nil, fmt.Errorf("error transforming any to map, value %v : %v", value, err)
+	}
+
+	ret, err := structpb.NewStruct(m)
+	if err != nil {
+		g.logger.Errorf("error creating pb Struct, value %v : %v", value, err)
+		return nil, fmt.Errorf("error creating pb Struct, value %v : %v", value, err)
+	}
+
+	return ret, nil
+}
+
+func (g *GrpcPbMapper) toStringAnyMap(value interface{}) (map[string]interface{}, error) {
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		g.logger.Errorf("error marshalling value %v : %v", value, err)
+		return nil, fmt.Errorf("error marshalling value %v : %v", value, err)
+	}
+
+	var m map[string]interface{} = nil
+
+	err = json.Unmarshal(bytes, &m)
+	if err != nil {
+		g.logger.Errorf("error unmarshalling value %v : %v", value, err)
+		return nil, fmt.Errorf("error unmarshalling value %v : %v", value, err)
+	}
+
+	return m, nil
+}
+
+func (g *GrpcPbMapper) fromRecoveryAddresses(addresses []kClient.RecoveryIdentityAddress) ([]*v0Identities.RecoveryIdentityAddress, error) {
+	if addresses == nil {
+		return nil, nil
+	}
+
+	ret := make([]*v0Identities.RecoveryIdentityAddress, 0, len(addresses))
+
+	for _, address := range addresses {
+		ptrMap, err := g.fromStringAnyMap(address.AdditionalProperties)
+		if err != nil {
+			g.logger.Errorf("error converting recovery addresses additionalProperties %v : %v", address, err)
+			return nil, fmt.Errorf("error converting recovery addresses additionalProperties %v : %v", address, err)
+		}
+
+		ret = append(
+			ret,
+			&v0Identities.RecoveryIdentityAddress{
+				CreatedAt:            g.fromTime(address.CreatedAt),
+				Id:                   address.Id,
+				UpdatedAt:            g.fromTime(address.UpdatedAt),
+				Value:                address.Value,
+				Via:                  address.Via,
+				AdditionalProperties: ptrMap,
+			},
+		)
+	}
+
+	return ret, nil
+}
+
+func (g *GrpcPbMapper) fromVerifiableAddresses(addresses []kClient.VerifiableIdentityAddress) ([]*v0Identities.VerifiableIdentityAddress, error) {
+	if addresses == nil {
+		return nil, nil
+	}
+
+	ret := make([]*v0Identities.VerifiableIdentityAddress, 0, len(addresses))
+	for _, address := range addresses {
+		ptrMap, err := g.fromStringAnyMap(address.AdditionalProperties)
+		if err != nil {
+			g.logger.Errorf("error converting verifiable addresses additionalProperties %v : %v", address, err)
+			return nil, fmt.Errorf("error converting verifiable addresses additionalProperties %v : %v", address, err)
+		}
+
+		ret = append(
+			ret,
+			&v0Identities.VerifiableIdentityAddress{
+				CreatedAt:            g.fromTime(address.CreatedAt),
+				Id:                   address.Id,
+				Status:               address.Status,
+				UpdatedAt:            g.fromTime(address.UpdatedAt),
+				Value:                address.Value,
+				Verified:             address.Verified,
+				VerifiedAt:           g.fromTime(address.VerifiedAt),
+				Via:                  address.Via,
+				AdditionalProperties: ptrMap,
+			},
+		)
+	}
+
+	return ret, nil
+}
+
+func (g *GrpcPbMapper) ToCreateIdentityModel(body *v0Identities.CreateIdentityBody) (*kClient.CreateIdentityBody, error) {
+	if body == nil {
+		return nil, nil
+	}
+
+	var credentials *kClient.IdentityWithCredentials = nil
+	if body.Credentials != nil {
+		if err := g.mapStringInterfaceMap(body.GetCredentials().AsMap(), &credentials); err != nil {
+			return nil, err
+		}
+	}
+
+	var metadataAdmin interface{} = nil
+	if body.MetadataAdmin != nil {
+		asMap := body.GetMetadataAdmin().AsMap()
+		if len(asMap) != 0 {
+			metadataAdmin = asMap
+		}
+	}
+	var metadataPublic interface{} = nil
+	if body.GetMetadataPublic() != nil {
+		asMap := body.GetMetadataPublic().AsMap()
+		if len(asMap) != 0 {
+			metadataPublic = body.GetMetadataPublic().AsMap()
+		}
+	}
+
+	var recoveryAddresses []kClient.RecoveryIdentityAddress = nil
+	if body.RecoveryAddresses != nil {
+		recoveryAddresses = make([]kClient.RecoveryIdentityAddress, 0, len(body.RecoveryAddresses))
+
+		for _, address := range body.RecoveryAddresses {
+			recoveryAddresses = append(recoveryAddresses, g.toRecoveryAddress(address))
+		}
+	}
+
+	var verifiableAddresses []kClient.VerifiableIdentityAddress = nil
+	if body.VerifiableAddresses != nil {
+		verifiableAddresses = make([]kClient.VerifiableIdentityAddress, 0, len(body.VerifiableAddresses))
+
+		for _, address := range body.VerifiableAddresses {
+			verifiableAddresses = append(verifiableAddresses, g.toVerifiableAddress(address))
+		}
+	}
+
+	var additionalProperties map[string]interface{} = nil
+	if body.GetAdditionalProperties() != nil {
+		asMap := body.AdditionalProperties.AsMap()
+		if len(asMap) != 0 {
+			additionalProperties = body.AdditionalProperties.AsMap()
+		}
+	}
+
+	var traits map[string]interface{} = nil
+	if body.GetTraits() != nil {
+		asMap := body.GetTraits().AsMap()
+		if len(asMap) != 0 {
+			traits = body.GetTraits().AsMap()
+		}
+	}
+
+	ret := &kClient.CreateIdentityBody{
+		Credentials:          credentials,
+		MetadataAdmin:        metadataAdmin,
+		MetadataPublic:       metadataPublic,
+		RecoveryAddresses:    recoveryAddresses,
+		SchemaId:             body.SchemaId,
+		State:                &body.State,
+		Traits:               traits,
+		VerifiableAddresses:  verifiableAddresses,
+		AdditionalProperties: additionalProperties,
+	}
+
+	return ret, nil
+}
+
+func (g *GrpcPbMapper) toRecoveryAddress(address *v0Identities.RecoveryIdentityAddress) kClient.RecoveryIdentityAddress {
+	ret := kClient.RecoveryIdentityAddress{
+		Id:                   address.GetId(),
+		Value:                address.GetValue(),
+		Via:                  address.GetVia(),
+		AdditionalProperties: g.toStringInterfaceMapFromStringValueMap(address.AdditionalProperties),
+	}
+
+	if address.GetCreatedAt() != nil {
+		asTime := address.GetCreatedAt().AsTime()
+		ret.CreatedAt = &asTime
+	}
+
+	if address.GetUpdatedAt() != nil {
+		asTime := address.GetUpdatedAt().AsTime()
+		ret.UpdatedAt = &asTime
+	}
+
+	return ret
+}
+
+func (g *GrpcPbMapper) toVerifiableAddress(address *v0Identities.VerifiableIdentityAddress) kClient.VerifiableIdentityAddress {
+	ret := kClient.VerifiableIdentityAddress{
+		Id:                   address.Id,
+		Status:               address.GetStatus(),
+		Value:                address.GetValue(),
+		Verified:             address.GetVerified(),
+		Via:                  address.GetVia(),
+		AdditionalProperties: g.toStringInterfaceMapFromStringValueMap(address.AdditionalProperties),
+	}
+
+	if address.GetCreatedAt() != nil {
+		asTime := address.GetCreatedAt().AsTime()
+		ret.CreatedAt = &asTime
+	}
+
+	if address.GetUpdatedAt() != nil {
+		asTime := address.GetUpdatedAt().AsTime()
+		ret.UpdatedAt = &asTime
+	}
+
+	if address.GetVerifiedAt() != nil {
+		asTime := address.GetVerifiedAt().AsTime()
+		ret.VerifiedAt = &asTime
+	}
+
+	return ret
+}
+
+func (g *GrpcPbMapper) toStringInterfaceMapFromStringValueMap(m map[string]*structpb.Value) map[string]interface{} {
+	if m == nil {
+		return nil
+	}
+
+	ret := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		ret[k] = v.AsInterface()
+	}
+
+	return ret
+}
+
+func (g *GrpcPbMapper) mapStringInterfaceMap(m map[string]any, model any) error {
+	if m == nil || len(m) == 0 {
+		return nil
+	}
+
+	bytesBody, err := json.Marshal(m)
+	if err != nil {
+		g.logger.Errorf("error marshalling credentials %v : %v", m, err)
+		return fmt.Errorf("error marshalling credentials %v : %v", m, err)
+	}
+
+	err = json.Unmarshal(bytesBody, &model)
+	if err != nil {
+		g.logger.Errorf("error unmarshalling credentials %v : %v", bytesBody, err)
+		return fmt.Errorf("error unmarshalling credentials %v : %v", bytesBody, err)
+	}
+
+	return nil
+}
+
+func (g *GrpcPbMapper) ToUpdateIdentityModel(body *v0Identities.UpdateIdentityBody) (*kClient.UpdateIdentityBody, error) {
+	if body == nil {
+		return nil, nil
+	}
+
+	var credentials *kClient.IdentityWithCredentials = nil
+	if body.Credentials != nil {
+		if err := g.mapStringInterfaceMap(body.GetCredentials().AsMap(), &credentials); err != nil {
+			return nil, err
+		}
+	}
+
+	var metadataAdmin interface{} = nil
+	if body.MetadataAdmin != nil {
+		asMap := body.GetMetadataAdmin().AsMap()
+		if len(asMap) != 0 {
+			metadataAdmin = body.GetMetadataAdmin().AsMap()
+		}
+	}
+	var metadataPublic interface{} = nil
+	if body.GetMetadataPublic() != nil {
+		asMap := body.GetMetadataPublic().AsMap()
+		if len(asMap) != 0 {
+			metadataPublic = body.GetMetadataPublic().AsMap()
+		}
+	}
+
+	var traits map[string]interface{} = nil
+	if body.GetTraits() != nil {
+		asMap := body.GetTraits().AsMap()
+		if len(asMap) != 0 {
+			traits = body.GetTraits().AsMap()
+		}
+	}
+
+	var additionalProperties map[string]interface{} = nil
+	if body.GetAdditionalProperties() != nil {
+		asMap := body.GetAdditionalProperties().AsMap()
+		if len(asMap) != 0 {
+			additionalProperties = body.AdditionalProperties.AsMap()
+		}
+	}
+
+	ret := &kClient.UpdateIdentityBody{
+		Credentials:          credentials,
+		MetadataAdmin:        metadataAdmin,
+		MetadataPublic:       metadataPublic,
+		SchemaId:             body.GetSchemaId(),
+		State:                body.GetState(),
+		Traits:               traits,
+		AdditionalProperties: additionalProperties,
+	}
+
+	return ret, nil
+}
+
+func NewGrpcMapper(logger logging.LoggerInterface) *GrpcPbMapper {
+	return &GrpcPbMapper{
+		logger: logger,
+	}
+}

--- a/pkg/identities/gRPC_mappers_test.go
+++ b/pkg/identities/gRPC_mappers_test.go
@@ -1,0 +1,349 @@
+// Copyright 2025 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0
+
+package identities
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	v0Identities "github.com/canonical/identity-platform-api/v0/identities"
+	kClient "github.com/ory/kratos-client-go"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+//go:generate mockgen -build_flags=--mod=mod -package identities -destination ./mock_logger.go -source=../../internal/logging/interfaces.go
+
+func TestGrpcPbMapper_FromIdentitiesModel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTime := time.Date(2025, 4, 25, 12, 12, 12, 0, time.UTC).UTC()
+	mockMappedTime := timestamppb.New(mockTime)
+
+	mockMetadata := make(map[string]interface{})
+	nestedMap := make(map[string]interface{})
+	nestedMap["nested-key"] = "test"
+	mockMetadata["test-key"] = nestedMap
+
+	mockState := "test-state"
+
+	mockCreds := make(map[string]kClient.IdentityCredentials)
+	mockOidcCreds := kClient.NewIdentityCredentials()
+	mockOidcCreds.SetCreatedAt(mockTime)
+	mockOidcCreds.SetUpdatedAt(mockTime)
+	mockOidcCreds.SetConfig(mockMetadata)
+	mockOidcCreds.SetVersion(1)
+	mockOidcCreds.SetIdentifiers([]string{"mock-identifier"})
+	mockOidcCreds.SetType("oidc")
+
+	mockCreds["oidc"] = *mockOidcCreds
+
+	mockMappedConfig := make(map[string]*structpb.Value, 1)
+	mockMappedStruct, _ := structpb.NewStruct(map[string]any{"nested-key": "test"})
+	mockMappedConfig["test-key"] = structpb.NewStructValue(mockMappedStruct)
+
+	mockMappedMetadata, _ := structpb.NewStruct(mockMetadata)
+
+	var mockVersion int64 = 1
+	mockTestValueString := "oidc"
+	mockMappedCreds := make(map[string]*v0Identities.IdentityCredentials, 1)
+
+	mockMappedOidcCreds := v0Identities.IdentityCredentials{
+		Config:      mockMappedConfig,
+		CreatedAt:   mockMappedTime,
+		Identifiers: []string{"mock-identifier"},
+		Type:        &mockTestValueString,
+		UpdatedAt:   mockMappedTime,
+		Version:     &mockVersion,
+	}
+	mockMappedCreds["oidc"] = &mockMappedOidcCreds
+
+	mockId := "mock-id"
+
+	mockRecoveryAddresses := make([]kClient.RecoveryIdentityAddress, 0, 1)
+	mockRecoveryAddresses = append(
+		mockRecoveryAddresses,
+		kClient.RecoveryIdentityAddress{
+			CreatedAt: &mockTime,
+			Id:        mockId,
+			UpdatedAt: &mockTime,
+			Value:     "mock-value",
+			Via:       "mock-via",
+		},
+	)
+
+	mockMappedRecoveryAddresses := make([]*v0Identities.RecoveryIdentityAddress, 0, 1)
+	mockMappedRecoveryAddresses = append(
+		mockMappedRecoveryAddresses,
+		&v0Identities.RecoveryIdentityAddress{
+			CreatedAt: mockMappedTime,
+			Id:        mockId,
+			UpdatedAt: mockMappedTime,
+			Value:     "mock-value",
+			Via:       "mock-via",
+		},
+	)
+
+	mockVerifiableAddresses := make([]kClient.VerifiableIdentityAddress, 0, 1)
+	mockVerifiableAddresses = append(
+		mockVerifiableAddresses,
+		kClient.VerifiableIdentityAddress{
+			CreatedAt:  &mockTime,
+			Id:         &mockId,
+			Status:     "mock-status",
+			UpdatedAt:  &mockTime,
+			Value:      "mock-value",
+			Verified:   true,
+			VerifiedAt: &mockTime,
+			Via:        "mock-via",
+		},
+	)
+
+	mockMappedVerifiableAddresses := make([]*v0Identities.VerifiableIdentityAddress, 0, 1)
+	mockMappedVerifiableAddresses = append(
+		mockMappedVerifiableAddresses,
+		&v0Identities.VerifiableIdentityAddress{
+			CreatedAt:  mockMappedTime,
+			Id:         &mockId,
+			Status:     "mock-status",
+			UpdatedAt:  mockMappedTime,
+			Value:      "mock-value",
+			Verified:   true,
+			VerifiedAt: mockMappedTime,
+			Via:        "mock-via",
+		},
+	)
+
+	tests := []struct {
+		name       string
+		identities []kClient.Identity
+		want       []*v0Identities.Identity
+	}{
+		{
+			name: "Successful mapping with full structs",
+			identities: []kClient.Identity{
+				{
+					CreatedAt:            &mockTime,
+					Credentials:          &mockCreds,
+					Id:                   "test-id",
+					MetadataAdmin:        mockMetadata,
+					MetadataPublic:       mockMetadata,
+					OrganizationId:       *kClient.NewNullableString(&mockState),
+					RecoveryAddresses:    mockRecoveryAddresses,
+					SchemaId:             "test-schema-id",
+					SchemaUrl:            "test://schema-url",
+					State:                &mockState,
+					StateChangedAt:       &mockTime,
+					Traits:               mockMetadata,
+					UpdatedAt:            &mockTime,
+					VerifiableAddresses:  mockVerifiableAddresses,
+					AdditionalProperties: mockMetadata,
+				},
+			},
+			want: []*v0Identities.Identity{
+				{
+					CreatedAt:      mockMappedTime,
+					Credentials:    mockMappedCreds,
+					Id:             "test-id",
+					MetadataAdmin:  mockMappedMetadata,
+					MetadataPublic: mockMappedMetadata,
+					OrganizationId: &v0Identities.NullableString{
+						Value: &mockState,
+						IsSet: true,
+					},
+					RecoveryAddresses:    mockMappedRecoveryAddresses,
+					SchemaId:             "test-schema-id",
+					SchemaUrl:            "test://schema-url",
+					State:                &mockState,
+					StateChangedAt:       mockMappedTime,
+					Traits:               mockMappedMetadata,
+					UpdatedAt:            mockMappedTime,
+					VerifiableAddresses:  mockMappedVerifiableAddresses,
+					AdditionalProperties: mockMappedConfig,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockLogger := NewMockLoggerInterface(ctrl)
+
+			g := NewGrpcMapper(mockLogger)
+
+			got, err := g.FromIdentitiesModel(tt.identities)
+			if err != nil {
+				t.Errorf("FromIdentitiesModel() error = %v", err)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FromIdentitiesModel() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGrpcPbMapper_ToCreateIdentityModel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockState := "mock-state"
+
+	mappedMockCreds := &kClient.IdentityWithCredentials{
+		Oidc: &kClient.IdentityWithCredentialsOidc{
+			Config: &kClient.IdentityWithCredentialsOidcConfig{
+				Providers: []kClient.IdentityWithCredentialsOidcConfigProvider{
+					{
+						Provider: "mock-provider",
+						Subject:  "mock-subject",
+					},
+				},
+			},
+		},
+	}
+
+	marshal, _ := json.Marshal(mappedMockCreds)
+
+	var mappedMockCredsMap map[string]any
+	_ = json.Unmarshal(marshal, &mappedMockCredsMap)
+
+	mockCreds, _ := structpb.NewStruct(mappedMockCredsMap)
+
+	tests := []struct {
+		name string
+		body *v0Identities.CreateIdentityBody
+		want *kClient.CreateIdentityBody
+	}{
+		{
+			name: "Successful mapping",
+			body: &v0Identities.CreateIdentityBody{
+				Credentials: mockCreds,
+				SchemaId:    "mock-schema-id",
+				State:       mockState,
+			},
+			want: &kClient.CreateIdentityBody{
+				Credentials: mappedMockCreds,
+				SchemaId:    "mock-schema-id",
+				State:       &mockState,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockLogger := NewMockLoggerInterface(ctrl)
+
+			g := NewGrpcMapper(mockLogger)
+
+			got, err := g.ToCreateIdentityModel(tt.body)
+
+			if err != nil {
+				t.Errorf("ToCreateIdentityModel() error = %v", err)
+				return
+			}
+
+			if got == nil || tt.want == nil {
+				if got != tt.want {
+					t.Errorf("got is %v, want is %v", got, tt.want)
+				}
+				return
+			}
+
+			// normalize map for testing purposes (due to underlying implementation leveraging json unmarshalling
+			got.Credentials.Oidc.Config.Providers[0].AdditionalProperties = nil
+
+			if !reflect.DeepEqual(got.Credentials.Oidc.Config.Providers[0], tt.want.Credentials.Oidc.Config.Providers[0]) {
+				t.Errorf("Credentials mismatch:\ngot  = %#v\nwant = %#v", got.Credentials.Oidc.Config.Providers[0], tt.want.Credentials.Oidc.Config.Providers[0])
+			}
+
+			if got.SchemaId != tt.want.SchemaId {
+				t.Errorf("SchemaId mismatch:\ngot  = %s\nwant = %s", got.SchemaId, tt.want.SchemaId)
+			}
+
+			if got.State == nil || tt.want.State == nil {
+				if got.State != tt.want.State {
+					t.Errorf("State pointer mismatch:\ngot  = %v\nwant = %v", got.State, tt.want.State)
+				}
+			} else if *got.State != *tt.want.State {
+				t.Errorf("State value mismatch:\ngot  = %s\nwant = %s", *got.State, *tt.want.State)
+			}
+		})
+	}
+}
+
+func TestGrpcPbMapper_ToUpdateIdentityModel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mappedMockCreds := &kClient.IdentityWithCredentials{
+		Oidc: &kClient.IdentityWithCredentialsOidc{
+			Config: &kClient.IdentityWithCredentialsOidcConfig{
+				Providers: []kClient.IdentityWithCredentialsOidcConfigProvider{
+					{
+						Provider: "mock-provider",
+						Subject:  "mock-subject",
+					},
+				},
+			},
+		},
+	}
+
+	marshal, _ := json.Marshal(mappedMockCreds)
+
+	var mappedMockCredsMap map[string]any
+	_ = json.Unmarshal(marshal, &mappedMockCredsMap)
+
+	mockCreds, _ := structpb.NewStruct(mappedMockCredsMap)
+
+	tests := []struct {
+		name string
+		body *v0Identities.UpdateIdentityBody
+		want *kClient.UpdateIdentityBody
+	}{
+		{
+			name: "Successful mapping with full structs",
+			body: &v0Identities.UpdateIdentityBody{
+				Credentials: mockCreds,
+				SchemaId:    "mock-schema-id",
+				State:       "mock-state",
+			},
+			want: &kClient.UpdateIdentityBody{
+				Credentials: mappedMockCreds,
+				SchemaId:    "mock-schema-id",
+				State:       "mock-state",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockLogger := NewMockLoggerInterface(ctrl)
+
+			g := NewGrpcMapper(mockLogger)
+
+			got, err := g.ToUpdateIdentityModel(tt.body)
+			if err != nil {
+				t.Errorf("ToUpdateIdentityModel() error = %v", err)
+				return
+			}
+
+			// normalize map for testing purposes (due to underlying implementation leveraging json unmarshalling
+			got.Credentials.Oidc.Config.Providers[0].AdditionalProperties = nil
+
+			if !reflect.DeepEqual(got.Credentials.Oidc.Config.Providers[0], tt.want.Credentials.Oidc.Config.Providers[0]) {
+				t.Errorf("Credentials mismatch:\ngot  = %#v\nwant = %#v", got.Credentials.Oidc.Config.Providers[0], tt.want.Credentials.Oidc.Config.Providers[0])
+			}
+
+			if got.SchemaId != tt.want.SchemaId {
+				t.Errorf("SchemaId mismatch:\ngot  = %s\nwant = %s", got.SchemaId, tt.want.SchemaId)
+			}
+
+			if got.State != tt.want.State {
+				t.Errorf("State value mismatch:\ngot  = %s\nwant = %s", got.State, tt.want.State)
+			}
+		})
+	}
+}

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	v0Groups "github.com/canonical/identity-platform-api/v0/groups"
+	v0Identities "github.com/canonical/identity-platform-api/v0/identities"
 	v0Roles "github.com/canonical/identity-platform-api/v0/roles"
 	v0Status "github.com/canonical/identity-platform-api/v0/status"
 	v1 "github.com/canonical/rebac-admin-ui-handlers/v1"
@@ -213,7 +214,7 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 	//statusAPI.RegisterEndpoints(apiRouter)
 	//metricsAPI.RegisterEndpoints(apiRouter)
 
-	identitiesAPI.RegisterEndpoints(apiRouter)
+	//identitiesAPI.RegisterEndpoints(apiRouter)
 	clientsAPI.RegisterEndpoints(apiRouter)
 	idpAPI.RegisterEndpoints(apiRouter)
 	schemasAPI.RegisterEndpoints(apiRouter)
@@ -243,6 +244,12 @@ func NewRouter(config *RouterConfig, wpool pool.WorkerPoolInterface) http.Handle
 		panic(err)
 	}
 
+	err = v0Identities.RegisterIdentitiesServiceHandlerServer(context.Background(), gRPCGatewayMux, identities.NewGrpcHandler(identitiesSvc, identities.NewGrpcMapper(logger), tracer, monitor, logger))
+	if err != nil {
+		panic(err)
+	}
+
+	apiRouter.Mount("/api/v0/identities", gRPCGatewayMux)
 	apiRouter.Mount("/api/v0/roles", gRPCGatewayMux)
 	apiRouter.Mount("/api/v0/groups", gRPCGatewayMux)
 	apiRouter.Mount("/api/v0/status", gRPCGatewayMux)


### PR DESCRIPTION
## Description
This PR add support for the Identities API (gRPC-gateway based).
A GrpcMapper struct has been added to brdige the mapping from and to the models used by admin uI, which are in turn taken from the Kratos SDK. This doesn't allow us to edit the json tags as I would have wanted to, that is why in the gRPC_mapper_test.go file you see I had to "normalize" some result since semantis is correctly preserved in the regular processing of the data by the actual service.

The gRPC mapper tests only focus on the happy path. This is due to difficulty in finding a way to generate and test an error that makes sense + the amount of time this task already took.

### Missing
gRPC_handlers_test file to cover for the five endpoints of the v0 Identities API.