### PR TITLE
fix: various startup bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ dev:
 
 GOOSE=goose
 GOOSE_DRIVER=postgres
-GOOSE_DBSTRING?=postgresql://user:user@localhost:5432/admin-service?sslmode=disable
+GOOSE_DBSTRING?=postgresql://iam:iam@localhost:5432/admin-service?sslmode=disable
 GOOSE_MIGRATION_DIR?=./migrations
 
 db-status:

--- a/deployments/helm/postgresql/values.yaml
+++ b/deployments/helm/postgresql/values.yaml
@@ -12,6 +12,7 @@ primary:
         CREATE DATABASE kratos;
         CREATE DATABASE hydra;
         CREATE DATABASE openfga;
+        CREATE DATABASE "admin-service";
 
 auth:
   database: "iam"

--- a/deployments/kubectl/configMap.yaml
+++ b/deployments/kubectl/configMap.yaml
@@ -31,6 +31,7 @@ data:
   MAIL_HOST: "mailhog.default.svc.cluster.local"
   MAIL_PORT: "1025"
   MAIL_FROM_ADDRESS: "identity-team@canonical.com"
+  DSN: "postgres://iam:iam@postgresql.default.svc.cluster.local/admin-service?sslmode=disable"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deployments/kubectl/configMap.yaml
+++ b/deployments/kubectl/configMap.yaml
@@ -10,7 +10,7 @@ data:
   KRATOS_PUBLIC_URL: http://kratos-public.default.svc.cluster.local
   KRATOS_ADMIN_URL: http://kratos-admin.default.svc.cluster.local
   HYDRA_ADMIN_URL: http://hydra-admin.default.svc.cluster.local:4445
-  IDP_CONFIGMAP_NAME: idps
+  IDP_CONFIGMAP_NAME: providers
   IDP_CONFIGMAP_NAMESPACE: default
   SCHEMAS_CONFIGMAP_NAME: identity-schemas
   SCHEMAS_CONFIGMAP_NAMESPACE: default

--- a/deployments/kubectl/configMap.yaml
+++ b/deployments/kubectl/configMap.yaml
@@ -55,7 +55,7 @@ data:
         "provider": "google",
         "client_secret": "3y38Q~aslkdhaskjhd~W0xWDB.123u98asd",
         "mapper_url": "file:///etc/config/kratos/google_schema.jsonnet",
-        "scope": ["profile", "email", "address", "phone"]
+        "scope": ["profile", "email", "address", "phone"],
         "requested_claims": "{\"userinfo\":{\"given_name\":{\"essential\":true},\"nickname\":null,\"email\":{\"essential\":true},\"email_verified\":{\"essential\":true},\"picture\":null,\"http://example.info/claims/groups\":null},\"id_token\":{\"auth_time\":{\"essential\":true},\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\"]}}}"
       }
     ]

--- a/structure-tests.yaml
+++ b/structure-tests.yaml
@@ -9,7 +9,7 @@ globalEnvVars:
   - key: "HYDRA_ADMIN_URL"
     value: "https://hydra.iam.admin"
   - key: "IDP_CONFIGMAP_NAME"
-    value: idps
+    value: providers
   - key: "IDP_CONFIGMAP_NAMESPACE"
     value: default
   - key: "SCHEMAS_CONFIGMAP_NAME"


### PR DESCRIPTION
While trying to get the platform running, I've come across a number of issues which I've fixed:

- Add missing DSN env var
- Create `admin-service` database along with other databases
- Use `iam:iam` as postgres credentials for goose migrations
- `idps` -> `providers` for `IDPCONFIG_NAME`
- JSON typo in default IDP configuration