### PR TITLE
chore: upgrade axios to 1.13.5 (not affected by axios crypto trojan)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,7 @@
     "@canonical/rebac-admin-admin-ui": "0.0.3",
     "@tanstack/react-query": "^5.28.6",
     "@use-it/event-listener": "0.1.7",
-    "axios": "1.12.2",
+    "axios": "1.13.5",
     "formik": "2.4.6",
     "react": "19.1.1",
     "react-dom": "19.1.1",


### PR DESCRIPTION
## Description
Admin UI wasn't actually affected by the trojan horse in axios. But this update still puts other CVEs behind its back.