### PR TITLE
IAM-1276 Improve NewRouter function and streamline code

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,6 @@ github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uq
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/getkin/kin-openapi v0.131.0 h1:NO2UeHnFKRYhZ8wg6Nyh5Cq7dHk4suQQr72a4pMrDxE=
 github.com/getkin/kin-openapi v0.131.0/go.mod h1:3OlG51PCYNsPByuiMB0t4fjnNlIDnaEDsjiKUV8nL58=
-github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
-github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
 github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=

--- a/pkg/ui/handlers.go
+++ b/pkg/ui/handlers.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd.
+// Copyright 2025 Canonical Ltd.
 // SPDX-License-Identifier: AGPL-3.0
 
 package ui
@@ -23,11 +23,6 @@ const (
 	UIPrefix      = "/ui"
 	indexTemplate = "index.html"
 )
-
-type Config struct {
-	DistFS      fs.FS
-	ContextPath string
-}
 
 type API struct {
 	contextPath string
@@ -121,12 +116,12 @@ func (a *API) uiFiles(w http.ResponseWriter, r *http.Request) {
 	a.fileServer.ServeHTTP(w, r)
 }
 
-func NewAPI(config *Config, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *API {
+func NewAPI(contextPath string, distFS fs.FS, tracer tracing.TracingInterface, monitor monitoring.MonitorInterface, logger logging.LoggerInterface) *API {
 	a := new(API)
 
-	a.distFS = config.DistFS
-	a.fileServer = http.FileServer(http.FS(config.DistFS))
-	a.contextPath = config.ContextPath
+	a.distFS = distFS
+	a.fileServer = http.FileServer(http.FS(distFS))
+	a.contextPath = contextPath
 
 	a.tracer = tracer
 	a.monitor = monitor


### PR DESCRIPTION
## Description
This PR refactors the NewRouter function to use the functional options pattern, allowing for cleaner and more flexible configuration. The following changes were made:

### Changes
- adopted functional options pattern in NewRouter for better extensibility and readability
- simplified logic in NewRouter, reducing repetition and unnecessary
- Removed infrequently used variables that were only declared and used once, inlined their usage instead
- Removed the ui.Config struct for its simplicity, but we should add it back as soon as the UI handler needs more info

## Small consideration on the functional options pattern
If we like this, we could easily apply the same pattern to our API handlers and services.
The "missing" part to make this actually 100% effective is to have sensible defaults for every settings in the available options, which right now we don't have.
Right now we have to pass **all** needed options to make sure the Router works as expected because the current defaults wouldn't allow the app to work with "missing" options compared to the ones we pass right now. Do we need it strictly? No. Would it allow us to streamline the code even more? Yes.

@shipperizer