### PR TITLE
ci: grant required GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,9 @@ jobs:
   build:
     uses: ./.github/workflows/build.yaml
   publish:
+    permissions:
+      packages: write
+      contents: read
     if: ${{ (github.ref == 'refs/heads/main') || (github.ref_type == 'tag') }}
     needs: [build, unit-test]
     uses: ./.github/workflows/publish.yaml
@@ -27,6 +30,11 @@ jobs:
     secrets:
       token: ${{ secrets.PAT_TOKEN }}
   scan:
+    permissions:
+      packages: read
+      contents: read
+      security-events: write
+      actions: read
     if: ${{ (github.ref == 'refs/heads/main') || (github.ref_type == 'tag') }}
     needs: publish
     uses: ./.github/workflows/scan.yaml

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -14,6 +14,11 @@ on:
   schedule:
     - cron: '0 19 * * 4'
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/cves.yaml
+++ b/.github/workflows/cves.yaml
@@ -24,6 +24,9 @@ jobs:
                  
     scheduled-check:
         if: ${{ github.event_name == 'schedule' }}
+        permissions:
+            contents: write
+            issues: write
         strategy:
             matrix:
                 issue: ${{ fromJson(needs.list-all-issues.outputs.issues) }}
@@ -34,5 +37,8 @@ jobs:
             issue: ${{ matrix.issue }}
 
     apply-labels:
+        permissions:
+            contents: write
+            issues: write
         uses: canonical/identity-team/.github/workflows/cve-check.yaml@84c2f3e8f31c76602dd3ccceff9b8231316af615 # v1.11.1
         if: ${{ github.event.issue.id }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      packages: write
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.set.outputs.image }}
@@ -68,6 +71,8 @@ jobs:
       run: echo "image=$image" >> "$GITHUB_OUTPUT"
 
   oci-factory:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     # only release to oci-factory in case of release
     if: github.ref_type == 'tag'

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -10,6 +10,11 @@ on:
         description: "image to scan"
 jobs:
   scan:
+    permissions:
+      packages: read
+      contents: read
+      security-events: write
+      actions: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
No workflow granted the GITHUB_TOKEN the scopes its jobs need, so they ran with the read-only repository default: publish.yaml could not push the rock to ghcr.io, scan.yaml could not upload its Trivy SARIF report, codeql-analysis could not upload its results and cves.yaml could not label CVE issues.

Permissions are set both on the reusable workflows (publish.yaml, scan.yaml) and on their caller jobs in ci.yaml, since a called workflow can never exceed the permissions granted by the calling job.

Add explicit least-privilege permissions, matching canonical/identity-platform-login-ui.