### PR TITLE
IAM-1539 Add goose migrations and related makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,31 @@ dev:
 		--tail \
 		--cache-artifacts=false
 .PHONY: dev
+
+
+GOOSE=goose
+GOOSE_DRIVER=postgres
+GOOSE_DBSTRING?=postgresql://user:user@localhost:5432/admin-service?sslmode=disable
+GOOSE_MIGRATION_DIR?=./migrations
+
+db-status:
+	@GOOSE_DRIVER=$(GOOSE_DRIVER) \
+	GOOSE_DBSTRING=$(GOOSE_DBSTRING) \
+	$(GOOSE) -dir $(GOOSE_MIGRATION_DIR) status
+.PHONY: db-status
+
+db:
+	@GOOSE_DRIVER=$(GOOSE_DRIVER) \
+	GOOSE_DBSTRING=$(GOOSE_DBSTRING) \
+	$(GOOSE) -dir $(GOOSE_MIGRATION_DIR) up
+.PHONY: migrate
+
+db-down:
+	@GOOSE_DRIVER=$(GOOSE_DRIVER) \
+	GOOSE_DBSTRING=$(GOOSE_DBSTRING) \
+	$(GOOSE) -dir $(GOOSE_MIGRATION_DIR) down
+.PHONY: migrate-down
+
+install-goose:
+	go install github.com/pressly/goose/v3/cmd/goose@v3.24.3
+.PHONY: install-goose

--- a/migrations/00001_initial_schema.sql
+++ b/migrations/00001_initial_schema.sql
@@ -1,0 +1,109 @@
+--  Copyright 2025 Canonical Ltd.
+--  SPDX-License-Identifier: AGPL-3.0
+
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE SEQUENCE identity_id_seq;
+CREATE SEQUENCE application_id_seq;
+CREATE SEQUENCE group_id_seq;
+CREATE SEQUENCE role_id_seq;
+CREATE SEQUENCE policy_id_seq;
+CREATE SEQUENCE permission_id_seq;
+
+CREATE TABLE identity
+(
+    id          BIGINT PRIMARY KEY DEFAULT nextval('identity_id_seq'),
+    identity_id TEXT NOT NULL UNIQUE,
+    username    TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE application
+(
+    id        BIGINT PRIMARY KEY DEFAULT nextval('application_id_seq'),
+    name      TEXT NOT NULL,
+    client_id TEXT NOT NULL,
+    owner     TEXT NOT NULL,
+    owner_id  BIGINT REFERENCES identity (id) ON DELETE CASCADE -- not used now, will become NOT NULL during the epic
+);
+
+CREATE TABLE "group"
+(
+    id       BIGINT PRIMARY KEY DEFAULT nextval('group_id_seq'),
+    name     TEXT NOT NULL,
+    owner    TEXT NOT NULL,
+    owner_id BIGINT REFERENCES identity (id) ON DELETE CASCADE -- not used now, will become NOT NULL during the epic
+);
+
+CREATE TABLE role
+(
+    id       BIGINT PRIMARY KEY DEFAULT nextval('role_id_seq'),
+    name     TEXT NOT NULL,
+    owner    TEXT NOT NULL,
+    owner_id BIGINT REFERENCES identity (id) ON DELETE CASCADE -- not used now, will become NOT NULL during the epic
+);
+
+CREATE TABLE policy
+(
+    id       BIGINT PRIMARY KEY DEFAULT nextval('policy_id_seq'),
+    version  TEXT   NOT NULL,
+    name     TEXT   NOT NULL,
+    owner    TEXT   NOT NULL,
+    owner_id BIGINT REFERENCES identity (id) ON DELETE CASCADE, -- not used now, will become NOT NULL during the epic
+    role_id  BIGINT NOT NULL REFERENCES role (id) ON DELETE CASCADE
+);
+
+CREATE TABLE permission
+(
+    id        BIGINT PRIMARY KEY DEFAULT nextval('permission_id_seq'),
+    resource  TEXT   NOT NULL,
+    action    TEXT   NOT NULL,
+    policy_id BIGINT NOT NULL REFERENCES policy (id) ON DELETE CASCADE
+);
+
+
+-- group ↔ identity
+CREATE TABLE group_identity
+(
+    group_id    BIGINT NOT NULL REFERENCES "group" (id) ON DELETE CASCADE,
+    identity_id BIGINT NOT NULL REFERENCES identity (id) ON DELETE CASCADE,
+    PRIMARY KEY (group_id, identity_id)
+);
+
+-- group ↔ role
+CREATE TABLE group_role
+(
+    group_id BIGINT NOT NULL REFERENCES "group" (id) ON DELETE CASCADE,
+    role_id  BIGINT NOT NULL REFERENCES role (id) ON DELETE CASCADE,
+    PRIMARY KEY (group_id, role_id)
+);
+
+-- identity ↔ role
+CREATE TABLE identity_role
+(
+    identity_id BIGINT NOT NULL REFERENCES identity (id) ON DELETE CASCADE,
+    role_id BIGINT NOT NULL REFERENCES role (id) ON DELETE CASCADE,
+    PRIMARY KEY (identity_id, role_id)
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS "role_identity";
+DROP TABLE IF EXISTS "group_role";
+DROP TABLE IF EXISTS "group_identity";
+DROP TABLE IF EXISTS "permission";
+DROP TABLE IF EXISTS "policy";
+DROP TABLE IF EXISTS "role";
+DROP TABLE IF EXISTS "group";
+DROP TABLE IF EXISTS "identity";
+DROP TABLE IF EXISTS "application";
+
+DROP SEQUENCE IF EXISTS "application_id_seq";
+DROP SEQUENCE IF EXISTS "identity_id_seq";
+DROP SEQUENCE IF EXISTS "group_id_seq";
+DROP SEQUENCE IF EXISTS "role_id_seq";
+DROP SEQUENCE IF EXISTS "policy_id_seq";
+DROP SEQUENCE IF EXISTS "permission_id_seq";
+
+-- +goose StatementEnd

--- a/migrations/00002_add_initial_indices.sql
+++ b/migrations/00002_add_initial_indices.sql
@@ -1,0 +1,14 @@
+--  Copyright 2025 Canonical Ltd.
+--  SPDX-License-Identifier: AGPL-3.0
+
+-- +goose Up
+CREATE INDEX idx_group_name_owner ON "group" (name, owner);
+CREATE INDEX idx_role_name_owner ON role (name, owner);
+CREATE INDEX idx_application_name_owner ON application (name, owner);
+CREATE UNIQUE INDEX idx_application_client_id ON application (client_id);
+
+-- +goose Down
+DROP INDEX idx_group_name_owner;
+DROP INDEX idx_role_name_owner;
+DROP INDEX idx_application_name_owner;
+DROP INDEX idx_application_client_id;


### PR DESCRIPTION
## Description
This PR add the first goose migration and makefile targets to handle goose connection to the db, goose up and down commands.

N.B.: this initial schema is more than the Jira task requested. Reason is: it doesn't bother us to have the schemas already.

The most important change is the presence of both the `owner` and `owner_id` columns.
This is because we don't have a plan to integrate identities in our db yet.
So right now the Owner can just be a string referencing a Kratos identity.
By the end of this Epic we will hopefully have more clarity on this.

Some indices have been added, but those will be driven by our implementations of the queries we need, so they will be subject to addition or changes.

