### PR TITLE
ci: add explicit workflow-level permissions to tiobe

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 7 1 * *'
 
+permissions:
+  contents: read
+
 jobs:
   TICS:
     runs-on: [ self-hosted, amd64, tiobe, noble ]


### PR DESCRIPTION
Sets the minimum-required `GITHUB_TOKEN` scope on `tiobe.yaml`:

- Workflow-level `permissions:` -> `contents: read`
- No changes to jobs, steps, runners, or triggers
- YAML still parses (`yaml.safe_load` succeeds)

Rationale:

- The TIOBE quality check job is read-only; nothing in it needs write access to the repo.
- Without an explicit block, the run inherits whatever default the repository's actions settings happen to be set to. That default has drifted in the past, and forks-of-forks lose track of it.
- the OpenSSF Scorecard Token-Permissions check flags missing per-workflow permissions as a finding.
- After the tj-actions/changed-files supply-chain incident from March 2025, the cost-benefit on explicit minimum scopes is firmly on the side of declaring them.
